### PR TITLE
feat: arrow rotation based on placement

### DIFF
--- a/.changeset/funny-clocks-invite.md
+++ b/.changeset/funny-clocks-invite.md
@@ -1,0 +1,9 @@
+---
+"@zag-js/combobox": patch
+"@zag-js/menu": patch
+"@zag-js/popover": patch
+"@zag-js/tooltip": patch
+"@zag-js/popper": patch
+---
+
+feat: arrow rotation based on placement

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -23,6 +23,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
 
   const popperStyles = getPlacementStyles({
     measured: !!state.context.currentPlacement,
+    placement: state.context.currentPlacement,
   })
 
   const api = {

--- a/packages/machines/menu/src/menu.connect.ts
+++ b/packages/machines/menu/src/menu.connect.ts
@@ -25,6 +25,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
 
   const popperStyles = getPlacementStyles({
     measured: !!state.context.anchorPoint || !!state.context.currentPlacement,
+    placement: state.context.currentPlacement,
   })
 
   const api = {

--- a/packages/machines/popover/src/popover.connect.ts
+++ b/packages/machines/popover/src/popover.connect.ts
@@ -9,6 +9,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
   const pointerdownNode = state.context.pointerdownNode
   const popperStyles = getPlacementStyles({
     measured: !!state.context.isPlacementComplete,
+    placement: state.context.currentPlacement,
   })
 
   return {

--- a/packages/machines/tooltip/src/tooltip.connect.ts
+++ b/packages/machines/tooltip/src/tooltip.connect.ts
@@ -16,6 +16,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
 
   const popperStyles = getPlacementStyles({
     measured: !!state.context.isPlacementComplete,
+    placement: state.context.currentPlacement,
   })
 
   return {

--- a/packages/utilities/popper/src/get-styles.ts
+++ b/packages/utilities/popper/src/get-styles.ts
@@ -1,8 +1,10 @@
+import { Placement } from "@floating-ui/dom"
 import { cssVars } from "./middleware"
 
 type Options = {
   measured: boolean
   strategy?: "absolute" | "fixed"
+  placement?: Placement
 }
 
 const UNMEASURED_FLOATING_STYLE = {
@@ -14,8 +16,15 @@ const UNMEASURED_FLOATING_STYLE = {
   pointerEvents: "none",
 } as const
 
+const ARROW_FLOATING_STYLE = {
+  bottom: "rotate(45deg)",
+  left: "rotate(135deg)",
+  top: "rotate(225deg)",
+  right: "rotate(315deg)",
+} as const
+
 export function getPlacementStyles(options: Options) {
-  const { measured, strategy = "absolute" } = options
+  const { measured, strategy = "absolute", placement = "bottom" } = options
 
   return {
     arrow: {
@@ -28,7 +37,7 @@ export function getPlacementStyles(options: Options) {
     } as const,
 
     innerArrow: {
-      transform: "rotate(45deg)",
+      transform: ARROW_FLOATING_STYLE[placement.split("-")[0]],
       background: cssVars.arrowBg.reference,
       top: "0",
       left: "0",


### PR DESCRIPTION
Closes #87 

## 📝 Description

Makes the arrow rotation dependent on the placement. This makes it easier to style the borders facing the trigger.

## ⛳️ Current behavior (updates)

Rotation of arrow is no longer just 45deg but now also 135, 225, 315 if the position is bottom, left, top or right resp.

## 💣 Is this a breaking change (Yes/No):

Shouldn't affect anyone as 45deg is the same as the other values. Only if users were styling their arrow dependent on placement already

## 📝 Additional Information
