### PR TITLE
numberinput: update parts dataset

### DIFF
--- a/.changeset/swift-meals-dress.md
+++ b/.changeset/swift-meals-dress.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/number-input": patch
+---
+
+Add additional dataset to identify the spin buttons

--- a/packages/machines/number-input/src/number-input.connect.ts
+++ b/packages/machines/number-input/src/number-input.connect.ts
@@ -136,6 +136,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
 
     decrementButtonProps: normalize.button<T>({
       "data-part": "spin-button",
+      "data-type": "decrement",
       id: dom.getDecButtonId(state.context),
       disabled: isDecrementDisabled,
       "data-disabled": dataAttr(isDecrementDisabled),
@@ -159,6 +160,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
 
     incrementButtonProps: normalize.button<T>({
       "data-part": "spin-button",
+      "data-type": "increment",
       id: dom.getIncButtonId(state.context),
       disabled: isIncrementDisabled,
       "data-disabled": dataAttr(isIncrementDisabled),


### PR DESCRIPTION
Closes #99

## 📝 Description

Add an extra dataset to identify the number-inputs increment and decrement parts.

## ⛳️ Current behavior (updates)

We only have the `data-part=spin-button` without additional info about if it's the increment or decrement button

## 🚀 New behavior

We now include a `data-type=(increment|decrement)` to help identify the elements via CSS or JS.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
