### PR TITLE
fix: number input dispatch change

### DIFF
--- a/.changeset/funny-countries-bake.md
+++ b/.changeset/funny-countries-bake.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/number-input": patch
+---
+
+Fix issue where onChange doesn't get triggered when value changes programmatically

--- a/.changeset/funny-countries-bake.md
+++ b/.changeset/funny-countries-bake.md
@@ -2,4 +2,5 @@
 "@zag-js/number-input": patch
 ---
 
-Fix issue where onChange doesn't get triggered when value changes programmatically
+- Fix issue where onChange doesn't get triggered when value changes programmatically
+- Fix SSR warning with `aria-roledescription` attribute on input

--- a/packages/machines/number-input/package.json
+++ b/packages/machines/number-input/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@zag-js/dom-utils": "workspace:*",
+    "@zag-js/form-utils": "workspace:*",
     "@zag-js/number-utils": "workspace:*",
     "@zag-js/utils": "workspace:*"
   },

--- a/packages/machines/number-input/src/number-input.connect.ts
+++ b/packages/machines/number-input/src/number-input.connect.ts
@@ -5,7 +5,6 @@ import {
   getEventStep,
   getNativeEvent,
   getEventPoint,
-  isIos,
   isLeftClick,
 } from "@zag-js/dom-utils"
 import { roundToDevicePixel } from "@zag-js/number-utils"
@@ -85,7 +84,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       name: state.context.name,
       id: dom.getInputId(state.context),
       role: "spinbutton",
-      value: state.context.formattedValue,
+      defaultValue: state.context.formattedValue,
       pattern: state.context.pattern,
       inputMode: state.context.inputMode,
       "aria-invalid": isInvalid || undefined,
@@ -97,7 +96,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       autoCorrect: "off",
       spellCheck: "false",
       type: "text",
-      "aria-roledescription": !isIos() ? "number field" : undefined,
+      "aria-roledescription": "numberfield",
       "aria-valuemin": state.context.min,
       "aria-valuemax": state.context.max,
       "aria-valuenow": isNaN(state.context.valueAsNumber) ? undefined : state.context.valueAsNumber,

--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -9,6 +9,7 @@ import {
 } from "@zag-js/dom-utils"
 import { isAtMax, isAtMin, isWithinRange, valueOf } from "@zag-js/number-utils"
 import { callAll } from "@zag-js/utils"
+import { dispatchInputValueEvent } from "@zag-js/form-utils"
 import { dom } from "./number-input.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./number-input.types"
 import { utils } from "./number-input.utils"
@@ -57,7 +58,7 @@ export function machine(ctx: UserDefinedContext) {
       },
 
       watch: {
-        value: ["invokeOnChange"],
+        value: ["invokeOnChange", "dispatchChangeEvent"],
         isOutOfRange: ["invokeOnInvalid"],
         scrubberCursorPoint: ["setVirtualCursorPosition"],
       },
@@ -387,6 +388,9 @@ export function machine(ctx: UserDefinedContext) {
           if (!cursor || !ctx.scrubberCursorPoint) return
           const { x, y } = ctx.scrubberCursorPoint
           cursor.style.transform = `translate3d(${x}px, ${y}px, 0px)`
+        },
+        dispatchChangeEvent(ctx) {
+          dispatchInputValueEvent(dom.getInputEl(ctx), ctx.formattedValue)
         },
       },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,6 +596,7 @@ importers:
     specifiers:
       '@zag-js/core': workspace:*
       '@zag-js/dom-utils': workspace:*
+      '@zag-js/form-utils': workspace:*
       '@zag-js/number-utils': workspace:*
       '@zag-js/types': workspace:*
       '@zag-js/utils': workspace:*
@@ -604,6 +605,7 @@ importers:
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
+      '@zag-js/form-utils': link:../../utilities/form-utils
       '@zag-js/number-utils': link:../../utilities/number
       '@zag-js/utils': link:../../utilities/core
 


### PR DESCRIPTION
Closes #265

## 📝 Description

Fix issue where the number input doesn't trigger change event when set programmatically. This was caused by the fact that we use the "controlled" state. Going forward, we'll stick with uncontrolled since this is the DOM works by default.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
