### PR TITLE
refactor: prop-types

### DIFF
--- a/.changeset/many-pears-type.md
+++ b/.changeset/many-pears-type.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/solid": patch
+"@zag-js/vue": patch
+"@zag-js/types": patch
+---
+
+Refactor prop types to use proxy instead of enum

--- a/packages/frameworks/solid/src/prop-types.ts
+++ b/packages/frameworks/solid/src/prop-types.ts
@@ -1,11 +1,5 @@
 import type { JSX } from "solid-js"
 
-type JSXElements = JSX.IntrinsicElements
-
-export type PropTypes = {
-  button: JSXElements["button"]
-  label: JSXElements["label"]
-  input: JSXElements["input"]
-  output: JSXElements["output"]
+export type PropTypes = JSX.IntrinsicElements & {
   element: JSX.HTMLAttributes<any>
 }

--- a/packages/frameworks/vue/src/prop-types.ts
+++ b/packages/frameworks/vue/src/prop-types.ts
@@ -1,16 +1,5 @@
-import * as Vue from "vue"
+import type { NativeElements } from "vue"
 
-type ReservedProps = {
-  key?: string | number | symbol
-  ref?: string | Vue.Ref | ((ref: Element | Vue.ComponentPublicInstance | null) => void)
-}
-
-type Attrs<T> = T & ReservedProps
-
-export type PropTypes = {
-  button: Attrs<Vue.ButtonHTMLAttributes>
-  input: Attrs<Vue.InputHTMLAttributes>
-  output: Attrs<Vue.OutputHTMLAttributes>
-  label: Attrs<Vue.LabelHTMLAttributes>
-  element: Attrs<Vue.HTMLAttributes>
+export type PropTypes = NativeElements & {
+  element: NativeElements["div"]
 }


### PR DESCRIPTION
## 📝 Description

In preparation for the upcoming components, we need to clean up the prop-types to allow most JSX elements, not just a few components we use currently (button, label, input, etc.).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
