### PR TITLE
fix: onInpuChange value bug in combobox react and vue examples

### DIFF
--- a/examples/next-ts/pages/combobox.tsx
+++ b/examples/next-ts/pages/combobox.tsx
@@ -18,7 +18,7 @@ export default function Page() {
       onOpen() {
         setOptions(comboboxData)
       },
-      onInputChange({ value }) {
+      onInputChange(value) {
         const filtered = comboboxData.filter((item) => item.label.toLowerCase().includes(value.toLowerCase()))
         setOptions(filtered.length > 0 ? filtered : comboboxData)
       },

--- a/examples/vue-ts/src/pages/combobox.tsx
+++ b/examples/vue-ts/src/pages/combobox.tsx
@@ -21,7 +21,7 @@ export default defineComponent({
         onOpen() {
           options.value = comboboxData
         },
-        onInputChange({ value }) {
+        onInputChange(value) {
           const filtered = comboboxData.filter((item) => item.label.toLowerCase().includes(value.toLowerCase()))
           options.value = filtered.length > 0 ? filtered : comboboxData
         },


### PR DESCRIPTION
We were accepting value from an object, but the method returns just value and not an object.