### PR TITLE
fix(slider): `disabled` is always false by default

### DIFF
--- a/.changeset/chilled-toys-pull.md
+++ b/.changeset/chilled-toys-pull.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/range-slider": patch
+"@zag-js/slider": patch
+---
+
+Fix issue where `disabled` is always false by default

--- a/packages/machines/range-slider/src/range-slider.machine.ts
+++ b/packages/machines/range-slider/src/range-slider.machine.ts
@@ -142,7 +142,7 @@ export function machine(ctx: UserDefinedContext = {}) {
           let cleanup: VoidFunction | undefined
           nextTick(() => {
             cleanup = trackFieldsetDisabled(dom.getRootEl(ctx), (disabled) => {
-              if (ctx.disabled != disabled) {
+              if (disabled) {
                 ctx.disabled = disabled
               }
             })

--- a/packages/machines/slider/src/slider.machine.ts
+++ b/packages/machines/slider/src/slider.machine.ts
@@ -136,7 +136,7 @@ export function machine(ctx: UserDefinedContext = {}) {
           let cleanup: VoidFunction | undefined
           nextTick(() => {
             cleanup = trackFieldsetDisabled(dom.getRootEl(ctx), (disabled) => {
-              if (disabled != ctx.disabled) {
+              if (disabled) {
                 ctx.disabled = disabled
               }
             })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #131

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

`disabled` is always false by default, even when we set it to true in the initial context

## 🚀 New behavior

The `trackFieldsetDisabled` activity only sets `disabled` in the context to true, if the fieldset is disabled.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

