### PR TITLE
Add support for focus and blur handlers

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": []
+  "ignore": ["@zag-js/shared", "next-ts", "vue-ts", "solid-ts"]
 }

--- a/.changeset/fresh-cars-give.md
+++ b/.changeset/fresh-cars-give.md
@@ -1,0 +1,23 @@
+---
+"@zag-js/number-input": patch
+---
+
+- Add support for `spinOnPress` to allow user control whether to spin the input's value when the decrement or increment
+  button is pressed.
+
+- Add support for `onFocus` and `onBlur` callbacks in the machine's context.
+
+```jsx
+const [state, send] = useMachine(
+  numberInput.machine({
+    onFocus(details) {
+      // details => { value: string, valueAsNumber: number, srcElement: HTMLElement | null }
+    },
+    onBlur(details) {
+      // details => { value: string, valueAsNumber: number }
+    },
+  }),
+)
+```
+
+- Add `focus()` and `blur()` methods to the machine's `api`

--- a/packages/machines/number-input/src/number-input.connect.ts
+++ b/packages/machines/number-input/src/number-input.connect.ts
@@ -53,6 +53,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     focus() {
       dom.getInputEl(state.context)?.focus()
     },
+    blur() {
+      dom.getInputEl(state.context)?.blur()
+    },
 
     rootProps: normalize.element({
       id: dom.getRootId(state.context),

--- a/packages/machines/number-input/src/number-input.types.ts
+++ b/packages/machines/number-input/src/number-input.types.ts
@@ -28,6 +28,11 @@ type IntlMessages = {
   decrementLabel: string
 }
 
+type Value = {
+  value: string
+  valueAsNumber: number
+}
+
 type PublicContext = DirectionProperty &
   CommonProperties & {
     /**
@@ -118,11 +123,19 @@ type PublicContext = DirectionProperty &
     /**
      * Function invoked when the value changes
      */
-    onChange?: (details: { value: string; valueAsNumber: number }) => void
+    onChange?: (details: Value) => void
     /**
      * Function invoked when the value overflows or underflows the min/max range
      */
-    onInvalid?: (details: { reason: ValidityState; value: string; valueAsNumber: number }) => void
+    onInvalid?: (details: Value & { reason: ValidityState }) => void
+    /**
+     * Function invoked when the number input is focused
+     */
+    onFocus?: (details: Value & { srcElement: HTMLElement | null }) => void
+    /**
+     * The value of the input when it is blurred
+     */
+    onBlur?: (details: Value) => void
     /**
      * The minimum number of fraction digits to use. Possible values are from 0 to 20
      */
@@ -131,6 +144,10 @@ type PublicContext = DirectionProperty &
      * The maximum number of fraction digits to use. Possible values are from 0 to 20;
      */
     maxFractionDigits?: number
+    /**
+     * Whether to spin the value when the increment/decrement button is pressed
+     */
+    spinOnPress?: boolean
   }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">

--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -52,6 +52,7 @@ export const numberInputControls = defineControls({
   disabled: { type: "boolean", defaultValue: false },
   clampValueOnBlur: { type: "boolean", defaultValue: true },
   allowMouseWheel: { type: "boolean", defaultValue: false },
+  spinOnPress: { type: "boolean", defaultValue: true },
   step: { type: "number", defaultValue: 1 },
   minFractionDigits: { type: "number", defaultValue: 0 },
   maxFractionDigits: { type: "number", defaultValue: 3 },


### PR DESCRIPTION
- Add support for `spinOnPress` to allow user control whether to spin the input's value when the decrement or increment
  button is pressed.

- Add support for `onFocus` and `onBlur` callbacks in the machine's context.

```jsx
const [state, send] = useMachine(
  numberInput.machine({
    onFocus(details) {
      // details => { value: string, valueAsNumber: number, srcElement: HTMLElement | null }
    },
    onBlur(details) {
      // details => { value: string, valueAsNumber: number }
    },
  }),
)
```

- Add `focus()` and `blur()` methods to the machine's `api`