### PR TITLE
Fix: tag input edit non existent tag

### DIFF
--- a/.changeset/chilly-moose-swim.md
+++ b/.changeset/chilly-moose-swim.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/tags-input": patch
+---
+
+Fixed issue where input tried to edit a non existent tag after all tags are deleted.

--- a/.xstate/tags-input.js
+++ b/.xstate/tags-input.js
@@ -27,7 +27,7 @@ const fetchMachine = createMachine({
     "hasTags && isInputCaretAtStart": false,
     "addOnPaste": false,
     "hasTags && isInputCaretAtStart && !isLastTagFocused": false,
-    "allowEditTag": false,
+    "allowEditTag && hasFocusedId": false,
     "isFirstTagFocused": false,
     "isInputRelatedTarget": false
   },
@@ -160,7 +160,7 @@ const fetchMachine = createMachine({
           actions: "clearFocusedId"
         },
         ENTER: {
-          cond: "allowEditTag",
+          cond: "allowEditTag && hasFocusedId",
           target: "editing:tag",
           actions: ["setEditedId", "initializeEditedTagValue", "focusEditedTagInput"]
         },
@@ -227,6 +227,7 @@ const fetchMachine = createMachine({
     "hasTags && isInputCaretAtStart": ctx => ctx["hasTags && isInputCaretAtStart"],
     "addOnPaste": ctx => ctx["addOnPaste"],
     "hasTags && isInputCaretAtStart && !isLastTagFocused": ctx => ctx["hasTags && isInputCaretAtStart && !isLastTagFocused"],
+    "allowEditTag && hasFocusedId": ctx => ctx["allowEditTag && hasFocusedId"],
     "isFirstTagFocused": ctx => ctx["isFirstTagFocused"],
     "isInputRelatedTarget": ctx => ctx["isInputRelatedTarget"]
   }

--- a/e2e/tags-input.e2e.ts
+++ b/e2e/tags-input.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, test, Locator } from "@playwright/test"
-import { paste, testid } from "./__utils"
+import { clickViz, paste, testid } from "./__utils"
 
 const input = testid("input")
 
@@ -39,6 +39,27 @@ test.describe("tags-input", () => {
     await page.keyboard.press("Backspace")
 
     await expect(page.locator(svelte.tag)).toBeHidden()
+    await expect(page.locator(input)).toBeFocused()
+  })
+
+  test.only("should not edit when no tag is focused", async ({ page }) => {
+    await clickViz(page)
+    //Focus input
+    await page.locator(input).focus()
+    //Clear Vue
+    await page.keyboard.press("Backspace")
+    await page.keyboard.press("Delete")
+    //Clear React
+    await page.keyboard.press("Backspace")
+    await page.keyboard.press("Delete")
+
+    await page.keyboard.press("Enter")
+
+    const svelte = item("Svelte")
+    await page.type(input, "Svelte")
+    await page.keyboard.press("Enter")
+    await expect(page.locator(svelte.tag)).toBeVisible()
+    await expect(page.locator(input)).toBeEmpty()
     await expect(page.locator(input)).toBeFocused()
   })
 

--- a/e2e/tags-input.e2e.ts
+++ b/e2e/tags-input.e2e.ts
@@ -42,7 +42,7 @@ test.describe("tags-input", () => {
     await expect(page.locator(input)).toBeFocused()
   })
 
-  test.only("should not edit when no tag is focused", async ({ page }) => {
+  test("should not edit when no tag is focused", async ({ page }) => {
     await clickViz(page)
     //Focus input
     await page.locator(input).focus()

--- a/packages/machines/tags-input/src/tags-input.machine.ts
+++ b/packages/machines/tags-input/src/tags-input.machine.ts
@@ -191,7 +191,7 @@ export function machine(ctx: UserDefinedContext) {
               actions: "clearFocusedId",
             },
             ENTER: {
-              guard: "allowEditTag",
+              guard: and("allowEditTag", "hasFocusedId"),
               target: "editing:tag",
               actions: ["setEditedId", "initializeEditedTagValue", "focusEditedTagInput"],
             },
@@ -343,7 +343,7 @@ export function machine(ctx: UserDefinedContext) {
         focusPrevTag(ctx) {
           if (!ctx.focusedId) return
           const prev = dom.getPrevEl(ctx, ctx.focusedId)
-          if (prev) ctx.focusedId = prev.id
+          ctx.focusedId = prev?.id || null
         },
         focusTag(ctx, evt) {
           ctx.focusedId = evt.id


### PR DESCRIPTION
Closes #238

## 📝 tag input edit non existent tag

When a tag is focused, we transition to the `navigating:tag` state. `delete` deletes the focused tag and `enter` transitions to the `editing:tag` state, with the `id` of the focused tag in context under `focusedId`.
Now when a tag is deleted, we remain in the `navigating:tag` state, and focus the new last tag, this approach allows the user to keep pressing delete to remove multiple tags, without having to focus them individually.
So when the user deletes the last tag, we're still in the `navigating:tag` state. But now, there's no more tags. The first issue, is as we focus the previous tag after deleting a tag, we don't account for when there's no previous tag (when all tags are deleted), so the id of the last deleted tag remains in context as focused tag.
Now when the user hits the `enter` key, the machine tries to edit the focused tag, which no longer exists.
I solve this, by setting `focusedId` back to null when we try to focus previous tag, but there's. none.
Now when the user clicks enter, the second issue arises, because `enter` in the `navigating:tag` state always has to edit a tag, the machine transitions to `editing:tag` even though there's no focused tag, thereby still blocking the main input.
So I fix this by checking the `hasFocusedId` guard whenever a user hits enter, to make sure that we only transition to `editing:tag` when a tag is focused.
