### PR TITLE
fix(number-input): initial values

### DIFF
--- a/.changeset/nice-planes-rhyme.md
+++ b/.changeset/nice-planes-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/number-input": patch
+---
+
+Fix issue where multiple number input rendered on page causes them to the initial value of the first input

--- a/.changeset/rich-radios-develop.md
+++ b/.changeset/rich-radios-develop.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/core": patch
+---
+
+Refactor to ensure that the config points to unique references

--- a/.xstate/number-input.js
+++ b/.xstate/number-input.js
@@ -10,7 +10,6 @@ const { choose } = actions;
 const fetchMachine = createMachine({
   id: "number-input",
   initial: "unknown",
-  entry: ["syncInputValue"],
   on: {
     SET_VALUE: {
       actions: ["setValue", "setHintToSet"]
@@ -27,7 +26,7 @@ const fetchMachine = createMachine({
       on: {
         SETUP: {
           target: "idle",
-          actions: "setupDocument"
+          actions: ["setupDocument", "syncInputValue"]
         }
       }
     },

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -47,15 +47,15 @@ export class Machine<
   private activityMap: S.ActivityMap<TContext, TState, TEvent>
   private sync: boolean
   public options: S.MachineOptions<TContext, TState, TEvent>
+  public config: S.MachineConfig<TContext, TState, TEvent>
 
   // Let's get started!
-  constructor(
-    public config: S.MachineConfig<TContext, TState, TEvent>,
-    options?: S.MachineOptions<TContext, TState, TEvent>,
-  ) {
-    // deep clone the config
+  constructor(config: S.MachineConfig<TContext, TState, TEvent>, options?: S.MachineOptions<TContext, TState, TEvent>) {
+    // clone the config and options
+    this.config = klona(config)
     this.options = klona(options ?? {})
-    this.id = config.id ?? `machine-${uuid()}`
+
+    this.id = this.config.id ?? `machine-${uuid()}`
 
     // maps
     this.guardMap = this.options?.guards ?? {}
@@ -65,11 +65,11 @@ export class Machine<
     this.sync = this.options?.sync ?? false
 
     // create mutatable state
-    this.state = createProxy(klona(config))
+    this.state = createProxy(this.config)
 
     // created actions
     const event = toEvent<TEvent>(ActionTypes.Created)
-    this.executeActions(config?.created, event)
+    this.executeActions(this.config?.created, event)
   }
 
   // immutable state value

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -1,4 +1,4 @@
-import { dataAttr, EventKeyMap, getEventKey, getNativeEvent, nextTick, validateBlur } from "@zag-js/dom-utils"
+import { dataAttr, EventKeyMap, getEventKey, getNativeEvent, validateBlur } from "@zag-js/dom-utils"
 import { getPlacementStyles } from "@zag-js/popper"
 import { normalizeProp, PropTypes, ReactPropTypes } from "@zag-js/types"
 import { isLeftClick } from "@zag-js/utils"

--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -55,8 +55,6 @@ export function machine(ctx: UserDefinedContext = {}) {
         isOutOfRange: ["invokeOnInvalid"],
       },
 
-      entry: ["syncInputValue"],
-
       on: {
         SET_VALUE: {
           actions: ["setValue", "setHintToSet"],
@@ -70,7 +68,7 @@ export function machine(ctx: UserDefinedContext = {}) {
           on: {
             SETUP: {
               target: "idle",
-              actions: "setupDocument",
+              actions: ["setupDocument", "syncInputValue"],
             },
           },
         },


### PR DESCRIPTION
Closes #80

## 📝 Description

When you render multiple instances of the Number Input, the initial value of every instance following the first instance quickly gets replaced with the initial value of the first instance (after briefly being correctly set to their own initial values).

This PR fixes that.