### PR TITLE
Add `setDisabled` method to API

### DIFF
--- a/.changeset/happy-horses-tie.md
+++ b/.changeset/happy-horses-tie.md
@@ -1,0 +1,8 @@
+---
+"@zag-js/checkbox": minor
+"@zag-js/rating": minor
+"@zag-js/slider": minor
+"@zag-js/toggle": minor
+---
+
+Add `setDisabled` method to API

--- a/.xstate/checkbox.js
+++ b/.xstate/checkbox.js
@@ -34,6 +34,9 @@ const fetchMachine = createMachine({
     SET_ACTIVE: {
       actions: "setActive"
     },
+    SET_DISABLED: {
+      actions: "setDisabled"
+    },
     SET_HOVERED: {
       actions: "setHovered"
     },

--- a/.xstate/rating.js
+++ b/.xstate/rating.js
@@ -18,6 +18,11 @@ const fetchMachine = createMachine({
     "isRadioFocused": false
   },
   on: {
+    SET_DISABLED: {
+      actions: "setDisabled"
+    }
+  },
+  on: {
     UPDATE_CONTEXT: {
       actions: "updateContext"
     }

--- a/.xstate/slider.js
+++ b/.xstate/slider.js
@@ -21,6 +21,9 @@ const fetchMachine = createMachine({
   },
   activities: ["trackFormReset", "trackFieldsetDisabled"],
   on: {
+    SET_DISABLED: {
+      actions: "setDisabled"
+    },
     SET_VALUE: {
       actions: "setValue"
     },

--- a/.xstate/toggle.js
+++ b/.xstate/toggle.js
@@ -18,6 +18,9 @@ const fetchMachine = createMachine({
     "isDefaultPressed": false
   },
   on: {
+    SET_DISABLED: {
+      actions: "setDisabled"
+    },
     SET_STATE: [{
       cond: "isPressed",
       target: "pressed",

--- a/packages/machines/checkbox/src/checkbox.connect.ts
+++ b/packages/machines/checkbox/src/checkbox.connect.ts
@@ -42,6 +42,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     setChecked(checked: boolean) {
       send({ type: "SET_STATE", checked, manual: true })
     },
+    setDisabled(disabled: boolean) {
+      send({ type: "SET_DISABLED", disabled })
+    },
     setIndeterminate(indeterminate: boolean) {
       send({ type: "SET_INDETERMINATE", value: indeterminate })
     },

--- a/packages/machines/checkbox/src/checkbox.machine.ts
+++ b/packages/machines/checkbox/src/checkbox.machine.ts
@@ -48,6 +48,9 @@ export function machine(ctx: UserDefinedContext) {
         SET_ACTIVE: {
           actions: "setActive",
         },
+        SET_DISABLED: {
+          actions: "setDisabled",
+        },
         SET_HOVERED: {
           actions: "setHovered",
         },
@@ -125,6 +128,9 @@ export function machine(ctx: UserDefinedContext) {
         },
         setIndeterminate(ctx, evt) {
           ctx.indeterminate = evt.value
+        },
+        setDisabled(ctx, evt) {
+          ctx.disabled = evt.disabled
         },
         syncInputIndeterminate(ctx) {
           const el = dom.getInputEl(ctx)

--- a/packages/machines/rating/src/rating.connect.ts
+++ b/packages/machines/rating/src/rating.connect.ts
@@ -39,6 +39,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         isChecked: isEqual || (state.context.value === -1 && index === 1),
       }
     },
+    setDisabled(disabled: boolean) {
+      send({ type: "SET_DISABLED", disabled })
+    },
 
     rootProps: normalize.element({
       dir: state.context.dir,

--- a/packages/machines/rating/src/rating.machine.ts
+++ b/packages/machines/rating/src/rating.machine.ts
@@ -24,6 +24,12 @@ export function machine(ctx: UserDefinedContext) {
         },
       },
 
+      on: {
+        SET_DISABLED: {
+          actions: "setDisabled",
+        },
+      },
+
       created: ["roundValueIfNeeded"],
 
       watch: {
@@ -152,6 +158,9 @@ export function machine(ctx: UserDefinedContext) {
           }
           let value = evt.index - factor
           ctx.hoveredValue = value
+        },
+        setDisabled(ctx, evt) {
+          ctx.disabled = evt.disabled
         },
         dispatchChangeEvent(ctx, evt) {
           if (evt.type !== "SETUP") {

--- a/packages/machines/slider/src/slider.connect.ts
+++ b/packages/machines/slider/src/slider.connect.ts
@@ -32,6 +32,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     setValue(value: number) {
       send({ type: "SET_VALUE", value })
     },
+    setDisabled(disabled: boolean) {
+      send({ type: "SET_DISABLED", disabled })
+    },
     getPercentValue(percent: number) {
       return percentToValue(percent, state.context)
     },

--- a/packages/machines/slider/src/slider.machine.ts
+++ b/packages/machines/slider/src/slider.machine.ts
@@ -40,6 +40,9 @@ export function machine(ctx: UserDefinedContext) {
       activities: ["trackFormReset", "trackFieldsetDisabled"],
 
       on: {
+        SET_DISABLED: {
+          actions: "setDisabled",
+        },
         SET_VALUE: {
           actions: "setValue",
         },
@@ -202,6 +205,9 @@ export function machine(ctx: UserDefinedContext) {
         },
         setToMax(ctx) {
           ctx.value = ctx.max
+        },
+        setDisabled(ctx, evt) {
+          ctx.disabled = evt.disabled
         },
         setValue(ctx, evt) {
           ctx.value = utils.convert(ctx, evt.value)

--- a/packages/machines/toggle/src/toggle.connect.ts
+++ b/packages/machines/toggle/src/toggle.connect.ts
@@ -12,6 +12,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     setPressed(value: boolean) {
       send({ type: "SET_STATE", pressed: value })
     },
+    setDisabled(disabled: boolean) {
+      send({ type: "SET_DISABLED", disabled })
+    },
     buttonProps: normalize.button({
       id: dom.getButtonId(state.context),
       type: "button",

--- a/packages/machines/toggle/src/toggle.machine.ts
+++ b/packages/machines/toggle/src/toggle.machine.ts
@@ -14,6 +14,9 @@ export function machine(ctx: UserDefinedContext) {
       },
 
       on: {
+        SET_DISABLED: {
+          actions: "setDisabled",
+        },
         SET_STATE: [
           { guard: "isPressed", target: "pressed", actions: ["invokeOnChange"] },
           { target: "unpressed", actions: ["invokeOnChange"] },
@@ -41,6 +44,9 @@ export function machine(ctx: UserDefinedContext) {
       actions: {
         invokeOnChange(ctx, evt) {
           ctx.onChange?.({ pressed: evt.pressed })
+        },
+        setDisabled(ctx, evt) {
+          ctx.disabled = evt.disabled
         },
       },
     },


### PR DESCRIPTION
Closes #230

## 📝 Add `setDisabled` method

Adds the `setDisabled` method to API, to enable dynamic `disabled` state change in components.