### PR TITLE
fix(toasts): export toast options

### DIFF
--- a/.changeset/happy-buses-rest.md
+++ b/.changeset/happy-buses-rest.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/toast": patch
+---
+
+Export `ToastOptions` type

--- a/packages/machines/toast/src/index.ts
+++ b/packages/machines/toast/src/index.ts
@@ -5,7 +5,15 @@ import { groupMachine } from "./toast-group.machine"
 import { createToastMachine as createMachine } from "./toast.machine"
 
 export { connect } from "./toast.connect"
-export type { GroupMachineContext, MachineContext, MachineState, Placement, Service, Type } from "./toast.types"
+export type {
+  GroupMachineContext,
+  MachineContext,
+  MachineState,
+  Placement,
+  Service,
+  ToastOptions,
+  Type,
+} from "./toast.types"
 export { createMachine }
 
 export const group = {


### PR DESCRIPTION
Resolves issue in Ark `ToastOptions can not be named`