### PR TITLE
refactor(readme): fix example typo from ; to :

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ function Example() {
   const [state, send] = useMachine(toggle.machine)
 
   // setup a unique id and ownerDocument for machine
-  const ref = useSetup({ send, id; "2" })
+  const ref = useSetup({ send, id: "2" })
 
   // convert machine details into `DOM` props
   const api = toggle.connect(state, send)


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # no issue is up for this.

## 📝 Description

Small typo present in the README example

## ⛳️ Current behavior (updates)

A semi colon was used after id instead of a colon, so the example doesn't work without updating it after copying the example.

## 🚀 New behavior

No error on example

## 💣 Is this a breaking change: NO

## 📝 Additional Information
N/A