### PR TITLE
chore: removes Redundant optional chaining operator

### DIFF
--- a/packages/machines/tags-input/src/tags-input.connect.ts
+++ b/packages/machines/tags-input/src/tags-input.connect.ts
@@ -154,7 +154,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
         const exec = keyMap[key]
 
         if (exec) {
-          exec?.(event)
+          exec(event)
           return
         }
 


### PR DESCRIPTION
Removed redundant optional chaining operator, in tags input keymap execution.