### PR TITLE
Filter undefined from context

### DIFF
--- a/.changeset/three-kings-matter.md
+++ b/.changeset/three-kings-matter.md
@@ -1,0 +1,27 @@
+---
+"@zag-js/react": patch
+"@zag-js/accordion": patch
+"@zag-js/checkbox": patch
+"@zag-js/combobox": patch
+"@zag-js/dialog": patch
+"@zag-js/editable": patch
+"@zag-js/hover-card": patch
+"@zag-js/menu": patch
+"@zag-js/number-input": patch
+"@zag-js/pagination": patch
+"@zag-js/pin-input": patch
+"@zag-js/popover": patch
+"@zag-js/pressable": patch
+"@zag-js/radio": patch
+"@zag-js/range-slider": patch
+"@zag-js/rating": patch
+"@zag-js/slider": patch
+"@zag-js/splitter": patch
+"@zag-js/tabs": patch
+"@zag-js/tags-input": patch
+"@zag-js/toast": patch
+"@zag-js/toggle": patch
+"@zag-js/tooltip": patch
+---
+
+Omit undefined values passed in machine's context

--- a/.changeset/three-kings-matter.md
+++ b/.changeset/three-kings-matter.md
@@ -1,5 +1,7 @@
 ---
 "@zag-js/react": patch
+"@zag-js/solid": patch
+"@zag-js/vue": patch
 "@zag-js/accordion": patch
 "@zag-js/checkbox": patch
 "@zag-js/combobox": patch

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "license": "MIT",
   "scripts": {
-    "build-fast": "turbo run build-fast --filter=./packages/**/*",
-    "build": "turbo run build --filter=./packages/**/*",
-    "start": "turbo run start --filter=./packages/**/*",
+    "packages": "pnpm --filter=./packages/** -r",
+    "build-fast": "pnpm packages -- build-fast",
+    "build": "pnpm packages -- build",
+    "start": "pnpm packages -- start",
     "prepare": "husky install",
     "sync-pkgs": "tsx scripts/sync-packages.ts",
     "clean-pkgs": "pnpm -r exec rm -rf dist .turbo .swc *.log",

--- a/packages/frameworks/react/package.json
+++ b/packages/frameworks/react/package.json
@@ -31,7 +31,8 @@
     "@zag-js/core": "workspace:*",
     "@zag-js/store": "workspace:*",
     "@zag-js/types": "workspace:*",
-    "proxy-compare": "2.3.0"
+    "proxy-compare": "2.3.0",
+    "use-deep-compare-effect": "^1.8.1"
   },
   "devDependencies": {
     "@types/react": "18.0.21",

--- a/packages/frameworks/react/package.json
+++ b/packages/frameworks/react/package.json
@@ -31,8 +31,7 @@
     "@zag-js/core": "workspace:*",
     "@zag-js/store": "workspace:*",
     "@zag-js/types": "workspace:*",
-    "proxy-compare": "2.3.0",
-    "use-deep-compare-effect": "^1.8.1"
+    "proxy-compare": "2.3.0"
   },
   "devDependencies": {
     "@types/react": "18.0.21",

--- a/packages/frameworks/react/package.json
+++ b/packages/frameworks/react/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/react": "18.0.21",
+    "@zag-js/utils": "workspace:*",
     "react": "18.2.0"
   },
   "peerDependencies": {

--- a/packages/frameworks/react/src/use-machine.ts
+++ b/packages/frameworks/react/src/use-machine.ts
@@ -1,4 +1,5 @@
 import type { MachineSrc, StateMachine as S } from "@zag-js/core"
+import { compact } from "@zag-js/utils"
 import { useEffect, useLayoutEffect, useRef } from "react"
 import { useSnapshot } from "./use-snapshot"
 
@@ -15,7 +16,9 @@ export function useService<
   TState extends S.StateSchema,
   TEvent extends S.EventObject = S.AnyEventObject,
 >(machine: MachineSrc<TContext, TState, TEvent>, options?: S.HookOptions<TContext, TState, TEvent>) {
-  const { actions, state: hydratedState, context } = options ?? {}
+  const { actions, state: hydratedState, context: _context } = options ?? {}
+
+  const context = _context ? compact(_context) : undefined
 
   const service = useConstant(() => {
     const _machine = typeof machine === "function" ? machine() : machine

--- a/packages/frameworks/react/src/use-machine.ts
+++ b/packages/frameworks/react/src/use-machine.ts
@@ -16,13 +16,11 @@ export function useService<
   TState extends S.StateSchema,
   TEvent extends S.EventObject = S.AnyEventObject,
 >(machine: MachineSrc<TContext, TState, TEvent>, options?: S.HookOptions<TContext, TState, TEvent>) {
-  const { actions, state: hydratedState, context: _context } = options ?? {}
-
-  const context = _context ? compact(_context) : undefined
+  const { actions, state: hydratedState, context } = options ?? {}
 
   const service = useConstant(() => {
     const _machine = typeof machine === "function" ? machine() : machine
-    return context ? _machine.withContext(context) : _machine
+    return context ? _machine.withContext(compact(context)) : _machine
   })
 
   useSafeLayoutEffect(() => {
@@ -39,11 +37,8 @@ export function useService<
 
   useSafeLayoutEffect(() => {
     service.setActions(actions)
-  }, [actions])
-
-  useSafeLayoutEffect(() => {
-    service.setContext(context)
-  }, [context])
+    service.setContext(compact(context))
+  }, [context, actions])
 
   return service
 }

--- a/packages/frameworks/solid/src/use-machine.ts
+++ b/packages/frameworks/solid/src/use-machine.ts
@@ -36,9 +36,7 @@ export function useService<
   })
 
   createEffect(() => {
-    if (context) {
-      service.setContext(compact(context))
-    }
+    service.setContext(compact(context))
   })
 
   createEffect(() => {

--- a/packages/frameworks/solid/src/use-machine.ts
+++ b/packages/frameworks/solid/src/use-machine.ts
@@ -1,4 +1,5 @@
 import type { MachineSrc, StateMachine as S } from "@zag-js/core"
+import { compact } from "@zag-js/utils"
 import { createEffect, onCleanup, onMount } from "solid-js"
 import { createStore, reconcile, Store } from "solid-js/store"
 
@@ -19,7 +20,7 @@ export function useService<
 
   const service = (() => {
     const _machine = typeof machine === "function" ? machine() : machine
-    return context ? _machine.withContext(context) : _machine
+    return context ? _machine.withContext(compact(context)) : _machine
   })()
 
   onMount(() => {
@@ -35,7 +36,9 @@ export function useService<
   })
 
   createEffect(() => {
-    service.setContext(context)
+    if (context) {
+      service.setContext(compact(context))
+    }
   })
 
   createEffect(() => {

--- a/packages/frameworks/vue/package.json
+++ b/packages/frameworks/vue/package.json
@@ -33,6 +33,7 @@
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
+    "@zag-js/utils": "workspace:*",
     "vue": "3.2.40"
   },
   "peerDependencies": {

--- a/packages/frameworks/vue/src/use-machine.ts
+++ b/packages/frameworks/vue/src/use-machine.ts
@@ -1,4 +1,5 @@
 import type { MachineSrc, StateMachine as S } from "@zag-js/core"
+import { compact } from "@zag-js/utils"
 import { ComputedRef, onBeforeUnmount, onMounted, Ref, shallowRef, watch } from "vue"
 
 type MachineOptions<
@@ -17,7 +18,7 @@ export function useService<
   const { actions, state: hydratedState, context } = options ?? {}
 
   const _machine = typeof machine === "function" ? machine() : machine
-  const service = context ? _machine.withContext(context.value) : _machine
+  const service = context ? _machine.withContext(compact(context.value)) : _machine
 
   onMounted(() => {
     service.start(hydratedState)
@@ -34,7 +35,7 @@ export function useService<
   watch(() => actions, service.setActions, { flush: "post", immediate: true })
 
   if (context) {
-    watch(context, (ctx) => service.setContext(ctx), { deep: true })
+    watch(context, (ctx) => service.setContext(compact(ctx)), { deep: true })
   }
 
   return service

--- a/packages/machines/accordion/src/accordion.machine.ts
+++ b/packages/machines/accordion/src/accordion.machine.ts
@@ -1,11 +1,12 @@
 import { createMachine, guards } from "@zag-js/core"
-import { add, isString, remove, toArray, warn } from "@zag-js/utils"
+import { add, compact, isString, remove, toArray, warn } from "@zag-js/utils"
 import { dom } from "./accordion.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./accordion.types"
 
 const { and, not } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "accordion",

--- a/packages/machines/checkbox/src/checkbox.machine.ts
+++ b/packages/machines/checkbox/src/checkbox.machine.ts
@@ -1,11 +1,13 @@
 import { createMachine, guards } from "@zag-js/core"
 import { dispatchInputCheckedEvent, trackFieldsetDisabled, trackFormReset } from "@zag-js/form-utils"
+import { compact } from "@zag-js/utils"
 import { dom } from "./checkbox.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./checkbox.types"
 
 const { and } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "checkbox",

--- a/packages/machines/combobox/src/combobox.machine.ts
+++ b/packages/machines/combobox/src/combobox.machine.ts
@@ -4,12 +4,14 @@ import { contains, observeAttributes, observeChildren, raf } from "@zag-js/dom-u
 import { trackInteractOutside } from "@zag-js/interact-outside"
 import { createLiveRegion } from "@zag-js/live-region"
 import { getPlacement } from "@zag-js/popper"
+import { compact } from "@zag-js/utils"
 import { dom } from "./combobox.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./combobox.types"
 
 const { and, not } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "combobox",

--- a/packages/machines/dialog/src/dialog.machine.ts
+++ b/packages/machines/dialog/src/dialog.machine.ts
@@ -3,12 +3,13 @@ import { createMachine } from "@zag-js/core"
 import { trackDismissableElement } from "@zag-js/dismissable"
 import { nextTick, raf } from "@zag-js/dom-utils"
 import { preventBodyScroll } from "@zag-js/remove-scroll"
-import { runIfFn } from "@zag-js/utils"
+import { compact, runIfFn } from "@zag-js/utils"
 import { createFocusTrap, FocusTrap } from "focus-trap"
 import { dom } from "./dialog.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./dialog.types"
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "dialog",

--- a/packages/machines/editable/package.json
+++ b/packages/machines/editable/package.json
@@ -34,6 +34,7 @@
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
+    "@zag-js/utils": "workspace:*",
     "@zag-js/dom-utils": "workspace:*",
     "@zag-js/form-utils": "workspace:*"
   },

--- a/packages/machines/editable/src/editable.machine.ts
+++ b/packages/machines/editable/src/editable.machine.ts
@@ -1,12 +1,14 @@
 import { createMachine, guards } from "@zag-js/core"
 import { contains, raf } from "@zag-js/dom-utils"
 import { trackInteractOutside } from "@zag-js/interact-outside"
+import { compact } from "@zag-js/utils"
 import { dom } from "./editable.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./editable.types"
 
 const { not } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "editable",

--- a/packages/machines/hover-card/package.json
+++ b/packages/machines/hover-card/package.json
@@ -45,6 +45,7 @@
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
-    "@zag-js/dom-utils": "workspace:*"
+    "@zag-js/dom-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*"
   }
 }

--- a/packages/machines/hover-card/src/hover-card.machine.ts
+++ b/packages/machines/hover-card/src/hover-card.machine.ts
@@ -2,12 +2,14 @@ import { createMachine, guards } from "@zag-js/core"
 import { trackDismissableElement } from "@zag-js/dismissable"
 import { raf } from "@zag-js/dom-utils"
 import { getPlacement } from "@zag-js/popper"
+import { compact } from "@zag-js/utils"
 import { dom } from "./hover-card.dom"
 import { MachineContext, MachineState, UserDefinedContext } from "./hover-card.types"
 
 const { not } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "hover-card",

--- a/packages/machines/menu/src/menu.machine.ts
+++ b/packages/machines/menu/src/menu.machine.ts
@@ -3,13 +3,14 @@ import { trackDismissableElement } from "@zag-js/dismissable"
 import { addPointerEvent, contains, findByTypeahead, getEventPoint, isFocusable, raf } from "@zag-js/dom-utils"
 import { getBasePlacement, getPlacement } from "@zag-js/popper"
 import { getElementPolygon, isPointInPolygon } from "@zag-js/rect-utils"
-import { add, isArray, remove } from "@zag-js/utils"
+import { add, compact, isArray, remove } from "@zag-js/utils"
 import { dom } from "./menu.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./menu.types"
 
 const { not, and } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "menu",

--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -8,7 +8,7 @@ import {
   supportsPointerEvent,
 } from "@zag-js/dom-utils"
 import { isAtMax, isAtMin, isWithinRange, valueOf } from "@zag-js/number-utils"
-import { callAll } from "@zag-js/utils"
+import { callAll, compact } from "@zag-js/utils"
 import { dispatchInputValueEvent } from "@zag-js/form-utils"
 import { dom } from "./number-input.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./number-input.types"
@@ -16,7 +16,8 @@ import { utils } from "./number-input.utils"
 
 const { not, and } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "number-input",

--- a/packages/machines/pagination/package.json
+++ b/packages/machines/pagination/package.json
@@ -43,6 +43,7 @@
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
-    "@zag-js/dom-utils": "workspace:*"
+    "@zag-js/dom-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*"
   }
 }

--- a/packages/machines/pagination/src/pagination.machine.ts
+++ b/packages/machines/pagination/src/pagination.machine.ts
@@ -1,7 +1,9 @@
 import { createMachine } from "@zag-js/core"
+import { compact } from "@zag-js/utils"
 import { MachineContext, MachineState, UserDefinedContext } from "./pagination.types"
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "pagination",

--- a/packages/machines/pin-input/src/pin-input.machine.ts
+++ b/packages/machines/pin-input/src/pin-input.machine.ts
@@ -1,12 +1,14 @@
 import { createMachine, guards } from "@zag-js/core"
 import { raf } from "@zag-js/dom-utils"
 import { dispatchInputValueEvent } from "@zag-js/form-utils"
+import { compact } from "@zag-js/utils"
 import { dom } from "./pin-input.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./pin-input.types"
 
 const { and, not } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "pin-input",

--- a/packages/machines/popover/src/popover.machine.ts
+++ b/packages/machines/popover/src/popover.machine.ts
@@ -4,14 +4,15 @@ import { trackDismissableElement } from "@zag-js/dismissable"
 import { addDomEvent, contains, nextTick, raf, isModifiedEvent } from "@zag-js/dom-utils"
 import { getPlacement } from "@zag-js/popper"
 import { preventBodyScroll } from "@zag-js/remove-scroll"
-import { next, runIfFn } from "@zag-js/utils"
+import { compact, next, runIfFn } from "@zag-js/utils"
 import { createFocusTrap, FocusTrap } from "focus-trap"
 import { dom } from "./popover.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./popover.types"
 
 const { and, or, not } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "popover",

--- a/packages/machines/pressable/package.json
+++ b/packages/machines/pressable/package.json
@@ -27,7 +27,8 @@
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
-    "@zag-js/dom-utils": "workspace:*"
+    "@zag-js/dom-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*"
   },
   "scripts": {
     "build-fast": "tsup src/index.ts --format=esm,cjs",

--- a/packages/machines/pressable/src/pressable.machine.ts
+++ b/packages/machines/pressable/src/pressable.machine.ts
@@ -1,10 +1,12 @@
 import { createMachine, ref } from "@zag-js/core"
 import { addDomEvent, disableTextSelection, isHTMLElement, restoreTextSelection } from "@zag-js/dom-utils"
+import { compact } from "@zag-js/utils"
 import { dom } from "./pressable.dom"
 import { MachineContext, MachineState, UserDefinedContext } from "./pressable.types"
 import { utils } from "./pressable.utils"
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "pressable",

--- a/packages/machines/radio/package.json
+++ b/packages/machines/radio/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@zag-js/dom-utils": "workspace:*",
-    "@zag-js/form-utils": "workspace:*"
+    "@zag-js/form-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*"
   }
 }

--- a/packages/machines/radio/src/radio.machine.ts
+++ b/packages/machines/radio/src/radio.machine.ts
@@ -1,11 +1,11 @@
 import { createMachine } from "@zag-js/core"
 import { dispatchInputCheckedEvent, trackFieldsetDisabled, trackFormReset } from "@zag-js/form-utils"
-
+import { compact } from "@zag-js/utils"
+import { dom } from "./radio.dom"
 import { MachineContext, MachineState, UserDefinedContext } from "./radio.types"
 
-import { dom } from "./radio.dom"
-
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "radio",

--- a/packages/machines/range-slider/package.json
+++ b/packages/machines/range-slider/package.json
@@ -38,6 +38,7 @@
     "@zag-js/dom-utils": "workspace:*",
     "@zag-js/form-utils": "workspace:*",
     "@zag-js/number-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*",
     "@zag-js/rect-utils": "workspace:*"
   },
   "scripts": {

--- a/packages/machines/range-slider/src/range-slider.machine.ts
+++ b/packages/machines/range-slider/src/range-slider.machine.ts
@@ -1,12 +1,14 @@
 import { createMachine } from "@zag-js/core"
 import { raf, trackPointerMove } from "@zag-js/dom-utils"
-import { trackFieldsetDisabled, trackFormReset } from "@zag-js/form-utils"
 import { trackElementsSize } from "@zag-js/element-size"
+import { trackFieldsetDisabled, trackFormReset } from "@zag-js/form-utils"
+import { compact } from "@zag-js/utils"
 import { dom, getClosestIndex } from "./range-slider.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./range-slider.types"
 import { utils } from "./range-slider.utils"
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "range-slider",

--- a/packages/machines/rating/src/rating.machine.ts
+++ b/packages/machines/rating/src/rating.machine.ts
@@ -1,10 +1,12 @@
 import { createMachine } from "@zag-js/core"
 import { raf } from "@zag-js/dom-utils"
 import { trackFieldsetDisabled, trackFormReset } from "@zag-js/form-utils"
+import { compact } from "@zag-js/utils"
 import { dom } from "./rating.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./rating.types"
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "rating",

--- a/packages/machines/slider/package.json
+++ b/packages/machines/slider/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@zag-js/dom-utils": "workspace:*",
     "@zag-js/form-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*",
     "@zag-js/number-utils": "workspace:*"
   },
   "scripts": {

--- a/packages/machines/slider/src/slider.machine.ts
+++ b/packages/machines/slider/src/slider.machine.ts
@@ -2,11 +2,13 @@ import { createMachine } from "@zag-js/core"
 import { raf, trackPointerMove } from "@zag-js/dom-utils"
 import { trackFieldsetDisabled, trackFormReset } from "@zag-js/form-utils"
 import { trackElementSize } from "@zag-js/element-size"
+import { compact } from "@zag-js/utils"
 import { dom } from "./slider.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./slider.types"
 import { utils } from "./slider.utils"
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "slider",

--- a/packages/machines/splitter/package.json
+++ b/packages/machines/splitter/package.json
@@ -35,7 +35,8 @@
   },
   "devDependencies": {
     "@zag-js/dom-utils": "workspace:*",
-    "@zag-js/number-utils": "workspace:*"
+    "@zag-js/number-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*"
   },
   "scripts": {
     "build-fast": "tsup src/index.ts --format=esm,cjs",

--- a/packages/machines/splitter/src/splitter.machine.ts
+++ b/packages/machines/splitter/src/splitter.machine.ts
@@ -1,12 +1,14 @@
 import { createMachine, guards } from "@zag-js/core"
-import { raf, trackPointerMove, getPointRelativeToNode } from "@zag-js/dom-utils"
+import { getPointRelativeToNode, raf, trackPointerMove } from "@zag-js/dom-utils"
 import { clamp, decrement, increment, snapToStep } from "@zag-js/number-utils"
+import { compact } from "@zag-js/utils"
 import { dom } from "./splitter.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./splitter.types"
 
 const { not } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "splitter",

--- a/packages/machines/tabs/src/tabs.machine.ts
+++ b/packages/machines/tabs/src/tabs.machine.ts
@@ -1,11 +1,13 @@
 import { createMachine, guards } from "@zag-js/core"
 import { getFocusables, nextTick, raf } from "@zag-js/dom-utils"
+import { compact } from "@zag-js/utils"
 import { dom } from "./tabs.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./tabs.types"
 
 const { not } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       initial: "unknown",

--- a/packages/machines/tags-input/src/tags-input.machine.ts
+++ b/packages/machines/tags-input/src/tags-input.machine.ts
@@ -4,13 +4,14 @@ import { contains, raf } from "@zag-js/dom-utils"
 import { trackFieldsetDisabled, trackFormReset } from "@zag-js/form-utils"
 import { trackInteractOutside } from "@zag-js/interact-outside"
 import { createLiveRegion } from "@zag-js/live-region"
-import { warn } from "@zag-js/utils"
+import { compact, warn } from "@zag-js/utils"
 import { dom } from "./tags-input.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./tags-input.types"
 
 const { and, not, or } = guards
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "tags-input",

--- a/packages/machines/toast/src/toast-group.machine.ts
+++ b/packages/machines/toast/src/toast-group.machine.ts
@@ -1,9 +1,11 @@
 import { createMachine } from "@zag-js/core"
 import { MAX_Z_INDEX } from "@zag-js/dom-utils"
+import { compact } from "@zag-js/utils"
 import { createToastMachine } from "./toast.machine"
 import type { GroupMachineContext, UserDefinedGroupContext } from "./toast.types"
 
-export function groupMachine(ctx: UserDefinedGroupContext) {
+export function groupMachine(userContext: UserDefinedGroupContext) {
+  const ctx = compact(userContext)
   return createMachine<GroupMachineContext>({
     id: "toaster",
     initial: "active",

--- a/packages/machines/toast/src/toast.machine.ts
+++ b/packages/machines/toast/src/toast.machine.ts
@@ -1,5 +1,6 @@
 import { createMachine, guards } from "@zag-js/core"
 import { trackDocumentVisibility } from "@zag-js/dom-utils"
+import { compact } from "@zag-js/utils"
 import { dom } from "./toast.dom"
 import type { MachineContext, MachineState, Options } from "./toast.types"
 import { getToastDuration } from "./toast.utils"
@@ -7,8 +8,10 @@ import { getToastDuration } from "./toast.utils"
 const { not, and, or } = guards
 
 export function createToastMachine(options: Options = {}) {
-  const { type = "info", duration, id = "toast", placement = "bottom", removeDelay = 500, ...rest } = options
-  const __duration = getToastDuration(duration, type)
+  const { type = "info", duration, id = "toast", placement = "bottom", removeDelay = 500, ...restProps } = options
+  const ctx = compact(restProps)
+
+  const computedDuration = getToastDuration(duration, type)
 
   return createMachine<MachineContext, MachineState>(
     {
@@ -18,12 +21,12 @@ export function createToastMachine(options: Options = {}) {
       context: {
         id,
         type,
-        remaining: __duration,
-        duration: __duration,
+        remaining: computedDuration,
+        duration: computedDuration,
         removeDelay,
         createdAt: Date.now(),
         placement,
-        ...rest,
+        ...ctx,
       },
 
       on: {

--- a/packages/machines/toggle/package.json
+++ b/packages/machines/toggle/package.json
@@ -33,7 +33,8 @@
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
-    "@zag-js/dom-utils": "workspace:*"
+    "@zag-js/dom-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*"
   },
   "scripts": {
     "build-fast": "tsup src/index.ts --format=esm,cjs",

--- a/packages/machines/toggle/src/toggle.machine.ts
+++ b/packages/machines/toggle/src/toggle.machine.ts
@@ -1,7 +1,9 @@
 import { createMachine } from "@zag-js/core"
+import { compact } from "@zag-js/utils"
 import type { MachineContext, MachineState, UserDefinedContext } from "./toggle.types"
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "toggle",

--- a/packages/machines/tooltip/src/tooltip.machine.ts
+++ b/packages/machines/tooltip/src/tooltip.machine.ts
@@ -9,11 +9,13 @@ import {
   raf,
 } from "@zag-js/dom-utils"
 import { getPlacement } from "@zag-js/popper"
+import { compact } from "@zag-js/utils"
 import { dom } from "./tooltip.dom"
 import { store } from "./tooltip.store"
 import type { MachineContext, MachineState, UserDefinedContext } from "./tooltip.types"
 
-export function machine(ctx: UserDefinedContext) {
+export function machine(userContext: UserDefinedContext) {
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "tooltip",

--- a/packages/utilities/core/src/object.ts
+++ b/packages/utilities/core/src/object.ts
@@ -1,6 +1,7 @@
 import { isObject } from "./guard"
 
-export function compact<T extends Record<string, unknown>>(obj: T): T {
+export function compact<T extends Record<string, unknown> | undefined>(obj: T): T {
+  if (obj === undefined) return obj
   return Object.fromEntries(
     Object.entries(obj)
       // remove undefined values

--- a/plop/machine/package.json.hbs
+++ b/plop/machine/package.json.hbs
@@ -33,6 +33,7 @@
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
-    "@zag-js/dom-utils": "workspace:*"
+    "@zag-js/dom-utils": "workspace:*",
+    "@zag-js/utils": "workspace:*"
   }
 }

--- a/plop/machine/src/{{machine}}.machine.ts.hbs
+++ b/plop/machine/src/{{machine}}.machine.ts.hbs
@@ -1,7 +1,9 @@
 import { createMachine, ref } from "@zag-js/core"
+import { compact } from "@zag-js/utils"
 import { MachineContext, MachineState, UserDefinedContext } from "./{{machine}}.types"
 
-export function machine(ctx: UserDefinedContext){ 
+export function machine(userContext: UserDefinedContext){ 
+  const ctx = compact(userContext)
   return createMachine<MachineContext, MachineState>(
     {
       id: "{{machine}}",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,7 @@ importers:
       '@zag-js/core': workspace:*
       '@zag-js/store': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
       proxy-compare: 2.3.0
       react: 18.2.0
     dependencies:
@@ -457,6 +458,7 @@ importers:
       proxy-compare: 2.3.0
     devDependencies:
       '@types/react': 18.0.21
+      '@zag-js/utils': link:../../utilities/core
       react: 18.2.0
 
   packages/frameworks/solid:
@@ -490,12 +492,14 @@ importers:
       '@zag-js/core': workspace:*
       '@zag-js/store': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
       vue: 3.2.40
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/store': link:../../store
       '@zag-js/types': link:../../types
     devDependencies:
+      '@zag-js/utils': link:../../utilities/core
       vue: 3.2.40
 
   packages/machines/accordion:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,13 +450,11 @@ importers:
       '@zag-js/types': workspace:*
       proxy-compare: 2.3.0
       react: 18.2.0
-      use-deep-compare-effect: ^1.8.1
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/store': link:../../store
       '@zag-js/types': link:../../types
       proxy-compare: 2.3.0
-      use-deep-compare-effect: 1.8.1_react@18.2.0
     devDependencies:
       '@types/react': 18.0.21
       react: 18.2.0
@@ -4482,11 +4480,6 @@ packages:
 
   /deprecation/2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
-    dev: false
-
-  /dequal/2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
     dev: false
 
   /detect-file/1.0.0:
@@ -8821,17 +8814,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
-
-  /use-deep-compare-effect/1.8.1_react@18.2.0:
-    resolution: {integrity: sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==}
-    engines: {node: '>=10', npm: '>=6'}
-    peerDependencies:
-      react: '>=16.13'
-    dependencies:
-      '@babel/runtime': 7.20.0
-      dequal: 2.0.3
-      react: 18.2.0
-    dev: false
 
   /use-sync-external-store/1.2.0_react@18.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,11 +450,13 @@ importers:
       '@zag-js/types': workspace:*
       proxy-compare: 2.3.0
       react: 18.2.0
+      use-deep-compare-effect: ^1.8.1
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/store': link:../../store
       '@zag-js/types': link:../../types
       proxy-compare: 2.3.0
+      use-deep-compare-effect: 1.8.1_react@18.2.0
     devDependencies:
       '@types/react': 18.0.21
       react: 18.2.0
@@ -575,6 +577,7 @@ importers:
       '@zag-js/form-utils': workspace:*
       '@zag-js/interact-outside': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/interact-outside': link:../../utilities/interact-outside
@@ -582,6 +585,7 @@ importers:
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
       '@zag-js/form-utils': link:../../utilities/form-utils
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/hover-card:
     specifiers:
@@ -590,6 +594,7 @@ importers:
       '@zag-js/dom-utils': workspace:*
       '@zag-js/popper': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/dismissable': link:../../utilities/dismissable
@@ -597,6 +602,7 @@ importers:
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/menu:
     specifiers:
@@ -639,11 +645,13 @@ importers:
       '@zag-js/core': workspace:*
       '@zag-js/dom-utils': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/pin-input:
     specifiers:
@@ -688,11 +696,13 @@ importers:
       '@zag-js/core': workspace:*
       '@zag-js/dom-utils': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/radio:
     specifiers:
@@ -700,12 +710,14 @@ importers:
       '@zag-js/dom-utils': workspace:*
       '@zag-js/form-utils': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
       '@zag-js/form-utils': link:../../utilities/form-utils
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/range-slider:
     specifiers:
@@ -717,6 +729,7 @@ importers:
       '@zag-js/rect-utils': workspace:*
       '@zag-js/slider': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/element-size': link:../../utilities/element-size
@@ -727,6 +740,7 @@ importers:
       '@zag-js/form-utils': link:../../utilities/form-utils
       '@zag-js/number-utils': link:../../utilities/number
       '@zag-js/rect-utils': link:../../utilities/rect
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/rating:
     specifiers:
@@ -751,6 +765,7 @@ importers:
       '@zag-js/form-utils': workspace:*
       '@zag-js/number-utils': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/element-size': link:../../utilities/element-size
@@ -759,6 +774,7 @@ importers:
       '@zag-js/dom-utils': link:../../utilities/dom
       '@zag-js/form-utils': link:../../utilities/form-utils
       '@zag-js/number-utils': link:../../utilities/number
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/splitter:
     specifiers:
@@ -766,12 +782,14 @@ importers:
       '@zag-js/dom-utils': workspace:*
       '@zag-js/number-utils': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
       '@zag-js/number-utils': link:../../utilities/number
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/tabs:
     specifiers:
@@ -825,11 +843,13 @@ importers:
       '@zag-js/core': workspace:*
       '@zag-js/dom-utils': workspace:*
       '@zag-js/types': workspace:*
+      '@zag-js/utils': workspace:*
     dependencies:
       '@zag-js/core': link:../../core
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
+      '@zag-js/utils': link:../../utilities/core
 
   packages/machines/tooltip:
     specifiers:
@@ -4462,6 +4482,11 @@ packages:
 
   /deprecation/2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+    dev: false
+
+  /dequal/2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
     dev: false
 
   /detect-file/1.0.0:
@@ -8796,6 +8821,17 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
+
+  /use-deep-compare-effect/1.8.1_react@18.2.0:
+    resolution: {integrity: sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13'
+    dependencies:
+      '@babel/runtime': 7.20.0
+      dequal: 2.0.3
+      react: 18.2.0
+    dev: false
 
   /use-sync-external-store/1.2.0_react@18.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}


### PR DESCRIPTION
## 📝 Description

Filter out `undefined` values from the context to make it easier to consume in design systems. We found this convenient when we tried to integrate Zag.js into Chakra UI

## ⛳️ Current behavior (updates)

For design system maintainers, it currently requires filtering undefined in their code, which can be tedious.

## 🚀 New behavior

Much better!

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
