### PR TITLE
Fix: number input clamp behaviour

### DIFF
--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -24,8 +24,6 @@ export function machine(ctx: UserDefinedContext = {}) {
         hint: null,
         value: "",
         step: 1,
-        min: Number.MIN_SAFE_INTEGER,
-        max: Number.MAX_SAFE_INTEGER,
         scrubberCursorPoint: null,
         invalid: false,
         ...ctx,
@@ -41,6 +39,8 @@ export function machine(ctx: UserDefinedContext = {}) {
         valueAsNumber: (ctx) => valueOf(ctx.value),
         isAtMin: (ctx) => isAtMin(ctx.value, ctx),
         isAtMax: (ctx) => isAtMax(ctx.value, ctx),
+        minValue: (ctx) => ctx.min ?? Number.MIN_SAFE_INTEGER,
+        maxValue: (ctx) => ctx.min ?? Number.MAX_SAFE_INTEGER,
         isOutOfRange: (ctx) => !isWithinRange(ctx.value, ctx),
         canIncrement: (ctx) => ctx.allowOverflow || !ctx.isAtMax,
         canDecrement: (ctx) => ctx.allowOverflow || !ctx.isAtMin,
@@ -317,10 +317,10 @@ export function machine(ctx: UserDefinedContext = {}) {
           ctx.value = ""
         },
         setToMax(ctx) {
-          ctx.value = ctx.max.toString()
+          ctx.value = ctx.maxValue.toString()
         },
         setToMin(ctx) {
-          ctx.value = ctx.min.toString()
+          ctx.value = ctx.minValue.toString()
         },
         setHint(ctx, evt) {
           ctx.hint = evt.hint
@@ -339,7 +339,7 @@ export function machine(ctx: UserDefinedContext = {}) {
         },
         invokeOnInvalid(ctx) {
           if (!ctx.isOutOfRange) return
-          const reason = ctx.valueAsNumber > ctx.max ? "rangeOverflow" : "rangeUnderflow"
+          const reason = ctx.valueAsNumber > ctx.maxValue ? "rangeOverflow" : "rangeUnderflow"
           ctx.onInvalid?.({
             reason,
             value: ctx.formattedValue,

--- a/packages/machines/number-input/src/number-input.types.ts
+++ b/packages/machines/number-input/src/number-input.types.ts
@@ -66,11 +66,11 @@ type PublicContext = DirectionProperty &
     /**
      * The minimum value of the number input
      */
-    min: number
+    min?: number
     /**
      * The maximum value of the number input
      */
-    max: number
+    max?: number
     /**
      * The amount to increment or decrement the value by
      */
@@ -135,6 +135,18 @@ type ComputedContext = Readonly<{
    * The value of the input as a number
    */
   valueAsNumber: number
+  /**
+   * @computed
+   * @default MIN_SAFE_INTEGER
+   * The minimum value of the input
+   */
+  minValue: number
+  /**
+   * @computed
+   * @default MAX_SAFE_INTEGER
+   * The maximum value of the input
+   */
+  maxValue: number
   /**
    * @computed
    * Whether the value is at the min

--- a/packages/utilities/number/src/number.ts
+++ b/packages/utilities/number/src/number.ts
@@ -22,8 +22,8 @@ export const valueToPercent = (v: number | string, r: Num<"step" | "min" | "max"
 
 export const percentToValue = (v: number | string, r: Num<"min" | "max">) => r.min + (r.max - r.min) * valueOf(v)
 
-export function clamp(v: number | string, o: Num<"min" | "max">) {
-  return Math.min(Math.max(valueOf(v), o.min), o.max)
+export function clamp(v: number | string, o: Num<"minValue" | "maxValue">) {
+  return Math.min(Math.max(valueOf(v), o.minValue), o.maxValue)
 }
 
 export function countDecimals(value: number) {
@@ -74,19 +74,19 @@ export function formatDecimal(v: number | string, o: Omit<FormatDecimalOptions, 
   }).format(valueOf(v))
 }
 
-export function isAtMax(v: number | string, o: Num<"max">) {
+export function isAtMax(v: number | string, o: Num<"maxValue">) {
   const val = valueOf(v)
-  return val >= o.max
+  return val >= o.maxValue
 }
 
-export function isAtMin(v: number | string, o: Num<"min">) {
+export function isAtMin(v: number | string, o: Num<"minValue">) {
   const val = valueOf(v)
-  return val <= o.min
+  return val <= o.minValue
 }
 
-export function isWithinRange(v: number | string, o: Num<"min" | "max">) {
+export function isWithinRange(v: number | string, o: Num<"minValue" | "maxValue">) {
   const val = valueOf(v)
-  return val >= o.min && val <= o.max
+  return val >= o.minValue && val <= o.maxValue
 }
 
 function decimalOperation(a: number, op: "-" | "+", b: number): number {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #98

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

Empty Input does not clamp to min when min is <= 0


## 💣 Is this a breaking change (Yes/No): No

 
