### PR TITLE
Fix: controlled context and react

### DIFF
--- a/.changeset/spotty-boxes-sing.md
+++ b/.changeset/spotty-boxes-sing.md
@@ -1,0 +1,11 @@
+---
+"@zag-js/core": patch
+"@zag-js/react": patch
+"@zag-js/solid": patch
+"@zag-js/svelte": patch
+"@zag-js/vue": patch
+---
+
+Improve support for updating the internal machine options.
+
+Fix react controlled context.

--- a/examples/next-ts/pages/rating.tsx
+++ b/examples/next-ts/pages/rating.tsx
@@ -42,6 +42,7 @@ export default function Page() {
   const [state, send] = useMachine(
     rating.machine({
       id: useId(),
+      value: 2.5,
     }),
     {
       context: controls.context,

--- a/examples/solid-ts/src/pages/rating.tsx
+++ b/examples/solid-ts/src/pages/rating.tsx
@@ -39,9 +39,15 @@ function Star() {
 export default function Page() {
   const controls = useControls(ratingControls)
 
-  const [state, send] = useMachine(rating.machine({ id: createUniqueId() }), {
-    context: controls.context,
-  })
+  const [state, send] = useMachine(
+    rating.machine({
+      id: createUniqueId(),
+      value: 2.5,
+    }),
+    {
+      context: controls.context,
+    },
+  )
 
   const api = createMemo(() => rating.connect(state, send, normalizeProps))
 

--- a/examples/vue-ts/src/pages/rating.tsx
+++ b/examples/vue-ts/src/pages/rating.tsx
@@ -47,9 +47,15 @@ export default defineComponent({
   name: "Rating",
   setup() {
     const controls = useControls(ratingControls)
-    const [state, send] = useMachine(rating.machine({ id: "rating" }), {
-      context: controls.context,
-    })
+    const [state, send] = useMachine(
+      rating.machine({
+        id: "rating",
+        value: 2.5,
+      }),
+      {
+        context: controls.context,
+      },
+    )
 
     const apiRef = computed(() => rating.connect(state.value, send, normalizeProps))
 

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -1,5 +1,18 @@
 import { ref, snapshot, subscribe } from "@zag-js/store"
-import { cast, clear, invariant, isArray, isDev, isObject, isString, noop, runIfFn, uuid, warn } from "@zag-js/utils"
+import {
+  cast,
+  clear,
+  compact,
+  invariant,
+  isArray,
+  isDev,
+  isObject,
+  isString,
+  noop,
+  runIfFn,
+  uuid,
+  warn,
+} from "@zag-js/utils"
 import { klona } from "klona/json"
 import { createProxy } from "./create-proxy"
 import { determineDelayFn } from "./delay-utils"
@@ -327,18 +340,20 @@ export class Machine<
    */
   public setContext = (context: Partial<Writable<TContext>> | undefined) => {
     if (!context) return
-    for (const key in context) {
-      this.state.context[<keyof TContext>key] = context[key]!
-    }
+    Object.assign(this.state.context, compact(context))
   }
 
   public withContext = (context: Partial<Writable<TContext>>) => {
-    const newContext = { ...this.config.context, ...context } as TContext
+    const newContext = { ...this.config.context, ...compact(context) } as TContext
     return new Machine({ ...this.config, context: newContext }, this.options)
   }
 
-  public setActions = (actions: Partial<S.MachineOptions<TContext, TState, TEvent>>["actions"]) => {
-    this.actionMap = { ...this.actionMap, ...actions }
+  public setOptions = (options: Partial<S.MachineOptions<TContext, TState, TEvent>>) => {
+    const opts = compact(options)
+    this.actionMap = { ...this.actionMap, ...opts.actions }
+    this.delayMap = { ...this.delayMap, ...opts.delays }
+    this.activityMap = { ...this.activityMap, ...opts.activities }
+    this.guardMap = { ...this.guardMap, ...opts.guards }
   }
 
   private getStateNode = (state: TState["value"] | null) => {

--- a/packages/frameworks/react/src/use-machine.ts
+++ b/packages/frameworks/react/src/use-machine.ts
@@ -1,5 +1,4 @@
 import type { MachineSrc, StateMachine as S } from "@zag-js/core"
-import { compact } from "@zag-js/utils"
 import { useEffect, useLayoutEffect, useRef } from "react"
 import { useSnapshot } from "./use-snapshot"
 
@@ -20,7 +19,7 @@ export function useService<
 
   const service = useConstant(() => {
     const _machine = typeof machine === "function" ? machine() : machine
-    return context ? _machine.withContext(compact(context)) : _machine
+    return context ? _machine.withContext(context) : _machine
   })
 
   useSafeLayoutEffect(() => {
@@ -35,10 +34,8 @@ export function useService<
     }
   }, [])
 
-  useSafeLayoutEffect(() => {
-    service.setActions(actions)
-    service.setContext(compact(context))
-  }, [context, actions])
+  service.setOptions({ actions })
+  service.setContext(context)
 
   return service
 }

--- a/packages/frameworks/solid/src/use-machine.ts
+++ b/packages/frameworks/solid/src/use-machine.ts
@@ -1,5 +1,4 @@
 import type { MachineSrc, StateMachine as S } from "@zag-js/core"
-import { compact } from "@zag-js/utils"
 import { createEffect, onCleanup, onMount } from "solid-js"
 import { createStore, reconcile, Store } from "solid-js/store"
 
@@ -20,7 +19,7 @@ export function useService<
 
   const service = (() => {
     const _machine = typeof machine === "function" ? machine() : machine
-    return context ? _machine.withContext(compact(context)) : _machine
+    return context ? _machine.withContext(context) : _machine
   })()
 
   onMount(() => {
@@ -36,11 +35,11 @@ export function useService<
   })
 
   createEffect(() => {
-    service.setContext(compact(context))
+    service.setContext(context)
   })
 
   createEffect(() => {
-    service.setActions(actions)
+    service.setOptions({ actions })
   })
 
   return service

--- a/packages/frameworks/svelte/src/use-machine.ts
+++ b/packages/frameworks/svelte/src/use-machine.ts
@@ -31,7 +31,7 @@ export function useMachine<
   })
 
   // update machine actives when `action` changes
-  $: service.setActions(actions)
+  $: service.setOptions({ actions })
 
   onDestroy(() => {
     service.stop()

--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -3,7 +3,6 @@ import { defineControls } from "./define-controls"
 export const accordionControls = defineControls({
   collapsible: { type: "boolean", defaultValue: false, label: "Allow Toggle" },
   multiple: { type: "boolean", defaultValue: false, label: "Allow Multiple" },
-  value: { type: "select", defaultValue: "", options: ["home", "about", "contact"], label: "Set value" },
 })
 
 export const checkboxControls = defineControls({
@@ -134,7 +133,6 @@ export const ratingControls = defineControls({
   disabled: { type: "boolean", defaultValue: false },
   readonly: { type: "boolean", defaultValue: false },
   allowHalf: { type: "boolean", defaultValue: true },
-  value: { type: "number", defaultValue: 2.5 },
   max: { type: "number", defaultValue: 5 },
   dir: { type: "select", options: ["ltr", "rtl"] as const, defaultValue: "ltr" },
 })


### PR DESCRIPTION
## 📝 Description

This PR improves the react `useMachine` to support readonly or controlled context values.

## ⛳️ Current behavior (updates)

This hook sometimes run into "Maximum depth" aka infinite loop issues when passed object types (object, array, functions)

## 🚀 New behavior

Works as intended

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
