### PR TITLE
Allow disabling tooltip by adding disabled to context

### DIFF
--- a/.changeset/smooth-zoos-march.md
+++ b/.changeset/smooth-zoos-march.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/tooltip": patch
+---
+
+Add `disabled` to context to allow disabling tooltips

--- a/packages/machines/tooltip/src/tooltip.connect.ts
+++ b/packages/machines/tooltip/src/tooltip.connect.ts
@@ -14,6 +14,8 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
   const triggerId = dom.getTriggerId(state.context)
   const contentId = dom.getContentId(state.context)
 
+  const isDisabled = state.context.disabled
+
   const popperStyles = getPlacementStyles({
     measured: !!state.context.isPlacementComplete,
     placement: state.context.currentPlacement,
@@ -51,17 +53,21 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         }
       },
       onPointerDown() {
+        if (isDisabled) return
         if (id === store.id) {
           send("POINTER_DOWN")
         }
       },
       onPointerMove() {
+        if (isDisabled) return
         send("POINTER_ENTER")
       },
       onPointerLeave() {
+        if (isDisabled) return
         send("POINTER_LEAVE")
       },
       onPointerCancel() {
+        if (isDisabled) return
         send("POINTER_LEAVE")
       },
     }),

--- a/packages/machines/tooltip/src/tooltip.types.ts
+++ b/packages/machines/tooltip/src/tooltip.types.ts
@@ -54,6 +54,10 @@ type PublicContext = CommonProperties & {
    * The user provided options used to position the popover content
    */
   positioning: PositioningOptions
+  /**
+   * Whether the tooltip is disabled
+   */
+  disabled?: boolean
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">


### PR DESCRIPTION
Add `disabled` to tooltip context to allow disabling tooltips