### PR TITLE
Shadow dom compatibility

### DIFF
--- a/.changeset/mean-feet-raise.md
+++ b/.changeset/mean-feet-raise.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/react": patch
+"@zag-js/solid": patch
+"@zag-js/vue": patch
+---
+
+Prefer `getRootNode` over `ownerDocument` to support shadow dom

--- a/packages/frameworks/react/src/use-setup.ts
+++ b/packages/frameworks/react/src/use-setup.ts
@@ -13,7 +13,7 @@ export function useSetup<T extends HTMLElement = HTMLDivElement>(props: UseSetup
   useEffect(() => {
     if (!id) return
     Promise.resolve().then(() => {
-      const doc = ref.current?.ownerDocument
+      const doc = ref.current?.getRootNode()
       send({ type: "SETUP", doc, id })
     })
   }, [id])

--- a/packages/frameworks/react/src/use-setup.ts
+++ b/packages/frameworks/react/src/use-setup.ts
@@ -13,7 +13,7 @@ export function useSetup<T extends HTMLElement = HTMLDivElement>(props: UseSetup
   useEffect(() => {
     if (!id) return
     Promise.resolve().then(() => {
-      const doc = ref.current?.getRootNode()
+      const doc = ref.current?.ownerDocument
       send({ type: "SETUP", doc, id })
     })
   }, [id])

--- a/packages/frameworks/solid/src/use-setup.ts
+++ b/packages/frameworks/solid/src/use-setup.ts
@@ -12,7 +12,7 @@ export function useSetup<T extends HTMLElement = HTMLDivElement>(props: UseSetup
 
   onMount(() => {
     Promise.resolve().then(() => {
-      send({ type: "SETUP", doc: el()?.ownerDocument, id })
+      send({ type: "SETUP", doc: el()?.getRootNode(), id })
     })
   })
 

--- a/packages/frameworks/solid/src/use-setup.ts
+++ b/packages/frameworks/solid/src/use-setup.ts
@@ -12,7 +12,7 @@ export function useSetup<T extends HTMLElement = HTMLDivElement>(props: UseSetup
 
   onMount(() => {
     Promise.resolve().then(() => {
-      send({ type: "SETUP", doc: el()?.getRootNode(), id })
+      send({ type: "SETUP", doc: el()?.ownerDocument, id })
     })
   })
 

--- a/packages/frameworks/vue/src/use-setup.ts
+++ b/packages/frameworks/vue/src/use-setup.ts
@@ -15,7 +15,7 @@ export function useSetup<T extends HTMLElement = HTMLDivElement>(props: UseSetup
 
   onMounted(() => {
     Promise.resolve().then(() => {
-      const doc = nodeRef.value?.getRootNode() ?? document
+      const doc = nodeRef.value?.ownerDocument ?? document
       send({ type: "SETUP", doc, id: isRef(id) ? id.value : id })
     })
   })

--- a/packages/frameworks/vue/src/use-setup.ts
+++ b/packages/frameworks/vue/src/use-setup.ts
@@ -15,7 +15,7 @@ export function useSetup<T extends HTMLElement = HTMLDivElement>(props: UseSetup
 
   onMounted(() => {
     Promise.resolve().then(() => {
-      const doc = nodeRef.value?.ownerDocument ?? document
+      const doc = nodeRef.value?.getRootNode() ?? document
       send({ type: "SETUP", doc, id: isRef(id) ? id.value : id })
     })
   })


### PR DESCRIPTION
Closes #81 

## 📝 Description

Uses `getRootNode()` over `ownerDocument` for compatibility with shadow root

## ⛳️ Current behavior (updates)

The browser api for fetching the root document

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

There are further places where `ownerDocument` is used (createPortal...). I will also take a look at those