### PR TITLE
fix: ensure code is transpiled with es2019 target

### DIFF
--- a/.changeset/eleven-shirts-speak.md
+++ b/.changeset/eleven-shirts-speak.md
@@ -1,0 +1,50 @@
+---
+"@zag-js/core": minor
+"@zag-js/react": minor
+"@zag-js/solid": minor
+"@zag-js/svelte": minor
+"@zag-js/vue": minor
+"@zag-js/accordion": minor
+"@zag-js/checkbox": minor
+"@zag-js/combobox": minor
+"@zag-js/dialog": minor
+"@zag-js/editable": minor
+"@zag-js/hover-card": minor
+"@zag-js/menu": minor
+"@zag-js/number-input": minor
+"@zag-js/pagination": minor
+"@zag-js/pin-input": minor
+"@zag-js/popover": minor
+"@zag-js/pressable": minor
+"@zag-js/radio": minor
+"@zag-js/range-slider": minor
+"@zag-js/rating": minor
+"@zag-js/slider": minor
+"@zag-js/splitter": minor
+"@zag-js/tabs": minor
+"@zag-js/tags-input": minor
+"@zag-js/toast": minor
+"@zag-js/toggle": minor
+"@zag-js/tooltip": minor
+"@zag-js/store": minor
+"@zag-js/types": minor
+"@zag-js/aria-hidden": minor
+"@zag-js/auto-resize": minor
+"@zag-js/utils": minor
+"@zag-js/dismissable": minor
+"@zag-js/dom-utils": minor
+"@zag-js/dom-query": minor
+"@zag-js/element-rect": minor
+"@zag-js/element-size": minor
+"@zag-js/focus-scope": minor
+"@zag-js/focus-visible": minor
+"@zag-js/form-utils": minor
+"@zag-js/interact-outside": minor
+"@zag-js/live-region": minor
+"@zag-js/number-utils": minor
+"@zag-js/popper": minor
+"@zag-js/rect-utils": minor
+"@zag-js/remove-scroll": minor
+---
+
+Ensures code is transpiled with `es2019` target for environments that don't support `es2020` and up, i.e. Cypress.

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  name: "tsup",
+  target: "es2019",
+})


### PR DESCRIPTION
## 📝 Description

Currently Cypress doesn't support optional chaining and the nullish coalescing operator, this ensures the packages are transpiled with the `es2019` target.

## ⛳️ Current behavior (updates)

Currently, code is transpiled with `??`
```javascript
var runIfFn = (v, ...a) => {
  const res = typeof v === "function" ? v(...a) : v;
  return res ?? void 0;
};
```

## 🚀 New behavior

This fix will transpile the above like:
```javascript
var runIfFn = (v, ...a) => {
  const res = typeof v === "function" ? v(...a) : v;
  return res != null ? res : void 0;
};
```

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
