### PR TITLE
Fix: setvalue error in number input

### DIFF
--- a/.changeset/perfect-wombats-relax.md
+++ b/.changeset/perfect-wombats-relax.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/number-input": patch
+---
+
+fixed a bug in the `setToMin` and `setToMax` api methods.

--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -311,7 +311,7 @@ export function machine(ctx: UserDefinedContext = {}) {
         },
         setValue(ctx, evt) {
           const value = evt.target?.value ?? evt.value
-          ctx.value = utils.sanitize(ctx, utils.parse(ctx, value))
+          ctx.value = utils.sanitize(ctx, utils.parse(ctx, value.toString()))
         },
         clearValue(ctx) {
           ctx.value = ""

--- a/packages/machines/number-input/src/number-input.utils.ts
+++ b/packages/machines/number-input/src/number-input.utils.ts
@@ -12,8 +12,10 @@ export const utils = {
     return ctx.validateCharacter?.(event.key) ?? utils.isFloatingPoint(event.key)
   },
   isFloatingPoint: (v: string) => /^[Ee0-9+\-.]$/.test(v),
-  sanitize: (ctx: Ctx, value: string) => {
+  sanitize: (ctx: Ctx, value: string | number) => {
+    console.log(value)
     return value
+      .toString()
       .split("")
       .filter(ctx.validateCharacter ?? utils.isFloatingPoint)
       .join("")

--- a/packages/machines/number-input/src/number-input.utils.ts
+++ b/packages/machines/number-input/src/number-input.utils.ts
@@ -12,10 +12,8 @@ export const utils = {
     return ctx.validateCharacter?.(event.key) ?? utils.isFloatingPoint(event.key)
   },
   isFloatingPoint: (v: string) => /^[Ee0-9+\-.]$/.test(v),
-  sanitize: (ctx: Ctx, value: string | number) => {
-    console.log(value)
+  sanitize: (ctx: Ctx, value: string) => {
     return value
-      .toString()
       .split("")
       .filter(ctx.validateCharacter ?? utils.isFloatingPoint)
       .join("")


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description

Issue in `setValue` action caused bugs in `setToMin` and `setToMax` API methods

## ⛳️ Current behavior (updates)

Those API methods don't work

## 🚀 New behavior

They work now

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
