### PR TITLE
build: switch to esm and `type: module`

### DIFF
--- a/.changeset/honest-owls-whisper.md
+++ b/.changeset/honest-owls-whisper.md
@@ -1,0 +1,49 @@
+---
+"@zag-js/core": patch
+"@zag-js/react": patch
+"@zag-js/solid": patch
+"@zag-js/svelte": patch
+"@zag-js/vue": patch
+"@zag-js/accordion": patch
+"@zag-js/checkbox": patch
+"@zag-js/combobox": patch
+"@zag-js/dialog": patch
+"@zag-js/editable": patch
+"@zag-js/hover-card": patch
+"@zag-js/menu": patch
+"@zag-js/number-input": patch
+"@zag-js/pin-input": patch
+"@zag-js/popover": patch
+"@zag-js/pressable": patch
+"@zag-js/radio": patch
+"@zag-js/range-slider": patch
+"@zag-js/rating": patch
+"@zag-js/slider": patch
+"@zag-js/splitter": patch
+"@zag-js/tabs": patch
+"@zag-js/tags-input": patch
+"@zag-js/toast": patch
+"@zag-js/toggle": patch
+"@zag-js/tooltip": patch
+"@zag-js/store": patch
+"@zag-js/types": patch
+"@zag-js/aria-hidden": patch
+"@zag-js/auto-resize": patch
+"@zag-js/utils": patch
+"@zag-js/dismissable": patch
+"@zag-js/dom-utils": patch
+"@zag-js/element-rect": patch
+"@zag-js/element-size": patch
+"@zag-js/focus-scope": patch
+"@zag-js/focus-visible": patch
+"@zag-js/form-utils": patch
+"@zag-js/hover-intent": patch
+"@zag-js/interact-outside": patch
+"@zag-js/live-region": patch
+"@zag-js/number-utils": patch
+"@zag-js/popper": patch
+"@zag-js/rect-utils": patch
+"@zag-js/remove-scroll": patch
+---
+
+Switch packages to use ESM and `type=module`

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "build": "turbo run build --filter=./packages/**/*",
     "start": "turbo run start --filter=./packages/**/*",
     "prepare": "husky install",
-    "swc": "node -r @swc-node/register",
-    "sync-pkgs": "pnpm swc scripts/sync-packages.ts",
+    "sync-pkgs": "tsx scripts/sync-packages.ts",
     "clean-pkgs": "pnpm -r exec rm -rf dist .turbo .swc *.log",
     "clean": "pnpm clean-pkgs && rm -rf node_modules",
     "react": "pnpm --filter \"./examples/next-ts\"",
@@ -36,9 +35,9 @@
     "version": "changeset version",
     "release": "changeset publish",
     "test": "jest",
-    "visualize": "pnpm swc scripts/visualize.ts --all",
-    "changelog": "pnpm swc scripts/changelog.ts",
-    "sandbox": "pnpm swc scripts/sandbox.ts"
+    "visualize": "tsx scripts/visualize.ts --all",
+    "changelog": "tsx scripts/changelog.ts",
+    "sandbox": "tsx scripts/sandbox.ts"
   },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx}": "prettier --write",
@@ -65,7 +64,6 @@
     "@octokit/rest": "19.0.4",
     "@playwright/test": "1.25.2",
     "@swc-node/jest": "1.5.2",
-    "@swc-node/register": "1.5.1",
     "@types/jest": "28.1.8",
     "@types/signale": "1.4.4",
     "@typescript-eslint/eslint-plugin": "5.30.6",
@@ -89,6 +87,7 @@
     "signale": "1.4.0",
     "start-server-and-test": "1.14.0",
     "tsup": "6.2.3",
+    "tsx": "3.9.0",
     "turbo": "1.4.3",
     "typescript": "4.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "release": "changeset publish",
     "test": "jest",
     "visualize": "pnpm swc scripts/visualize.ts --all",
-    "changelog": "pnpm swc scripts/changelog.ts"
+    "changelog": "pnpm swc scripts/changelog.ts",
+    "sandbox": "pnpm swc scripts/sandbox.ts"
   },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx}": "prettier --write",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/core",
   "version": "0.1.10",
   "description": "A minimal implementation of xstate fsm for UI machines",
@@ -13,8 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/machine",
   "sideEffects": false,
@@ -22,9 +22,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/machine",
   "sideEffects": false,

--- a/packages/frameworks/react/package.json
+++ b/packages/frameworks/react/package.json
@@ -14,7 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/frameworks/react",
   "sideEffects": false,

--- a/packages/frameworks/react/package.json
+++ b/packages/frameworks/react/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/react",
   "version": "0.1.16",
   "description": "The react wrapper for zag",
@@ -13,8 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/frameworks/react",
   "sideEffects": false,
@@ -43,9 +43,9 @@
     "react": ">=16.8.6"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/frameworks/solid/package.json
+++ b/packages/frameworks/solid/package.json
@@ -14,7 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/frameworks/solid",
   "sideEffects": false,

--- a/packages/frameworks/solid/package.json
+++ b/packages/frameworks/solid/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/solid",
   "version": "0.1.15",
   "description": "The solid.js wrapper for zag",
@@ -13,8 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/frameworks/solid",
   "sideEffects": false,
@@ -41,9 +41,9 @@
     "solid-js": ">=1.1.3"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/frameworks/svelte/package.json
+++ b/packages/frameworks/svelte/package.json
@@ -14,7 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/core/svelte",
   "sideEffects": false,

--- a/packages/frameworks/svelte/package.json
+++ b/packages/frameworks/svelte/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/svelte",
   "version": "0.1.13",
   "description": "The svelte wrapper for zag",
@@ -13,8 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/core/svelte",
   "sideEffects": false,
@@ -37,9 +37,9 @@
     "svelte": ">=3.0.0"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/frameworks/vue/package.json
+++ b/packages/frameworks/vue/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/vue",
   "version": "0.1.14",
   "description": "The vue wrapper for zag",
@@ -13,8 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/frameworks/vue",
   "sideEffects": false,
@@ -39,9 +39,9 @@
     "vue": ">=3.0.0"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/frameworks/vue/package.json
+++ b/packages/frameworks/vue/package.json
@@ -14,7 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/frameworks/vue",
   "sideEffects": false,

--- a/packages/machines/accordion/package.json
+++ b/packages/machines/accordion/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/accordion",
   "version": "0.1.13",
   "description": "Core logic for the accordion widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/accordion",
   "sideEffects": false,
   "files": [
@@ -37,9 +37,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/accordion/package.json
+++ b/packages/machines/accordion/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/accordion",
   "sideEffects": false,

--- a/packages/machines/checkbox/package.json
+++ b/packages/machines/checkbox/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/checkbox",
   "sideEffects": false,

--- a/packages/machines/checkbox/package.json
+++ b/packages/machines/checkbox/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/checkbox",
   "version": "0.1.6",
   "description": "Core logic for the checkbox widget implemented as a state machine",
@@ -14,18 +15,17 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/checkbox",
   "sideEffects": false,
   "files": [
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/machines/combobox/package.json
+++ b/packages/machines/combobox/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/combobox",
   "version": "0.1.15",
   "description": "Core logic for the combobox widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/combobox",
   "sideEffects": false,
   "files": [
@@ -41,9 +41,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/combobox/package.json
+++ b/packages/machines/combobox/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/combobox",
   "sideEffects": false,

--- a/packages/machines/dialog/package.json
+++ b/packages/machines/dialog/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/dialog",
   "version": "0.1.13",
   "description": "Core logic for the dialog widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/dialog",
   "sideEffects": false,
   "files": [
@@ -41,9 +41,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/dialog/package.json
+++ b/packages/machines/dialog/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/dialog",
   "sideEffects": false,

--- a/packages/machines/editable/package.json
+++ b/packages/machines/editable/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/editable",
   "version": "0.1.14",
   "description": "Core logic for the editable widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/editable",
   "sideEffects": false,
   "files": [
@@ -37,9 +37,9 @@
     "@zag-js/dom-utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/editable/package.json
+++ b/packages/machines/editable/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/editable",
   "sideEffects": false,

--- a/packages/machines/hover-card/package.json
+++ b/packages/machines/hover-card/package.json
@@ -15,7 +15,7 @@
   "author": "Abraham Aremu <anubra266@gmail.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/hover-card",
   "sideEffects": false,

--- a/packages/machines/hover-card/package.json
+++ b/packages/machines/hover-card/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/hover-card",
   "version": "0.0.1",
   "description": "Core logic for the hover-card widget implemented as a state machine",
@@ -14,18 +15,17 @@
   "author": "Abraham Aremu <anubra266@gmail.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/hover-card",
   "sideEffects": false,
   "files": [
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/menu/package.json
+++ b/packages/machines/menu/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/menu",
   "sideEffects": false,

--- a/packages/machines/menu/package.json
+++ b/packages/machines/menu/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/menu",
   "version": "0.1.14",
   "description": "Core logic for the menu widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/menu",
   "sideEffects": false,
   "files": [
@@ -40,9 +40,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/number-input/package.json
+++ b/packages/machines/number-input/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/number-input",
   "sideEffects": false,

--- a/packages/machines/number-input/package.json
+++ b/packages/machines/number-input/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/number-input",
   "version": "0.1.17",
   "description": "Core logic for the number-input widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/number-input",
   "sideEffects": false,
   "files": [
@@ -39,9 +39,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/pin-input/package.json
+++ b/packages/machines/pin-input/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/pin-input",
   "version": "0.1.15",
   "description": "Core logic for the pin-input widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/pin-input",
   "sideEffects": false,
   "files": [
@@ -38,9 +38,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/pin-input/package.json
+++ b/packages/machines/pin-input/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/pin-input",
   "sideEffects": false,

--- a/packages/machines/popover/package.json
+++ b/packages/machines/popover/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/popover",
   "version": "0.1.14",
   "description": "Core logic for the popover widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/popover",
   "sideEffects": false,
   "files": [
@@ -42,9 +42,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/popover/package.json
+++ b/packages/machines/popover/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/popover",
   "sideEffects": false,

--- a/packages/machines/pressable/package.json
+++ b/packages/machines/pressable/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/pressable",
   "version": "0.2.0",
   "description": "Core logic for the pressable widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Abraham Aremu <anubra266@gmail.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/pressable",
   "sideEffects": false,
   "files": [
@@ -30,9 +30,9 @@
     "@zag-js/dom-utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/pressable/package.json
+++ b/packages/machines/pressable/package.json
@@ -15,7 +15,7 @@
   "author": "Abraham Aremu <anubra266@gmail.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/pressable",
   "sideEffects": false,

--- a/packages/machines/radio/package.json
+++ b/packages/machines/radio/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/radio",
   "version": "0.0.3",
   "description": "Core logic for the radio widget implemented as a state machine",
@@ -14,18 +15,17 @@
   "author": "Abraham Aremu <anubra266@gmail.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/radio",
   "sideEffects": false,
   "files": [
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/radio/package.json
+++ b/packages/machines/radio/package.json
@@ -15,7 +15,7 @@
   "author": "Abraham Aremu <anubra266@gmail.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/radio",
   "sideEffects": false,

--- a/packages/machines/range-slider/package.json
+++ b/packages/machines/range-slider/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/range-slider",
   "version": "0.1.14",
   "description": "Core logic for the range-slider widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/range-slider",
   "sideEffects": false,
   "files": [
@@ -41,9 +41,9 @@
     "@zag-js/rect-utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/range-slider/package.json
+++ b/packages/machines/range-slider/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/range-slider",
   "sideEffects": false,

--- a/packages/machines/rating/package.json
+++ b/packages/machines/rating/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/rating",
   "version": "0.1.15",
   "description": "Core logic for the rating widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/rating",
   "sideEffects": false,
   "files": [
@@ -38,9 +38,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/rating/package.json
+++ b/packages/machines/rating/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/rating",
   "sideEffects": false,

--- a/packages/machines/slider/package.json
+++ b/packages/machines/slider/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/slider",
   "version": "0.1.14",
   "description": "Core logic for the slider widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/slider",
   "sideEffects": false,
   "files": [
@@ -39,9 +39,9 @@
     "@zag-js/number-utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/slider/package.json
+++ b/packages/machines/slider/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/slider",
   "sideEffects": false,

--- a/packages/machines/splitter/package.json
+++ b/packages/machines/splitter/package.json
@@ -16,7 +16,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/splitter",
   "sideEffects": false,

--- a/packages/machines/splitter/package.json
+++ b/packages/machines/splitter/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/splitter",
   "version": "0.1.13",
   "description": "Core logic for the splitter widget implemented as a state machine",
@@ -15,9 +16,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/splitter",
   "sideEffects": false,
   "files": [
@@ -38,9 +38,9 @@
     "@zag-js/number-utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/tabs/package.json
+++ b/packages/machines/tabs/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/tabs",
   "sideEffects": false,

--- a/packages/machines/tabs/package.json
+++ b/packages/machines/tabs/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/tabs",
   "version": "0.1.13",
   "description": "Core logic for the tabs widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/tabs",
   "sideEffects": false,
   "files": [
@@ -37,9 +37,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/tags-input/package.json
+++ b/packages/machines/tags-input/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/tags-input",
   "version": "0.2.7",
   "description": "Core logic for the tags-input widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/tags-input",
   "sideEffects": false,
   "files": [
@@ -41,9 +41,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/tags-input/package.json
+++ b/packages/machines/tags-input/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/tags-input",
   "sideEffects": false,

--- a/packages/machines/toast/package.json
+++ b/packages/machines/toast/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/toast",
   "version": "0.1.14",
   "description": "Core logic for the toast widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/toast",
   "sideEffects": false,
   "files": [
@@ -37,9 +37,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/toast/package.json
+++ b/packages/machines/toast/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/toast",
   "sideEffects": false,

--- a/packages/machines/toggle/package.json
+++ b/packages/machines/toggle/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/toggle",
   "sideEffects": false,

--- a/packages/machines/toggle/package.json
+++ b/packages/machines/toggle/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/toggle",
   "version": "0.1.13",
   "description": "Core logic for the toggle widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/toggle",
   "sideEffects": false,
   "files": [
@@ -36,9 +36,9 @@
     "@zag-js/dom-utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/machines/tooltip/package.json
+++ b/packages/machines/tooltip/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/tooltip",
   "sideEffects": false,

--- a/packages/machines/tooltip/package.json
+++ b/packages/machines/tooltip/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/tooltip",
   "version": "0.1.14",
   "description": "Core logic for the tooltip widget implemented as a state machine",
@@ -14,9 +15,8 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/tooltip",
   "sideEffects": false,
   "files": [
@@ -38,9 +38,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/store",
   "version": "0.1.2",
   "description": "The reactive store package for zag machines",
@@ -11,8 +12,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/store",
   "sideEffects": false,
@@ -20,9 +20,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -12,7 +12,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/store",
   "sideEffects": false,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/types",
   "version": "0.2.5",
   "keywords": [
@@ -9,8 +10,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/types",
   "sideEffects": false,
@@ -27,9 +27,9 @@
     "csstype": "3.1.0"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,7 +10,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/types",
   "sideEffects": false,

--- a/packages/utilities/aria-hidden/package.json
+++ b/packages/utilities/aria-hidden/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/aria-hidden",
   "version": "0.1.2",
   "description": "Hide targets from screen readers",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/aria-hidden",
   "sideEffects": false,
@@ -19,9 +19,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/utilities/aria-hidden/package.json
+++ b/packages/utilities/aria-hidden/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/aria-hidden",
   "sideEffects": false,

--- a/packages/utilities/auto-resize/package.json
+++ b/packages/utilities/auto-resize/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/auto-resize",
   "sideEffects": false,

--- a/packages/utilities/auto-resize/package.json
+++ b/packages/utilities/auto-resize/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/auto-resize",
   "version": "0.1.2",
   "description": "Autoresize utilities for the web",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/auto-resize",
   "sideEffects": false,
@@ -19,9 +19,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/utilities/core/package.json
+++ b/packages/utilities/core/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/utils",
   "version": "0.1.4",
   "description": "",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/core",
   "sideEffects": false,
@@ -25,9 +25,9 @@
     "url": "https://github.com/chakra-ui/zag/issues"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/utilities/core/package.json
+++ b/packages/utilities/core/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/core",
   "sideEffects": false,

--- a/packages/utilities/dismissable/package.json
+++ b/packages/utilities/dismissable/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/dismissable",
   "version": "0.1.4",
   "description": "Dismissable layer utilities for the DOM",
@@ -14,8 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/interact-outside",
   "sideEffects": false,
@@ -23,9 +23,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/utilities/dismissable/package.json
+++ b/packages/utilities/dismissable/package.json
@@ -15,7 +15,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/interact-outside",
   "sideEffects": false,

--- a/packages/utilities/dom/package.json
+++ b/packages/utilities/dom/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/dom-utils",
   "version": "0.1.11",
   "description": "",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/dom",
   "sideEffects": false,
@@ -31,9 +31,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/utilities/dom/package.json
+++ b/packages/utilities/dom/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/dom",
   "sideEffects": false,

--- a/packages/utilities/element-rect/package.json
+++ b/packages/utilities/element-rect/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/element-rect",
   "sideEffects": false,

--- a/packages/utilities/element-rect/package.json
+++ b/packages/utilities/element-rect/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/element-rect",
   "version": "0.1.1",
   "description": "observe element&#x27;s rect over time",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/element-rect",
   "sideEffects": false,
@@ -19,9 +19,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/utilities/element-size/package.json
+++ b/packages/utilities/element-size/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/element-size",
   "sideEffects": false,

--- a/packages/utilities/element-size/package.json
+++ b/packages/utilities/element-size/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/element-size",
   "version": "0.2.1",
   "description": "Observer the size of an element over time",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/element-size",
   "sideEffects": false,
@@ -19,9 +19,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/utilities/focus-scope/package.json
+++ b/packages/utilities/focus-scope/package.json
@@ -14,7 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/focus-scope",
   "sideEffects": false,

--- a/packages/utilities/focus-scope/package.json
+++ b/packages/utilities/focus-scope/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/focus-scope",
   "version": "0.0.3",
   "description": "Manage and trap focus within an element",
@@ -13,8 +14,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/focus-scope",
   "sideEffects": false,
@@ -22,9 +22,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/utilities/focus-visible/package.json
+++ b/packages/utilities/focus-visible/package.json
@@ -12,7 +12,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/focus-visible",
   "sideEffects": false,

--- a/packages/utilities/focus-visible/package.json
+++ b/packages/utilities/focus-visible/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/focus-visible",
   "version": "0.1.4",
   "description": "Focus visible polyfill utility based on WICG",
@@ -11,8 +12,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/focus-visible",
   "sideEffects": false,
@@ -20,9 +20,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/utilities/form-utils/package.json
+++ b/packages/utilities/form-utils/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/form-utils",
   "sideEffects": false,

--- a/packages/utilities/form-utils/package.json
+++ b/packages/utilities/form-utils/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/form-utils",
   "version": "0.1.1",
   "description": "",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/form-utils",
   "sideEffects": false,
@@ -22,9 +22,9 @@
     "@zag-js/dom-utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/utilities/hover-intent/package.json
+++ b/packages/utilities/hover-intent/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/hover-intent",
   "sideEffects": false,

--- a/packages/utilities/hover-intent/package.json
+++ b/packages/utilities/hover-intent/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/hover-intent",
   "version": "0.0.3",
   "description": "Track interactions when user intends to hover an element",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/hover-intent",
   "sideEffects": false,
@@ -19,9 +19,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/utilities/interact-outside/package.json
+++ b/packages/utilities/interact-outside/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/interact-outside",
   "version": "0.1.4",
   "description": "Track interations or focus outside an element",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/interact-outside",
   "sideEffects": false,
@@ -19,9 +19,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/utilities/interact-outside/package.json
+++ b/packages/utilities/interact-outside/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/interact-outside",
   "sideEffects": false,

--- a/packages/utilities/live-region/package.json
+++ b/packages/utilities/live-region/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/live-region",
   "sideEffects": false,

--- a/packages/utilities/live-region/package.json
+++ b/packages/utilities/live-region/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/live-region",
   "version": "0.1.2",
   "description": "Implementing live region for screen readers",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/live-region",
   "sideEffects": false,
@@ -19,9 +19,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/packages/utilities/number/package.json
+++ b/packages/utilities/number/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/number",
   "sideEffects": false,

--- a/packages/utilities/number/package.json
+++ b/packages/utilities/number/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/number-utils",
   "version": "0.1.4",
   "description": "",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/number",
   "sideEffects": false,
@@ -25,9 +25,9 @@
     "url": "https://github.com/chakra-ui/zag/issues"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/utilities/popper/package.json
+++ b/packages/utilities/popper/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/popper",
   "sideEffects": false,

--- a/packages/utilities/popper/package.json
+++ b/packages/utilities/popper/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/popper",
   "version": "0.1.11",
   "description": "Dynamic positioning logic for ui machines",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/popper",
   "sideEffects": false,
@@ -32,9 +32,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/utilities/rect/package.json
+++ b/packages/utilities/rect/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/rect-utils",
   "version": "0.1.6",
   "description": "",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/rect",
   "sideEffects": false,
@@ -29,9 +29,9 @@
     "@zag-js/utils": "workspace:*"
   },
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/packages/utilities/rect/package.json
+++ b/packages/utilities/rect/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/rect",
   "sideEffects": false,

--- a/packages/utilities/remove-scroll/package.json
+++ b/packages/utilities/remove-scroll/package.json
@@ -11,7 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/remove-scroll",
   "sideEffects": false,

--- a/packages/utilities/remove-scroll/package.json
+++ b/packages/utilities/remove-scroll/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/remove-scroll",
   "version": "0.1.4",
   "description": "JavaScript utility to remove scroll on body",
@@ -10,8 +11,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/zag#readme",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/remove-scroll",
   "sideEffects": false,
@@ -19,9 +19,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir tests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand -u",

--- a/plop/machine/package.json.hbs
+++ b/plop/machine/package.json.hbs
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@zag-js/{{machine}}",
   "version": "0.0.0",
   "description": "Core logic for the {{machine}} widget implemented as a state machine",
@@ -8,14 +9,13 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
   "repository": "https://github.com/chakra-ui/zag/tree/main/packages/{{machine}}",
   "sideEffects": false,
   "files": ["dist/**/*"],
   "scripts": {
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build-fast": "tsup src/index.ts --format=esm",
     "start": "pnpm build --watch",
-    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build": "tsup src/index.ts --format=esm --dts",
     "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "test-ci": "pnpm test --ci --runInBand",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,6 @@ importers:
       '@octokit/rest': 19.0.4
       '@playwright/test': 1.25.2
       '@swc-node/jest': 1.5.2
-      '@swc-node/register': 1.5.1
       '@types/jest': 28.1.8
       '@types/signale': 1.4.4
       '@typescript-eslint/eslint-plugin': 5.30.6
@@ -40,6 +39,7 @@ importers:
       signale: 1.4.0
       start-server-and-test: 1.14.0
       tsup: 6.2.3
+      tsx: 3.9.0
       turbo: 1.4.3
       typescript: 4.8.3
     dependencies:
@@ -55,7 +55,6 @@ importers:
       '@octokit/rest': 19.0.4
       '@playwright/test': 1.25.2
       '@swc-node/jest': 1.5.2_typescript@4.8.3
-      '@swc-node/register': 1.5.1_typescript@4.8.3
       '@types/jest': 28.1.8
       '@types/signale': 1.4.4
       '@typescript-eslint/eslint-plugin': 5.30.6_b1a262c5ac0f7b887de19127efcfe684
@@ -79,6 +78,7 @@ importers:
       signale: 1.4.0
       start-server-and-test: 1.14.0
       tsup: 6.2.3_typescript@4.8.3
+      tsx: 3.9.0
       turbo: 1.4.3
       typescript: 4.8.3
 
@@ -1953,6 +1953,38 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: false
 
+  /@esbuild-kit/cjs-loader/2.3.3:
+    resolution: {integrity: sha512-Rt4O1mXlPEDVxvjsHLgbtHVdUXYK9C1/6ThpQnt7FaXIjUOsI6qhHYMgALhNnlIMZffag44lXd6Dqgx3xALbpQ==}
+    dependencies:
+      '@esbuild-kit/core-utils': 2.3.1
+      get-tsconfig: 4.2.0
+    dev: false
+
+  /@esbuild-kit/core-utils/2.3.1:
+    resolution: {integrity: sha512-y2ThiUw/AkKCS7mIBF/EGce79aHIomOVFAIFmF5Z0DRZTNXVg9uFDXBkhAu7PAj64Po1ELfKJN9R7/zs3PIEAg==}
+    dependencies:
+      esbuild: 0.15.8
+      source-map-support: 0.5.21
+    dev: false
+
+  /@esbuild-kit/esm-loader/2.4.2:
+    resolution: {integrity: sha512-N9dPKAj8WOx6djVnStgILWXip4fjDcBk9L7azO0/uQDpu8Ee0eaL78mkN4Acid9BzvNAKWwdYXFJZnsVahNEew==}
+    dependencies:
+      '@esbuild-kit/core-utils': 2.3.1
+      get-tsconfig: 4.2.0
+    dev: false
+
+  /@esbuild/android-arm/0.15.8:
+    resolution: {integrity: sha512-CyEWALmn+no/lbgbAJsbuuhT8s2J19EJGHkeyAwjbFJMrj80KJ9zuYsoAvidPTU7BgBf87r/sgae8Tw0dbOc4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      esbuild-wasm: 0.15.8
+    dev: false
+    optional: true
+
   /@esbuild/linux-loong64/0.14.54:
     resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
     engines: {node: '>=12'}
@@ -1963,6 +1995,15 @@ packages:
 
   /@esbuild/linux-loong64/0.15.5:
     resolution: {integrity: sha512-UHkDFCfSGTuXq08oQltXxSZmH1TXyWsL+4QhZDWvvLl6mEJQqk3u7/wq1LjhrrAXYIllaTtRSzUXl4Olkf2J8A==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-loong64/0.15.8:
+    resolution: {integrity: sha512-pE5RQsOTSERCtfZdfCT25wzo7dfhOSlhAXcsZmuvRYhendOv7djcdvtINdnDp2DAjP17WXlBB4nBO6sHLczmsg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -4880,6 +4921,17 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-android-64/0.15.8:
+    resolution: {integrity: sha512-bVh8FIKOolF7/d4AMzt7xHlL0Ljr+mYKSHI39TJWDkybVWHdn6+4ODL3xZGHOxPpdRpitemXA1WwMKYBsw8dGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      esbuild-wasm: 0.15.8
+    dev: false
+    optional: true
+
   /esbuild-android-arm64/0.14.54:
     resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
     engines: {node: '>=12'}
@@ -4890,6 +4942,15 @@ packages:
 
   /esbuild-android-arm64/0.15.5:
     resolution: {integrity: sha512-YyEkaQl08ze3cBzI/4Cm1S+rVh8HMOpCdq8B78JLbNFHhzi4NixVN93xDrHZLztlocEYqi45rHHCgA8kZFidFg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-android-arm64/0.15.8:
+    resolution: {integrity: sha512-ReAMDAHuo0H1h9LxRabI6gwYPn8k6WiUeyxuMvx17yTrJO+SCnIfNc/TSPFvDwtK9MiyiKG/2dBYHouT/M0BXQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -4914,6 +4975,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-darwin-64/0.15.8:
+    resolution: {integrity: sha512-KaKcGfJ+yto7Fo5gAj3xwxHMd1fBIKatpCHK8znTJLVv+9+NN2/tIPBqA4w5rBwjX0UqXDeIE2v1xJP+nGEXgA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-darwin-arm64/0.14.54:
     resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
     engines: {node: '>=12'}
@@ -4924,6 +4994,15 @@ packages:
 
   /esbuild-darwin-arm64/0.15.5:
     resolution: {integrity: sha512-WIfQkocGtFrz7vCu44ypY5YmiFXpsxvz2xqwe688jFfSVCnUsCn2qkEVDo7gT8EpsLOz1J/OmqjExePL1dr1Kg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-darwin-arm64/0.15.8:
+    resolution: {integrity: sha512-8tjEaBgAKnXCkP7bhEJmEqdG9HEV6oLkF36BrMzpfW2rgaw0c48Zrxe+9RlfeGvs6gDF4w+agXyTjikzsS3izw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -4948,6 +5027,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-freebsd-64/0.15.8:
+    resolution: {integrity: sha512-jaxcsGHYzn2L0/lffON2WfH4Nc+d/EwozVTP5K2v016zxMb5UQMhLoJzvLgBqHT1SG0B/mO+a+THnJCMVg15zw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-freebsd-arm64/0.14.54:
     resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
     engines: {node: '>=12'}
@@ -4958,6 +5046,15 @@ packages:
 
   /esbuild-freebsd-arm64/0.15.5:
     resolution: {integrity: sha512-2JQQ5Qs9J0440F/n/aUBNvY6lTo4XP/4lt1TwDfHuo0DY3w5++anw+jTjfouLzbJmFFiwmX7SmUhMnysocx96w==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-freebsd-arm64/0.15.8:
+    resolution: {integrity: sha512-2xp2UlljMvX8HExtcg7VHaeQk8OBU0CSl1j18B5CcZmSDkLF9p3utuMXIopG3a08fr9Hv+Dz6+seSXUow/G51w==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -4982,6 +5079,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-linux-32/0.15.8:
+    resolution: {integrity: sha512-9u1E54BRz1FQMl86iaHK146+4ID2KYNxL3trLZT4QLLx3M7Q9n4lGG3lrzqUatGR2cKy8c33b0iaCzsItZWkFg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-64/0.14.54:
     resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
     engines: {node: '>=12'}
@@ -4992,6 +5098,15 @@ packages:
 
   /esbuild-linux-64/0.15.5:
     resolution: {integrity: sha512-ne0GFdNLsm4veXbTnYAWjbx3shpNKZJUd6XpNbKNUZaNllDZfYQt0/zRqOg0sc7O8GQ+PjSMv9IpIEULXVTVmg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-64/0.15.8:
+    resolution: {integrity: sha512-4HxrsN9eUzJXdVGMTYA5Xler82FuZUu21bXKN42zcLHHNKCAMPUzD62I+GwDhsdgUBAUj0tRXDdsQHgaP6v0HA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -5016,6 +5131,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-linux-arm/0.15.8:
+    resolution: {integrity: sha512-7DVBU9SFjX4+vBwt8tHsUCbE6Vvl6y6FQWHAgyw1lybC5gULqn/WnjHYHN2/LJaZRsDBvxWT4msEgwLGq1Wd3Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-arm64/0.14.54:
     resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
     engines: {node: '>=12'}
@@ -5026,6 +5150,15 @@ packages:
 
   /esbuild-linux-arm64/0.15.5:
     resolution: {integrity: sha512-7EgFyP2zjO065XTfdCxiXVEk+f83RQ1JsryN1X/VSX2li9rnHAt2swRbpoz5Vlrl6qjHrCmq5b6yxD13z6RheA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-arm64/0.15.8:
+    resolution: {integrity: sha512-1OCm7Aq0tEJT70PbxmHSGYDLYP8DKH8r4Nk7/XbVzWaduo9beCjGBB+tGZIHK6DdTQ3h00/4Tb/70YMH/bOtKg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -5050,6 +5183,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-linux-mips64le/0.15.8:
+    resolution: {integrity: sha512-yeFoNPVFPEzZvFYBfUQNG2TjGRaCyV1E27OcOg4LOtnGrxb2wA+mkW3luckyv1CEyd00mpAg7UdHx8nlx3ghgA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-ppc64le/0.14.54:
     resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
     engines: {node: '>=12'}
@@ -5060,6 +5202,15 @@ packages:
 
   /esbuild-linux-ppc64le/0.15.5:
     resolution: {integrity: sha512-QdRHGeZ2ykl5P0KRmfGBZIHmqcwIsUKWmmpZTOq573jRWwmpfRmS7xOhmDHBj9pxv+6qRMH8tLr2fe+ZKQvCYw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-ppc64le/0.15.8:
+    resolution: {integrity: sha512-CEyMMUUNabXibw8OSNmBXhOIGhnjNVl5Lpseiuf00iKN0V47oqDrbo4dsHz1wH62m49AR8iG8wpDlTqfYgKbtg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -5084,6 +5235,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-linux-riscv64/0.15.8:
+    resolution: {integrity: sha512-OCGSOaspMUjexSCU8ZiA0UnV/NiRU+s2vIfEcAQWQ6u32R+2luyfh/4ZaY6jFbylJE07Esc/yRvb9Q5fXuClXA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-s390x/0.14.54:
     resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
     engines: {node: '>=12'}
@@ -5094,6 +5254,15 @@ packages:
 
   /esbuild-linux-s390x/0.15.5:
     resolution: {integrity: sha512-J2ngOB4cNzmqLHh6TYMM/ips8aoZIuzxJnDdWutBw5482jGXiOzsPoEF4j2WJ2mGnm7FBCO4StGcwzOgic70JQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-s390x/0.15.8:
+    resolution: {integrity: sha512-RHdpdfxRTSrZXZJlFSLazFU4YwXLB5Rgf6Zr5rffqSsO4y9JybgtKO38bFwxZNlDXliYISXN/YROKrG9s7mZQA==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -5118,6 +5287,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-netbsd-64/0.15.8:
+    resolution: {integrity: sha512-VolFFRatBH09T5QMWhiohAWCOien1R1Uz9K0BRVVTBgBaVBt7eArsXTKxVhUgRf2vwu2c2SXkuP0r7HLG0eozw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-openbsd-64/0.14.54:
     resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
     engines: {node: '>=12'}
@@ -5128,6 +5306,15 @@ packages:
 
   /esbuild-openbsd-64/0.15.5:
     resolution: {integrity: sha512-2mMFfkLk3oPWfopA9Plj4hyhqHNuGyp5KQyTT9Rc8hFd8wAn5ZrbJg+gNcLMo2yzf8Uiu0RT6G9B15YN9WQyMA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-openbsd-64/0.15.8:
+    resolution: {integrity: sha512-HTAPlg+n4kUeE/isQxlCfsOz0xJGNoT5LJ9oYZWFKABfVf4Ycu7Zlf5ITgOnrdheTkz8JeL/gISIOCFAoOXrSA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -5152,6 +5339,23 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-sunos-64/0.15.8:
+    resolution: {integrity: sha512-qMP/jR/FzcIOwKj+W+Lb+8Cfr8GZHbHUJxAPi7DUhNZMQ/6y7sOgRzlOSpRrbbUntrRZh0MqOyDhJ3Gpo6L1QA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-wasm/0.15.8:
+    resolution: {integrity: sha512-Y7uCl5RNO4URjlemjdx++ukVHEMt5s5AfMWYUnMiK4Sry+pPCvQIctzXq6r6FKCyGKjX6/NGMCqR2OX6aLxj0w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-windows-32/0.14.54:
     resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
     engines: {node: '>=12'}
@@ -5162,6 +5366,15 @@ packages:
 
   /esbuild-windows-32/0.15.5:
     resolution: {integrity: sha512-e+duNED9UBop7Vnlap6XKedA/53lIi12xv2ebeNS4gFmu7aKyTrok7DPIZyU5w/ftHD4MUDs5PJUkQPP9xJRzg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-windows-32/0.15.8:
+    resolution: {integrity: sha512-RKR1QHh4iWzjUhkP8Yqi75PPz/KS+b8zw3wUrzw6oAkj+iU5Qtyj61ZDaSG3Qf2vc6hTIUiPqVTqBH0NpXFNwg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -5186,6 +5399,15 @@ packages:
     dev: false
     optional: true
 
+  /esbuild-windows-64/0.15.8:
+    resolution: {integrity: sha512-ag9ptYrsizgsR+PQE8QKeMqnosLvAMonQREpLw4evA4FFgOBMLEat/dY/9txbpozTw9eEOYyD3a4cE9yTu20FA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-windows-arm64/0.14.54:
     resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
     engines: {node: '>=12'}
@@ -5196,6 +5418,15 @@ packages:
 
   /esbuild-windows-arm64/0.15.5:
     resolution: {integrity: sha512-Yz8w/D8CUPYstvVQujByu6mlf48lKmXkq6bkeSZZxTA626efQOJb26aDGLzmFWx6eg/FwrXgt6SZs9V8Pwy/aA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-windows-arm64/0.15.8:
+    resolution: {integrity: sha512-dbpAb0VyPaUs9mgw65KRfQ9rqiWCHpNzrJusoPu+LpEoswosjt/tFxN7cd2l68AT4qWdBkzAjDLRon7uqMeWcg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -5258,6 +5489,36 @@ packages:
       esbuild-windows-32: 0.15.5
       esbuild-windows-64: 0.15.5
       esbuild-windows-arm64: 0.15.5
+    dev: false
+
+  /esbuild/0.15.8:
+    resolution: {integrity: sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.15.8
+      '@esbuild/linux-loong64': 0.15.8
+      esbuild-android-64: 0.15.8
+      esbuild-android-arm64: 0.15.8
+      esbuild-darwin-64: 0.15.8
+      esbuild-darwin-arm64: 0.15.8
+      esbuild-freebsd-64: 0.15.8
+      esbuild-freebsd-arm64: 0.15.8
+      esbuild-linux-32: 0.15.8
+      esbuild-linux-64: 0.15.8
+      esbuild-linux-arm: 0.15.8
+      esbuild-linux-arm64: 0.15.8
+      esbuild-linux-mips64le: 0.15.8
+      esbuild-linux-ppc64le: 0.15.8
+      esbuild-linux-riscv64: 0.15.8
+      esbuild-linux-s390x: 0.15.8
+      esbuild-netbsd-64: 0.15.8
+      esbuild-openbsd-64: 0.15.8
+      esbuild-sunos-64: 0.15.8
+      esbuild-windows-32: 0.15.8
+      esbuild-windows-64: 0.15.8
+      esbuild-windows-arm64: 0.15.8
     dev: false
 
   /escalade/3.1.1:
@@ -5970,6 +6231,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.2
+
+  /get-tsconfig/4.2.0:
+    resolution: {integrity: sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==}
+    dev: false
 
   /git-raw-commits/2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
@@ -9169,6 +9434,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.8.3
+    dev: false
+
+  /tsx/3.9.0:
+    resolution: {integrity: sha512-ofxsE+qjqCYYq4UBt5khglvb+ESgxef1YpuNcdQI92kvcAT2tZVrnSK3g4bRXTUhLmKHcC5q8vIZA47os/stng==}
+    hasBin: true
+    dependencies:
+      '@esbuild-kit/cjs-loader': 2.3.3
+      '@esbuild-kit/core-utils': 2.3.1
+      '@esbuild-kit/esm-loader': 2.4.2
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: false
 
   /tty-table/4.1.6:

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -1,0 +1,29 @@
+import findPkgs from "find-packages"
+import { writeFile } from "fs/promises"
+import { join } from "path"
+
+async function main() {
+  const pkgs = await findPkgs(process.cwd(), {
+    includeRoot: false,
+    patterns: ["packages/**/*"],
+  })
+
+  Promise.all(
+    pkgs.map((pkg) => {
+      const { dir, manifest } = pkg
+
+      delete manifest.module
+      delete manifest.main
+
+      const data = {
+        type: "module",
+        main: "dist/index.mjs",
+        ...manifest,
+      }
+
+      return writeFile(join(dir, "package.json"), JSON.stringify(data, null, 2))
+    }),
+  )
+}
+
+main()


### PR DESCRIPTION
## 📝 Description

This PR updates the repo to use modern package format and `type: module` in the `package.json`

## ⛳️ Current behavior (updates)

We currently ship both CJS and ESM which isn't really needed anymore

## 🚀 New behavior

We ship only ESM

## 💣 Is this a breaking change (Yes/No):

Potentially depending on how the user consumes Zag.

## 📝 Additional Information
