### PR TITLE
fix: number input firefox issue

### DIFF
--- a/.changeset/seven-lizards-shout.md
+++ b/.changeset/seven-lizards-shout.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/number-input": patch
+---
+
+Fix issue where firefox doesn't fire the pointerup event consistently on disabled button. This created an bug where it
+required an extra click when the value is decreased to 0.

--- a/.xstate/number-input.js
+++ b/.xstate/number-input.js
@@ -104,6 +104,7 @@ const fetchMachine = createMachine({
     },
     "before:spin": {
       tags: ["focus"],
+      activities: "trackButtonDisabled",
       entry: choose([{
         cond: "isIncrementHint",
         actions: "increment"

--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -140,6 +140,7 @@ export function machine(ctx: UserDefinedContext = {}) {
 
         "before:spin": {
           tags: ["focus"],
+          activities: "trackButtonDisabled",
           entry: choose([
             { guard: "isIncrementHint", actions: "increment" },
             { guard: "isDecrementHint", actions: "decrement" },


### PR DESCRIPTION
Closes #103

## 📝 Description

Fix issue where Firefox doesn't send pointerup event for disabled buttons, requiring an explicit tracking of the disabled state to execute the proper transition.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
