### PR TITLE
fix: remove hook sync

### DIFF
--- a/.changeset/tame-terms-compete.md
+++ b/.changeset/tame-terms-compete.md
@@ -1,0 +1,10 @@
+---
+"@zag-js/core": patch
+"@zag-js/react": patch
+"@zag-js/combobox": patch
+"@zag-js/editable": patch
+"@zag-js/number-input": patch
+"@zag-js/tags-input": patch
+---
+
+Remove support for internal `hookSync` property.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -382,13 +382,6 @@ export declare namespace StateMachine {
     delays?: DelayMap<TContext, TEvent>
     activities?: ActivityMap<TContext, TState, TEvent>
     sync?: boolean
-    /**
-     * Notify `useSnapshot` to execute state update synchronously within `valtio`.
-     * Useful if this component has an input element.
-     *
-     * @see Valtio https://github.com/pmndrs/valtio#update-synchronously
-     */
-    hookSync?: boolean
   }
 
   export type HookOptions<TContext extends Dict, TState extends StateSchema, TEvent extends EventObject> = {

--- a/packages/frameworks/react/src/use-actor.ts
+++ b/packages/frameworks/react/src/use-actor.ts
@@ -6,11 +6,7 @@ export function useActor<
   TState extends S.StateSchema,
   TEvent extends S.EventObject = S.AnyEventObject,
 >(service: Machine<TContext, TState, TEvent>) {
-  const current = useSnapshot(service.state, {
-    sync: service.options.hookSync,
-  })
-
+  const current = useSnapshot(service.state)
   const typedState = current as unknown as S.State<TContext, TState, TEvent>
-
   return [typedState, service.send] as const
 }

--- a/packages/frameworks/react/src/use-machine.ts
+++ b/packages/frameworks/react/src/use-machine.ts
@@ -47,11 +47,7 @@ export function useMachine<
 >(machine: MachineSrc<TContext, TState, TEvent>, options?: S.HookOptions<TContext, TState, TEvent>) {
   const service = useService(machine, options)
 
-  const state = useSnapshot(service.state, {
-    sync: service.options.hookSync,
-  })
-
+  const state = useSnapshot(service.state)
   const typedState = state as unknown as S.State<TContext, TState, TEvent>
-
   return [typedState, service.send, service] as const
 }

--- a/packages/machines/combobox/src/combobox.machine.ts
+++ b/packages/machines/combobox/src/combobox.machine.ts
@@ -594,8 +594,6 @@ export function machine(userContext: UserDefinedContext) {
           ctx.sectionLabel = label
         },
       },
-
-      hookSync: true,
     },
   )
 }

--- a/packages/machines/editable/src/editable.machine.ts
+++ b/packages/machines/editable/src/editable.machine.ts
@@ -184,8 +184,6 @@ export function machine(userContext: UserDefinedContext) {
           dom.getInputEl(ctx)?.blur()
         },
       },
-
-      hookSync: true,
     },
   )
 }

--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -400,8 +400,6 @@ export function machine(userContext: UserDefinedContext) {
           dispatchInputValueEvent(dom.getInputEl(ctx), ctx.formattedValue)
         },
       },
-
-      hookSync: true,
     },
   )
 }

--- a/packages/machines/tags-input/src/tags-input.machine.ts
+++ b/packages/machines/tags-input/src/tags-input.machine.ts
@@ -553,8 +553,6 @@ export function machine(userContext: UserDefinedContext) {
           if (msg) region.announce(msg)
         },
       },
-
-      hookSync: true,
     },
   )
 }


### PR DESCRIPTION
## 📝 Description

In previous versions of Zag.js, we needed a "magic" property, `hookSync` which helped Valtio synchronously update values when using controlled inputs.

By default, Zag.js uses uncontrolled inputs for better SSR and progressive enhancement. We also sync with the DOM manually using the onChange/onInput callback.

## ⛳️ Current behavior (updates)

Max call stack exceeded error when using any machine with this `hookSync` option and using a controlled context

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
