### PR TITLE
fix: use guards in setup

### DIFF
--- a/.changeset/hip-eels-worry.md
+++ b/.changeset/hip-eels-worry.md
@@ -1,0 +1,8 @@
+---
+"next-ts": minor
+"solid-ts": minor
+"vue-ts": minor
+"@zag-js/dialog": minor
+---
+
+Fix visualizer failing because guards were not used in setup check

--- a/.changeset/hip-eels-worry.md
+++ b/.changeset/hip-eels-worry.md
@@ -3,6 +3,7 @@
 "solid-ts": patch
 "vue-ts": patch
 "@zag-js/dialog": patch
+"@zag-js/popover": patch
 ---
 
 Fix visualizer failing because guards were not used in setup check

--- a/.changeset/hip-eels-worry.md
+++ b/.changeset/hip-eels-worry.md
@@ -1,8 +1,8 @@
 ---
-"next-ts": minor
-"solid-ts": minor
-"vue-ts": minor
-"@zag-js/dialog": minor
+"next-ts": patch
+"solid-ts": patch
+"vue-ts": patch
+"@zag-js/dialog": patch
 ---
 
 Fix visualizer failing because guards were not used in setup check

--- a/.xstate/dialog.js
+++ b/.xstate/dialog.js
@@ -14,6 +14,7 @@ const fetchMachine = createMachine({
   id: "dialog",
   initial: "unknown",
   context: {
+    "isOpen": false,
     "isTopMostDialog && closeOnOutsideClick && isValidUnderlayClick": false
   },
   on: {
@@ -24,10 +25,14 @@ const fetchMachine = createMachine({
   states: {
     unknown: {
       on: {
-        SETUP: {
-          target: ctx.open ? "open" : "closed",
+        SETUP: [{
+          cond: "isOpen",
+          target: "open",
           actions: "setupDocument"
-        }
+        }, {
+          target: "closed",
+          actions: "setupDocument"
+        }]
       }
     },
     open: {
@@ -60,6 +65,7 @@ const fetchMachine = createMachine({
     })
   },
   guards: {
+    "isOpen": ctx => ctx["isOpen"],
     "isTopMostDialog && closeOnOutsideClick && isValidUnderlayClick": ctx => ctx["isTopMostDialog && closeOnOutsideClick && isValidUnderlayClick"]
   }
 });

--- a/.xstate/popover.js
+++ b/.xstate/popover.js
@@ -14,6 +14,7 @@ const fetchMachine = createMachine({
   id: "popover",
   initial: "unknown",
   context: {
+    "isOpen": false,
     "closeOnEsc": false,
     "isLastTabbableElement && closeOnBlur && portalled": false,
     "(isFirstTabbableElement || isContentFocused) && closeOnBlur && portalled": false,
@@ -28,10 +29,14 @@ const fetchMachine = createMachine({
   states: {
     unknown: {
       on: {
-        SETUP: {
-          target: ctx.open ? "open" : "closed",
-          actions: ["setupDocument", "checkRenderedElements"]
-        }
+        SETUP: [{
+          cond: "isOpen",
+          target: "open",
+          actions: "setupDocument"
+        }, {
+          target: "closed",
+          actions: "setupDocument"
+        }]
       }
     },
     closed: {
@@ -88,6 +93,7 @@ const fetchMachine = createMachine({
     })
   },
   guards: {
+    "isOpen": ctx => ctx["isOpen"],
     "closeOnEsc": ctx => ctx["closeOnEsc"],
     "isLastTabbableElement && closeOnBlur && portalled": ctx => ctx["isLastTabbableElement && closeOnBlur && portalled"],
     "(isFirstTabbableElement || isContentFocused) && closeOnBlur && portalled": ctx => ctx["(isFirstTabbableElement || isContentFocused) && closeOnBlur && portalled"],

--- a/.xstate/popover.js
+++ b/.xstate/popover.js
@@ -32,10 +32,10 @@ const fetchMachine = createMachine({
         SETUP: [{
           cond: "isOpen",
           target: "open",
-          actions: "setupDocument"
+          actions: ["setupDocument", "checkRenderedElements"]
         }, {
           target: "closed",
-          actions: "setupDocument"
+          actions: ["setupDocument", "checkRenderedElements"]
         }]
       }
     },

--- a/examples/next-ts/pages/dialog-default-open.tsx
+++ b/examples/next-ts/pages/dialog-default-open.tsx
@@ -10,7 +10,7 @@ import { Toolbar } from "../components/toolbar"
 export default function Page() {
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const [state, send] = useMachine(dialog.machine({ isOpen: true }))
+  const [state, send] = useMachine(dialog.machine({ open: true }))
   const ref = useSetup<HTMLButtonElement>({ send, id: useId() })
   const parentDialog = dialog.connect(state, send)
 

--- a/examples/solid-ts/src/pages/dialog-default-open.tsx
+++ b/examples/solid-ts/src/pages/dialog-default-open.tsx
@@ -11,7 +11,7 @@ injectGlobal(dialogStyle)
 
 export default function Page() {
   // dialog 1
-  const [state, send] = useMachine(dialog.machine({ isOpen: true }))
+  const [state, send] = useMachine(dialog.machine({ open: true }))
   const ref = useSetup<HTMLButtonElement>({ send, id: createUniqueId() })
   const parentDialog = createMemo(() => dialog.connect<PropTypes>(state, send, normalizeProps))
 

--- a/examples/vue-ts/src/pages/dialog-default-open.tsx
+++ b/examples/vue-ts/src/pages/dialog-default-open.tsx
@@ -14,7 +14,7 @@ export default defineComponent({
   setup() {
     const inputRef = vueRef<HTMLInputElement | null>(null)
 
-    const [state, send] = useMachine(dialog.machine({ isOpen: true }))
+    const [state, send] = useMachine(dialog.machine({ open: true }))
     const ref = useSetup({ send, id: useId() })
     const parentDialogRef = computed(() => dialog.connect<PropTypes>(state.value, send, normalizeProps))
 

--- a/packages/machines/dialog/src/dialog.machine.ts
+++ b/packages/machines/dialog/src/dialog.machine.ts
@@ -32,10 +32,17 @@ export function machine(ctx: UserDefinedContext = {}) {
       states: {
         unknown: {
           on: {
-            SETUP: {
-              target: ctx.open ? "open" : "closed",
-              actions: "setupDocument",
-            },
+            SETUP: [
+              {
+                guard: "isOpen",
+                target: "open",
+                actions: "setupDocument",
+              },
+              {
+                target: "closed",
+                actions: "setupDocument",
+              },
+            ],
           },
         },
         open: {
@@ -72,6 +79,7 @@ export function machine(ctx: UserDefinedContext = {}) {
         isTopMostDialog: (ctx) => ctx.isTopMostDialog,
         closeOnOutsideClick: (ctx) => ctx.closeOnOutsideClick,
         isValidUnderlayClick: (ctx, evt) => evt.target === ctx.pointerdownNode,
+        isOpen: (ctx) => !!ctx.open,
       },
       activities: {
         trackPointerDown(ctx, _evt) {

--- a/packages/machines/popover/src/popover.machine.ts
+++ b/packages/machines/popover/src/popover.machine.ts
@@ -45,11 +45,11 @@ export function machine(ctx: UserDefinedContext = {}) {
               {
                 guard: "isOpen",
                 target: "open",
-                actions: "setupDocument",
+                actions: ["setupDocument", "checkRenderedElements"],
               },
               {
                 target: "closed",
-                actions: "setupDocument",
+                actions: ["setupDocument", "checkRenderedElements"],
               },
             ],
           },

--- a/packages/machines/popover/src/popover.machine.ts
+++ b/packages/machines/popover/src/popover.machine.ts
@@ -41,10 +41,17 @@ export function machine(ctx: UserDefinedContext = {}) {
       states: {
         unknown: {
           on: {
-            SETUP: {
-              target: ctx.open ? "open" : "closed",
-              actions: ["setupDocument", "checkRenderedElements"],
-            },
+            SETUP: [
+              {
+                guard: "isOpen",
+                target: "open",
+                actions: "setupDocument",
+              },
+              {
+                target: "closed",
+                actions: "setupDocument",
+              },
+            ],
           },
         },
 
@@ -105,6 +112,7 @@ export function machine(ctx: UserDefinedContext = {}) {
         },
       },
     },
+
     {
       activities: {
         computePlacement(ctx) {
@@ -179,6 +187,7 @@ export function machine(ctx: UserDefinedContext = {}) {
         isContentFocused: (ctx) => dom.getContentEl(ctx) === dom.getActiveEl(ctx),
         isFirstTabbableElement: (ctx) => dom.getFirstTabbableEl(ctx) === dom.getActiveEl(ctx),
         isLastTabbableElement: (ctx) => dom.getLastTabbableEl(ctx) === dom.getActiveEl(ctx),
+        isOpen: (ctx) => !!ctx.open,
       },
       actions: {
         checkRenderedElements(ctx) {


### PR DESCRIPTION
Using guards for checks in Setup to avoid visualizer failing
<img width="1440" alt="CleanShot 2022-06-07 at 17 01 47@2x" src="https://user-images.githubusercontent.com/30869823/172427824-ad377377-9d4f-437b-bf5d-839584eb08fc.png">

