### PR TITLE
Fix rating defaultvalue

### DIFF
--- a/.changeset/cool-stingrays-tie.md
+++ b/.changeset/cool-stingrays-tie.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/rating": patch
+---
+
+Use `defaultValue` instead of `value` in hiiden input

--- a/packages/machines/rating/src/rating.connect.ts
+++ b/packages/machines/rating/src/rating.connect.ts
@@ -52,7 +52,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       type: "text",
       hidden: true,
       id: dom.getInputId(state.context),
-      value: state.context.value,
+      defaultValue: state.context.value,
     }),
 
     labelProps: normalize.element({


### PR DESCRIPTION


## 📝 Fix rating defaultValue

> Rating hidden input uses `value` without `onChange` handler
