### PR TITLE
refactor: slider component

### DIFF
--- a/.changeset/cuddly-swans-pay.md
+++ b/.changeset/cuddly-swans-pay.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/slider": patch
+"@zag-js/range-slider": patch
+---
+
+Refactor styles and hoist CSS variables to `root` part

--- a/packages/machines/range-slider/src/range-slider.connect.ts
+++ b/packages/machines/range-slider/src/range-slider.connect.ts
@@ -78,6 +78,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
       "data-orientation": state.context.orientation,
       id: dom.getRootId(state.context),
       dir: state.context.dir,
+      style: dom.getRootStyle(state.context),
     }),
 
     outputProps: normalize.output<T>({
@@ -204,7 +205,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
       "data-disabled": dataAttr(isDisabled),
       "data-orientation": state.context.orientation,
       "data-focus": dataAttr(isFocused),
-      style: dom.getControlStyle(state.context),
+      style: dom.getControlStyle(),
       onPointerDown(event) {
         if (!isInteractive) return
 
@@ -223,11 +224,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
       role: "presentation",
       "aria-hidden": true,
       "data-orientation": state.context.orientation,
-      style: {
-        userSelect: "none",
-        pointerEvents: "none",
-        position: "relative",
-      },
+      style: dom.getMarkerGroupStyle(),
     }),
 
     getMarkerProps({ value }: { value: number }) {

--- a/packages/machines/range-slider/src/range-slider.dom.ts
+++ b/packages/machines/range-slider/src/range-slider.dom.ts
@@ -39,7 +39,7 @@ export const dom = {
   getRangeId: (ctx: Ctx) => ctx.ids?.range ?? `slider:${ctx.uid}:range`,
   getLabelId: (ctx: Ctx) => ctx.ids?.label ?? `slider:${ctx.uid}:label`,
   getOutputId: (ctx: Ctx) => ctx.ids?.output ?? `slider:${ctx.uid}:output`,
-  getMarkerId: (ctx: Ctx, value: number) => `slider-${ctx.uid}:marker:${value}`,
+  getMarkerId: (ctx: Ctx, value: number) => `slider:${ctx.uid}:marker:${value}`,
 
   getRootEl: (ctx: Ctx) => dom.getRootNode(ctx).getElementById(dom.getRootId(ctx)),
   getThumbEl: (ctx: Ctx, index: number) => dom.getRootNode(ctx).getElementById(dom.getThumbId(ctx, index)),

--- a/packages/machines/range-slider/src/range-slider.dom.ts
+++ b/packages/machines/range-slider/src/range-slider.dom.ts
@@ -3,8 +3,7 @@ import { dispatchInputValueEvent, queryAll } from "@zag-js/dom-utils"
 import { clamp, percentToValue } from "@zag-js/number-utils"
 import type { Point } from "@zag-js/rect-utils"
 import { closest, getElementRect, relativeToNode } from "@zag-js/rect-utils"
-import { unstable__dom } from "@zag-js/slider"
-import type { Style } from "@zag-js/types"
+import { styles } from "./range-slider.style"
 import type { MachineContext as Ctx } from "./range-slider.types"
 import { utils } from "./range-slider.utils"
 
@@ -27,34 +26,8 @@ function getValueFromPoint(ctx: Ctx, point: Point) {
   return utils.fromPercent(ctx, percent)
 }
 
-export function getRangeStyle(ctx: Ctx): Style {
-  const { orientation, value: values, max } = ctx
-
-  const startValue = (values[0] / max) * 100
-  const endValue = 100 - (values[values.length - 1] / max) * 100
-
-  const style: Style = {
-    position: "absolute",
-    "--slider-range-start": `${startValue}%`,
-    "--slider-range-end": `${endValue}%`,
-  }
-
-  if (orientation === "vertical") {
-    return {
-      ...style,
-      bottom: "var(--slider-range-start)",
-      top: "var(--slider-range-end)",
-    }
-  }
-
-  return {
-    ...style,
-    [ctx.isRtl ? "right" : "left"]: "var(--slider-range-start)",
-    [ctx.isRtl ? "left" : "right"]: "var(--slider-range-end)",
-  }
-}
-
 export const dom = {
+  ...styles,
   getDoc: (ctx: Ctx) => ctx.doc ?? document,
   getRootNode: (ctx: Ctx) => ctx.rootNode ?? dom.getDoc(ctx),
 
@@ -85,29 +58,6 @@ export const dom = {
       if (!input) return
       dispatchInputValueEvent(input, value)
     })
-  },
-
-  getControlStyle: unstable__dom.getControlStyle,
-  getThumbStyle(ctx: Ctx, index: number) {
-    const value = ctx.value[index]
-    const thumbSize = ctx.thumbSize?.[index] ?? { width: 0, height: 0 }
-    return unstable__dom.getThumbStyle({ ...ctx, value, thumbSize })
-  },
-  getRangeStyle,
-  getMarkerStyle(ctx: Ctx, percent: number): Style {
-    const style: Style = {
-      position: "absolute",
-      pointerEvents: "none",
-    }
-
-    if (ctx.isHorizontal) {
-      percent = ctx.isRtl ? 100 - percent : percent
-      style.left = `${percent}%`
-    } else {
-      style.bottom = `${percent}%`
-    }
-
-    return style
   },
 }
 

--- a/packages/machines/range-slider/src/range-slider.style.ts
+++ b/packages/machines/range-slider/src/range-slider.style.ts
@@ -1,0 +1,57 @@
+import { unstable__dom } from "@zag-js/slider"
+import type { Style } from "@zag-js/types"
+import type { MachineContext as Ctx } from "./range-slider.types"
+
+/* -----------------------------------------------------------------------------
+ * Range style calculations
+ * -----------------------------------------------------------------------------*/
+
+export function getRangeOffsets(ctx: Ctx) {
+  let start = (ctx.value[0] / ctx.max) * 100
+  let end = 100 - (ctx.value[ctx.value.length - 1] / ctx.max) * 100
+  return { start: `${start}%`, end: `${end}%` }
+}
+
+/* -----------------------------------------------------------------------------
+ * Thumb style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getThumbStyle(ctx: Ctx, index: number): Style {
+  const placementProp = ctx.isVertical ? "bottom" : ctx.isRtl ? "right" : "left"
+  return {
+    visibility: ctx.hasMeasuredThumbSize ? "visible" : "hidden",
+    position: "absolute",
+    transform: "var(--slider-thumb-transform)",
+    [placementProp]: `var(--slider-thumb-offset-${index})`,
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * Root style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getRootStyle(ctx: Ctx): Style {
+  const range = getRangeOffsets(ctx)
+
+  const offsetStyles = ctx.value.reduce((acc, value, index) => {
+    const thumbSize = ctx.thumbSize?.[index] ?? { width: 0, height: 0 }
+    const offset = unstable__dom.getThumbOffset({ ...ctx, value, thumbSize })
+    return { ...acc, [`--slider-thumb-offset-${index}`]: offset }
+  }, {} as Style)
+
+  return {
+    ...offsetStyles,
+    "--slider-thumb-transform": ctx.isVertical ? "translateY(50%)" : "translateX(-50%)",
+    "--slider-range-start": range.start,
+    "--slider-range-end": range.end,
+  }
+}
+
+export const styles = {
+  getRootStyle,
+  getControlStyle: unstable__dom.getControlStyle,
+  getThumbStyle,
+  getRangeStyle: unstable__dom.getRangeStyle,
+  getMarkerStyle: unstable__dom.getMarkerStyle,
+  getMarkerGroupStyle: unstable__dom.getMarkerGroupStyle,
+}

--- a/packages/machines/slider/src/slider.connect.ts
+++ b/packages/machines/slider/src/slider.connect.ts
@@ -10,6 +10,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
   const ariaLabel = state.context["aria-label"]
   const ariaLabelledBy = state.context["aria-labelledby"]
   const ariaValueText = state.context.getAriaValueText?.(state.context.value)
+
   const isFocused = state.matches("focus")
   const isDragging = state.matches("dragging")
   const isDisabled = state.context.disabled
@@ -43,6 +44,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
       "data-orientation": state.context.orientation,
       id: dom.getRootId(state.context),
       dir: state.context.dir,
+      style: dom.getRootStyle(state.context),
     }),
 
     labelProps: normalize.label<T>({
@@ -56,9 +58,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
         event.preventDefault()
         dom.getThumbEl(state.context)?.focus()
       },
-      style: {
-        userSelect: "none",
-      },
+      style: dom.getLabelStyle(),
     }),
 
     thumbProps: normalize.element<T>({
@@ -161,7 +161,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
       "data-invalid": dataAttr(isInvalid),
       "data-orientation": state.context.orientation,
       "data-focus": dataAttr(isFocused),
-      style: { position: "relative" },
+      style: dom.getTrackStyle(),
     }),
 
     rangeProps: normalize.element<T>({
@@ -192,7 +192,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
         event.preventDefault()
         event.stopPropagation()
       },
-      style: dom.getControlStyle(state.context),
+      style: dom.getControlStyle(),
     }),
 
     markerGroupProps: normalize.element<T>({
@@ -200,11 +200,7 @@ export function connect<T extends PropTypes = ReactPropTypes>(state: State, send
       role: "presentation",
       "aria-hidden": true,
       "data-orientation": state.context.orientation,
-      style: {
-        userSelect: "none",
-        pointerEvents: "none",
-        position: "relative",
-      },
+      style: dom.getMarkerGroupStyle(),
     }),
 
     getMarkerProps({ value }: { value: number }) {

--- a/packages/machines/slider/src/slider.dom.ts
+++ b/packages/machines/slider/src/slider.dom.ts
@@ -1,96 +1,12 @@
 import { dispatchInputValueEvent } from "@zag-js/dom-utils"
-import { transform, valueToPercent } from "@zag-js/number-utils"
 import type { Point } from "@zag-js/rect-utils"
 import { relativeToNode } from "@zag-js/rect-utils"
-import type { Style } from "@zag-js/types"
-import type { MachineContext as Ctx, SharedContext } from "./slider.types"
+import { styles } from "./slider.style"
+import type { MachineContext as Ctx } from "./slider.types"
 import { utils } from "./slider.utils"
 
-/**
- * To ensure the slider thumb is always within the track (on the y-axis)
- */
-function getVerticalThumbOffset(ctx: SharedContext) {
-  const { height = 0 } = ctx.thumbSize ?? {}
-  const getValue = transform([ctx.min, ctx.max], [-height / 2, height / 2])
-  return parseFloat(getValue(ctx.value).toFixed(2))
-}
-
-/**
- * To ensure the slider thumb is always within the track (on the x-axis)
- */
-function getHorizontalThumbOffset(ctx: SharedContext) {
-  const { width = 0 } = ctx.thumbSize ?? {}
-
-  if (ctx.isRtl) {
-    const getValue = transform([ctx.max, ctx.min], [-width * 1.5, -width / 2])
-    return -1 * parseFloat(getValue(ctx.value).toFixed(2))
-  }
-
-  const getValue = transform([ctx.min, ctx.max], [-width / 2, width / 2])
-  return parseFloat(getValue(ctx.value).toFixed(2))
-}
-
-function getThumbStyle(ctx: SharedContext): Style {
-  const percent = valueToPercent(ctx.value, ctx)
-  const offset = ctx.isVertical ? getVerticalThumbOffset(ctx) : getHorizontalThumbOffset(ctx)
-
-  const style: Style = {
-    visibility: ctx.hasMeasuredThumbSize ? "visible" : "hidden",
-    position: "absolute",
-    transform: "var(--slider-thumb-transform)",
-    "--slider-thumb-placement": `calc(${percent}% - ${offset}px)`,
-  }
-
-  if (ctx.isVertical) {
-    style.bottom = "var(--slider-thumb-placement)"
-  } else {
-    style[ctx.isRtl ? "right" : "left"] = "var(--slider-thumb-placement)"
-  }
-
-  return style
-}
-
-function getRangeStyle(ctx: Ctx): Style {
-  const percent = valueToPercent(ctx.value, ctx)
-
-  const style: Style = {
-    position: "absolute",
-  }
-
-  let startValue = "0%"
-  let endValue = `${100 - percent}%`
-
-  if (ctx.origin === "center") {
-    const isNegative = percent < 50
-    startValue = isNegative ? `${percent}%` : "50%"
-    endValue = isNegative ? "50%" : endValue
-  }
-
-  if (ctx.isVertical) {
-    return {
-      ...style,
-      bottom: startValue,
-      top: endValue,
-    }
-  }
-
-  return {
-    ...style,
-    [ctx.isRtl ? "right" : "left"]: startValue,
-    [ctx.isRtl ? "left" : "right"]: endValue,
-  }
-}
-
-function getControlStyle(ctx: Pick<Ctx, "isVertical">): Style {
-  return {
-    touchAction: "none",
-    userSelect: "none",
-    "--slider-thumb-transform": ctx.isVertical ? "translateY(50%)" : "translateX(-50%)",
-    position: "relative",
-  }
-}
-
 export const dom = {
+  ...styles,
   getDoc: (ctx: Ctx) => ctx.doc ?? document,
   getRootNode: (ctx: Ctx) => ctx.rootNode ?? dom.getDoc(ctx),
 
@@ -99,7 +15,7 @@ export const dom = {
   getControlId: (ctx: Ctx) => ctx.ids?.control ?? `slider:${ctx.uid}:control`,
   getInputId: (ctx: Ctx) => `slider:${ctx.uid}:input`,
   getOutputId: (ctx: Ctx) => ctx.ids?.output ?? `slider:${ctx.uid}:output`,
-  getTrackId: (ctx: Ctx) => ctx.ids?.track ?? `slider:-${ctx.uid}track`,
+  getTrackId: (ctx: Ctx) => ctx.ids?.track ?? `slider:${ctx.uid}track`,
   getRangeId: (ctx: Ctx) => ctx.ids?.track ?? `slider:${ctx.uid}:range`,
   getLabelId: (ctx: Ctx) => ctx.ids?.label ?? `slider:${ctx.uid}:label`,
   getMarkerId: (ctx: Ctx, value: number) => `slider:${ctx.uid}:marker:${value}`,
@@ -108,10 +24,6 @@ export const dom = {
   getThumbEl: (ctx: Ctx) => dom.getRootNode(ctx).getElementById(dom.getThumbId(ctx)),
   getControlEl: (ctx: Ctx) => dom.getRootNode(ctx).getElementById(dom.getControlId(ctx)),
   getInputEl: (ctx: Ctx) => dom.getRootNode(ctx).getElementById(dom.getInputId(ctx)) as HTMLInputElement | null,
-
-  getControlStyle,
-  getThumbStyle,
-  getRangeStyle,
 
   getValueFromPoint(ctx: Ctx, point: Point): number | undefined {
     // get the slider root element
@@ -137,21 +49,5 @@ export const dom = {
     const input = dom.getInputEl(ctx)
     if (!input) return
     dispatchInputValueEvent(input, ctx.value)
-  },
-
-  getMarkerStyle(ctx: Ctx, percent: number): Style {
-    const style: Style = {
-      position: "absolute",
-      pointerEvents: "none",
-    }
-
-    if (ctx.isHorizontal) {
-      percent = ctx.isRtl ? 100 - percent : percent
-      style.left = `${percent}%`
-    } else {
-      style.bottom = `${percent}%`
-    }
-
-    return style
   },
 }

--- a/packages/machines/slider/src/slider.style.ts
+++ b/packages/machines/slider/src/slider.style.ts
@@ -1,0 +1,154 @@
+import { transform, valueToPercent } from "@zag-js/number-utils"
+import type { Style } from "@zag-js/types"
+import type { MachineContext as Ctx, SharedContext } from "./slider.types"
+
+/* -----------------------------------------------------------------------------
+ * Thumb style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getVerticalThumbOffset(ctx: SharedContext) {
+  const { height = 0 } = ctx.thumbSize ?? {}
+  const getValue = transform([ctx.min, ctx.max], [-height / 2, height / 2])
+  return parseFloat(getValue(ctx.value).toFixed(2))
+}
+
+function getHorizontalThumbOffset(ctx: SharedContext) {
+  const { width = 0 } = ctx.thumbSize ?? {}
+
+  if (ctx.isRtl) {
+    const getValue = transform([ctx.max, ctx.min], [-width * 1.5, -width / 2])
+    return -1 * parseFloat(getValue(ctx.value).toFixed(2))
+  }
+
+  const getValue = transform([ctx.min, ctx.max], [-width / 2, width / 2])
+  return parseFloat(getValue(ctx.value).toFixed(2))
+}
+
+function getThumbOffset(ctx: SharedContext) {
+  const percent = valueToPercent(ctx.value, ctx)
+  const offset = ctx.isVertical ? getVerticalThumbOffset(ctx) : getHorizontalThumbOffset(ctx)
+  return `calc(${percent}% - ${offset}px)`
+}
+
+function getThumbStyle(ctx: SharedContext): Style {
+  const placementProp = ctx.isVertical ? "bottom" : ctx.isRtl ? "right" : "left"
+  return {
+    visibility: ctx.hasMeasuredThumbSize ? "visible" : "hidden",
+    position: "absolute",
+    transform: "var(--slider-thumb-transform)",
+    [placementProp]: "var(--slider-thumb-offset)",
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * Range style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getRangeOffsets(ctx: Ctx) {
+  const percent = valueToPercent(ctx.value, ctx)
+
+  let start = "0%"
+  let end = `${100 - percent}%`
+
+  if (ctx.origin === "center") {
+    const isNegative = percent < 50
+    start = isNegative ? `${percent}%` : "50%"
+    end = isNegative ? "50%" : end
+  }
+
+  return { start, end }
+}
+
+function getRangeStyle(ctx: Pick<SharedContext, "isVertical" | "isRtl">): Style {
+  if (ctx.isVertical) {
+    return {
+      position: "absolute",
+      bottom: "var(--slider-range-start)",
+      top: "var(--slider-range-end)",
+    }
+  }
+
+  return {
+    position: "absolute",
+    [ctx.isRtl ? "right" : "left"]: "var(--slider-range-start)",
+    [ctx.isRtl ? "left" : "right"]: "var(--slider-range-end)",
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * Control style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getControlStyle(): Style {
+  return {
+    touchAction: "none",
+    userSelect: "none",
+    position: "relative",
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * Root style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getRootStyle(ctx: Ctx): Style {
+  const range = getRangeOffsets(ctx)
+  return {
+    "--slider-thumb-transform": ctx.isVertical ? "translateY(50%)" : "translateX(-50%)",
+    "--slider-thumb-offset": getThumbOffset(ctx),
+    "--slider-range-start": range.start,
+    "--slider-range-end": range.end,
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * Marker style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getMarkerStyle(ctx: Pick<SharedContext, "isHorizontal" | "isRtl">, percent: number): Style {
+  return {
+    position: "absolute",
+    pointerEvents: "none",
+    [ctx.isHorizontal ? "left" : "bottom"]: `${ctx.isRtl ? 100 - percent : percent}%`,
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * Label style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getLabelStyle(): Style {
+  return { userSelect: "none" }
+}
+
+/* -----------------------------------------------------------------------------
+ * Label style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getTrackStyle(): Style {
+  return { position: "relative" }
+}
+
+/* -----------------------------------------------------------------------------
+ * Label style calculations
+ * -----------------------------------------------------------------------------*/
+
+function getMarkerGroupStyle(): Style {
+  return {
+    userSelect: "none",
+    pointerEvents: "none",
+    position: "relative",
+  }
+}
+
+export const styles = {
+  getThumbOffset,
+  getControlStyle,
+  getThumbStyle,
+  getRangeStyle,
+  getRootStyle,
+  getMarkerStyle,
+  getLabelStyle,
+  getTrackStyle,
+  getMarkerGroupStyle,
+}


### PR DESCRIPTION
## 📝 Description

This PR cleans up the style calculations in the slider and range-slider components. We now expose the positions of the thumbs and range via CSS to allow users to build elements (like tooltips) that follow the thumb position.

## ⛳️ Current behavior (updates)

Works, but can be improved.

## 🚀 New behavior

Scoped CSS variables to the root element for better access to position data in CSS

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
