### PR TITLE
fix: improve popper transform origin calculations

### DIFF
--- a/.changeset/funny-experts-boil.md
+++ b/.changeset/funny-experts-boil.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/popover": patch
+---
+
+Add data-expanded to popover content props

--- a/.changeset/purple-owls-battle.md
+++ b/.changeset/purple-owls-battle.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/popper": patch
+---
+
+Compute transform origin based on arrow position if needed

--- a/packages/machines/popover/src/popover.connect.ts
+++ b/packages/machines/popover/src/popover.connect.ts
@@ -7,6 +7,7 @@ import type { Send, State } from "./popover.types"
 export function connect<T extends PropTypes = ReactPropTypes>(state: State, send: Send, normalize = normalizeProp) {
   const isOpen = state.matches("open")
   const pointerdownNode = state.context.pointerdownNode
+
   const popperStyles = getPlacementStyles({
     measured: !!state.context.isPlacementComplete,
     placement: state.context.currentPlacement,
@@ -64,6 +65,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
       tabIndex: -1,
       role: "dialog",
       hidden: !isOpen,
+      "data-expanded": dataAttr(isOpen),
       "aria-labelledby": state.context.isTitleRendered ? dom.getTitleId(state.context) : undefined,
       "aria-describedby": state.context.isDescriptionRendered ? dom.getDescriptionId(state.context) : undefined,
       "data-placement": state.context.currentPlacement,

--- a/packages/utilities/popper/src/get-placement.ts
+++ b/packages/utilities/popper/src/get-placement.ts
@@ -28,8 +28,8 @@ export function getPlacement(
    * The middleware stack
    * -----------------------------------------------------------------------------*/
 
-  const middleware: Middleware[] = [transformOrigin]
   const arrowEl = floating.querySelector<HTMLElement>("[data-part=arrow]")
+  const middleware: Middleware[] = []
 
   if (options.flip) {
     middleware.push(
@@ -59,9 +59,11 @@ export function getPlacement(
     // prettier-ignore
     middleware.push(
       arrow({ element: arrowEl, padding: 8 }),
-      shiftArrow({ element: arrowEl })
+      shiftArrow({ element: arrowEl }),
     )
   }
+
+  middleware.push(transformOrigin)
 
   if (options.sameWidth || options.fitViewport) {
     middleware.push(

--- a/packages/utilities/popper/src/middleware.ts
+++ b/packages/utilities/popper/src/middleware.ts
@@ -1,4 +1,4 @@
-import { Middleware } from "@floating-ui/dom"
+import { Coords, Middleware } from "@floating-ui/dom"
 
 /* -----------------------------------------------------------------------------
  * Shared middleware utils
@@ -18,28 +18,32 @@ export const cssVars = {
  * Transform Origin Middleware
  * -----------------------------------------------------------------------------*/
 
-const transforms = {
+const getTransformOrigin = (arrow?: Partial<Coords>) => ({
   top: "bottom center",
-  "top-start": "bottom left",
-  "top-end": "bottom right",
+  "top-start": arrow ? `${arrow.x}px bottom` : "left bottom",
+  "top-end": arrow ? `${arrow.x}px bottom` : "right bottom",
   bottom: "top center",
-  "bottom-start": "top left",
-  "bottom-end": "top right",
+  "bottom-start": arrow ? `${arrow.x}px top` : "top left",
+  "bottom-end": arrow ? `${arrow.x}px top` : "top right",
   left: "right center",
-  "left-start": "right top",
-  "left-end": "right bottom",
+  "left-start": arrow ? `right ${arrow.y}px` : "right top",
+  "left-end": arrow ? `right ${arrow.y}px` : "right bottom",
   right: "left center",
-  "right-start": "left top",
-  "right-end": "left bottom",
-}
+  "right-start": arrow ? `left ${arrow.y}px` : "left top",
+  "right-end": arrow ? `left ${arrow.y}px` : "left bottom",
+})
 
 export const transformOrigin: Middleware = {
   name: "transformOrigin",
-  fn({ placement, elements }) {
+  fn({ placement, elements, middlewareData }) {
+    const { arrow } = middlewareData
+    const transformOrigin = getTransformOrigin(arrow)[placement]
+
     const { floating } = elements
-    floating.style.setProperty(cssVars.transformOrigin.variable, transforms[placement])
+    floating.style.setProperty(cssVars.transformOrigin.variable, transformOrigin)
+
     return {
-      data: { transformOrigin: transforms[placement] },
+      data: { transformOrigin },
     }
   },
 }

--- a/shared/style.ts
+++ b/shared/style.ts
@@ -106,6 +106,11 @@ export const menuStyle: CSSObject = {
   },
 }
 
+const scale = keyframes({
+  from: { transform: "scale(0.9)", opacity: 0 },
+  to: { transform: "scale(1)", opacity: 1 },
+})
+
 export const popoverStyle: CSSObject = {
   "[data-part=root]": {
     display: "flex",
@@ -124,6 +129,10 @@ export const popoverStyle: CSSObject = {
     position: "relative",
     filter: "drop-shadow(0 4px 8px rgba(0, 0, 0, 0.2))",
     width: "260px",
+    transformOrigin: "var(--transform-origin)",
+    "&[data-expanded]": {
+      animation: `${scale} 0.1s ease-out`,
+    },
   },
   "[data-part=title]": {
     fontSize: "15px",


### PR DESCRIPTION
## 📝 Description

This PR improves the transform-origin calculation of popper-related components such that its origin starts from the arrow position. This improves the UX for apps with subtle scale transitions/animations.

## ⛳️ Current behavior (updates)

We've hardcoded the transform origins

## 🚀 New behavior

Now dynamic, based on placement and if the arrow is rendered.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
