### PR TITLE
Fix menu doesn't trigger select on mobile

### DIFF
--- a/.changeset/sharp-candles-hammer.md
+++ b/.changeset/sharp-candles-hammer.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/dom-utils": patch
+---
+
+Remove redundant helper

--- a/.changeset/warm-donuts-hug.md
+++ b/.changeset/warm-donuts-hug.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/menu": patch
+---
+
+Fix issue where menu doesn't trigger select on mobile

--- a/.changeset/wdfarm-dfuts-hug.md
+++ b/.changeset/wdfarm-dfuts-hug.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/dom-utils": patch
+---
+
+Remove unneeded utilities

--- a/.xstate/menu.js
+++ b/.xstate/menu.js
@@ -224,7 +224,7 @@ const fetchMachine = createMachine({
           actions: "setIntentPolygon"
         },
         ITEM_POINTERDOWN: {
-          actions: ["setPointerdownNode"]
+          actions: ["setPointerdownNode", "focusItem"]
         },
         TYPEAHEAD: {
           actions: "focusMatchedItem"

--- a/packages/machines/menu/src/menu.machine.ts
+++ b/packages/machines/menu/src/menu.machine.ts
@@ -254,7 +254,7 @@ export function machine(ctx: UserDefinedContext) {
               actions: "setIntentPolygon",
             },
             ITEM_POINTERDOWN: {
-              actions: ["setPointerdownNode"],
+              actions: ["setPointerdownNode", "focusItem"],
             },
             TYPEAHEAD: {
               actions: "focusMatchedItem",

--- a/packages/utilities/dom/src/event.ts
+++ b/packages/utilities/dom/src/event.ts
@@ -57,11 +57,3 @@ export const isModifiedEvent = (v: Pick<KeyboardEvent, "ctrlKey" | "metaKey" | "
 
 export const isCtrlKey = (v: Pick<KeyboardEvent, "ctrlKey" | "metaKey">) =>
   isMac() ? v.metaKey && !v.ctrlKey : v.ctrlKey && !v.metaKey
-
-export function whenMouse<E>(handler: JSX.PointerEventHandler<E>): JSX.PointerEventHandler<E> {
-  return (event) => (event.pointerType === "mouse" ? handler(event) : undefined)
-}
-
-export function whenTouchOrPen<E>(handler: JSX.PointerEventHandler<E>): JSX.PointerEventHandler<E> {
-  return (event) => (event.pointerType !== "mouse" ? handler(event) : undefined)
-}


### PR DESCRIPTION
Closes #283 

## 📝 Description

This PR fixes the issue where the menu doesn't trigger selects on mobile. This was caused by the fact that `ctx.activeId` was undefined/null.

