### PR TITLE
fix: context update infinite loop

### DIFF
--- a/.changeset/large-owls-kick.md
+++ b/.changeset/large-owls-kick.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/react": patch
+---
+
+Fix issue where context update causes infinite loop.

--- a/examples/next-ts/hooks/use-controls.tsx
+++ b/examples/next-ts/hooks/use-controls.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-onchange */
-import React, { useState } from "react"
 import { ControlRecord, ControlValue } from "@zag-js/shared"
+import { useState } from "react"
 
 function getDefaultValues<T extends ControlRecord>(obj: T) {
   return Object.keys(obj).reduce(
@@ -17,6 +17,10 @@ export function useControls<T extends ControlRecord>(config: T) {
 
   return {
     context: state,
+    setContext(value: any) {
+      const pojo = JSON.parse(JSON.stringify(value))
+      setState(pojo)
+    },
     ui: () => (
       <div className="controls-container">
         {Object.keys(config).map((key) => {

--- a/examples/next-ts/hooks/use-controls.tsx
+++ b/examples/next-ts/hooks/use-controls.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/no-onchange */
 import { ControlRecord, ControlValue } from "@zag-js/shared"
+import { split } from "@zag-js/utils"
 import { useState } from "react"
 
 function getDefaultValues<T extends ControlRecord>(obj: T) {
@@ -19,7 +20,8 @@ export function useControls<T extends ControlRecord>(config: T) {
     context: state,
     setContext(value: any) {
       const pojo = JSON.parse(JSON.stringify(value))
-      setState(pojo)
+      const [filtered] = split(pojo, Object.keys(config)) as any
+      setState(filtered)
     },
     ui: () => (
       <div className="controls-container">

--- a/examples/next-ts/pages/accordion.tsx
+++ b/examples/next-ts/pages/accordion.tsx
@@ -1,5 +1,5 @@
 import * as accordion from "@zag-js/accordion"
-import { useMachine, normalizeProps } from "@zag-js/react"
+import { normalizeProps, useMachine } from "@zag-js/react"
 import { accordionControls, accordionData } from "@zag-js/shared"
 import { useId } from "react"
 import { StateVisualizer } from "../components/state-visualizer"
@@ -15,6 +15,9 @@ export default function Page() {
     }),
     {
       context: controls.context,
+      onChange: (state) => {
+        controls.setContext(state.context)
+      },
     },
   )
 

--- a/examples/next-ts/pages/rating.tsx
+++ b/examples/next-ts/pages/rating.tsx
@@ -45,6 +45,9 @@ export default function Page() {
     }),
     {
       context: controls.context,
+      onChange: (state) => {
+        controls.setContext(state.context)
+      },
     },
   )
 

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -1,5 +1,18 @@
 import { ref, snapshot, subscribe } from "@zag-js/store"
-import { cast, clear, invariant, isArray, isDev, isObject, isString, noop, runIfFn, uuid, warn } from "@zag-js/utils"
+import {
+  cast,
+  clear,
+  compact,
+  invariant,
+  isArray,
+  isDev,
+  isObject,
+  isString,
+  noop,
+  runIfFn,
+  uuid,
+  warn,
+} from "@zag-js/utils"
 import { klona } from "klona/json"
 import { createProxy } from "./create-proxy"
 import { determineDelayFn } from "./delay-utils"
@@ -327,18 +340,16 @@ export class Machine<
    */
   public setContext = (context: Partial<Writable<TContext>> | undefined) => {
     if (!context) return
-    for (const key in context) {
-      this.state.context[<keyof TContext>key] = context[key]!
-    }
+    Object.assign(this.state.context, compact(context))
   }
 
   public withContext = (context: Partial<Writable<TContext>>) => {
-    const newContext = { ...this.config.context, ...context } as TContext
+    const newContext = { ...this.config.context, ...compact(context) } as TContext
     return new Machine({ ...this.config, context: newContext }, this.options)
   }
 
   public setActions = (actions: Partial<S.MachineOptions<TContext, TState, TEvent>>["actions"]) => {
-    this.actionMap = { ...this.actionMap, ...actions }
+    this.actionMap = { ...this.actionMap, ...compact(actions) }
   }
 
   private getStateNode = (state: TState["value"] | null) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -395,6 +395,7 @@ export declare namespace StateMachine {
     actions?: ActionMap<TContext, TState, TEvent>
     state?: StateInit<TContext, TState>
     context?: UserContext<TContext>
+    onChange?: StateListener<TContext, TState, TEvent>
   }
 
   export type Self<TContext extends Dict, TState extends StateSchema, TEvent extends EventObject> = {

--- a/packages/frameworks/react/src/use-machine.ts
+++ b/packages/frameworks/react/src/use-machine.ts
@@ -34,13 +34,8 @@ export function useService<
     }
   }, [])
 
-  useSafeLayoutEffect(() => {
-    service.setActions(actions)
-  }, [actions])
-
-  useSafeLayoutEffect(() => {
-    service.setContext(context)
-  }, [context])
+  service.setActions(actions)
+  service.setContext(context)
 
   return service
 }

--- a/packages/frameworks/react/src/use-machine.ts
+++ b/packages/frameworks/react/src/use-machine.ts
@@ -15,7 +15,7 @@ export function useService<
   TState extends S.StateSchema,
   TEvent extends S.EventObject = S.AnyEventObject,
 >(machine: MachineSrc<TContext, TState, TEvent>, options?: S.HookOptions<TContext, TState, TEvent>) {
-  const { actions, state: hydratedState, context } = options ?? {}
+  const { actions, state: hydratedState, context, onChange } = options ?? {}
 
   const service = useConstant(() => {
     const _machine = typeof machine === "function" ? machine() : machine
@@ -27,6 +27,10 @@ export function useService<
 
     if (service.state.can("SETUP")) {
       service.send("SETUP")
+    }
+
+    if (onChange) {
+      service.subscribe(onChange)
     }
 
     return () => {

--- a/packages/frameworks/solid/src/use-machine.ts
+++ b/packages/frameworks/solid/src/use-machine.ts
@@ -15,7 +15,7 @@ export function useService<
   TState extends S.StateSchema,
   TEvent extends S.EventObject = S.AnyEventObject,
 >(machine: MachineSrc<TContext, TState, TEvent>, options?: HookOptions<TContext, TState, TEvent>) {
-  const { actions, state: hydratedState, context } = options ?? {}
+  const { actions, state: hydratedState, context, onChange } = options ?? {}
 
   const service = (() => {
     const _machine = typeof machine === "function" ? machine() : machine
@@ -27,6 +27,10 @@ export function useService<
 
     if (service.state.can("SETUP")) {
       service.send("SETUP")
+    }
+
+    if (onChange) {
+      service.subscribe(onChange)
     }
 
     onCleanup(() => {

--- a/packages/utilities/core/src/index.ts
+++ b/packages/utilities/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./array"
 export * from "./functions"
 export * from "./guard"
+export * from "./object"
 export * from "./warning"

--- a/packages/utilities/core/src/object.ts
+++ b/packages/utilities/core/src/object.ts
@@ -10,3 +10,16 @@ export function compact<T>(value: T) {
   }
   return value
 }
+
+export function split<T, K extends keyof T>(value: T, keys: K[]): [Pick<T, K>, Omit<T, K>] {
+  const left = {} as any
+  const right = {} as any
+  for (const key in value) {
+    if (keys.includes(key as any)) {
+      left[key] = value[key]
+    } else {
+      right[key] = value[key]
+    }
+  }
+  return [left, right]
+}

--- a/packages/utilities/core/src/object.ts
+++ b/packages/utilities/core/src/object.ts
@@ -1,0 +1,12 @@
+import { isObject } from "./guard"
+
+export function compact<T>(value: T) {
+  for (const key in value) {
+    if (value[key] === undefined) {
+      delete value[key]
+    } else if (isObject(value[key])) {
+      compact(value[key])
+    }
+  }
+  return value
+}


### PR DESCRIPTION
## 📝 Description

This PR fixed a react-specific issue where a transient context update causes infinite loop when we pass an object type (function, object, array)

```jsx
// this will cause an Maximum stack exceeded error
useMachine(machine, { context: { value: [1, 2, 3] } })
```

## 🚀 New behavior

Works as expected.

## 💣 Is this a breaking change (Yes/No):

Maybe? Depending on how the user currently implements this. However, this feels like the right solution for the transient updates.

## 📝 Additional Information
