### PR TITLE
chore: add `form` attribute to all form related elements

### DIFF
--- a/.changeset/forty-hornets-hug.md
+++ b/.changeset/forty-hornets-hug.md
@@ -1,0 +1,14 @@
+---
+"@zag-js/checkbox": patch
+"@zag-js/combobox": patch
+"@zag-js/editable": patch
+"@zag-js/number-input": patch
+"@zag-js/pin-input": patch
+"@zag-js/radio": patch
+"@zag-js/range-slider": patch
+"@zag-js/rating": patch
+"@zag-js/slider": patch
+"@zag-js/tags-input": patch
+---
+
+Add support for `form` attribute

--- a/packages/machines/checkbox/src/checkbox.connect.ts
+++ b/packages/machines/checkbox/src/checkbox.connect.ts
@@ -25,6 +25,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
   const ariaChecked = isIndeterminate ? "mixed" : isChecked
 
   const name = state.context.name
+  const form = state.context.form
   const value = state.context.value
 
   const trulyDisabled = isDisabled && !isFocusable
@@ -123,6 +124,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       "aria-describedby": ariaDescribedBy,
       "aria-disabled": isDisabled,
       name,
+      form,
       value,
       style: visuallyHiddenStyle,
       onChange() {

--- a/packages/machines/checkbox/src/checkbox.types.ts
+++ b/packages/machines/checkbox/src/checkbox.types.ts
@@ -55,7 +55,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the underlying checkbox.
      */
     form?: string
     /**

--- a/packages/machines/checkbox/src/checkbox.types.ts
+++ b/packages/machines/checkbox/src/checkbox.types.ts
@@ -55,11 +55,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
      * The associate form of the underlying checkbox.
-=======
-     * The associate form of the underlying input element.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
     /**

--- a/packages/machines/checkbox/src/checkbox.types.ts
+++ b/packages/machines/checkbox/src/checkbox.types.ts
@@ -55,6 +55,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * The value to be used in the checkbox input.
      * This is the value that will be returned on form submission.
      */

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -98,6 +98,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       "aria-invalid": isInvalid,
       "data-invalid": dataAttr(isInvalid),
       name: state.context.name,
+      form: state.context.form,
       disabled: isDisabled,
       autoFocus: state.context.autoFocus,
       autoComplete: "off",

--- a/packages/machines/combobox/src/combobox.types.ts
+++ b/packages/machines/combobox/src/combobox.types.ts
@@ -40,6 +40,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * Whether the combobox is disabled
      */
     disabled?: boolean

--- a/packages/machines/combobox/src/combobox.types.ts
+++ b/packages/machines/combobox/src/combobox.types.ts
@@ -40,7 +40,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the combobox.
      */
     form?: string
     /**

--- a/packages/machines/editable/src/editable.connect.ts
+++ b/packages/machines/editable/src/editable.connect.ts
@@ -72,6 +72,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       "data-part": "input",
       "aria-label": translations.input,
       name: state.context.name,
+      form: state.context.form,
       id: dom.getInputId(state.context),
       hidden: autoResize ? undefined : !isEditing,
       placeholder: placeholder?.edit,

--- a/packages/machines/editable/src/editable.types.ts
+++ b/packages/machines/editable/src/editable.types.ts
@@ -39,6 +39,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * Whether the editable should auto-resize to fit the content.
      */
     autoResize?: boolean

--- a/packages/machines/editable/src/editable.types.ts
+++ b/packages/machines/editable/src/editable.types.ts
@@ -39,7 +39,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the underlying input.
      */
     form?: string
     /**

--- a/packages/machines/editable/src/editable.types.ts
+++ b/packages/machines/editable/src/editable.types.ts
@@ -39,11 +39,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
      * The associate form of the underlying input.
-=======
-     * The associate form of the editable input.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
     /**

--- a/packages/machines/number-input/src/number-input.connect.ts
+++ b/packages/machines/number-input/src/number-input.connect.ts
@@ -82,6 +82,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     inputProps: normalize.input({
       "data-part": "input",
       name: state.context.name,
+      form: state.context.form,
       id: dom.getInputId(state.context),
       role: "spinbutton",
       defaultValue: state.context.formattedValue,

--- a/packages/machines/number-input/src/number-input.types.ts
+++ b/packages/machines/number-input/src/number-input.types.ts
@@ -44,7 +44,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the underlying input.
      */
     form?: string
     /**

--- a/packages/machines/number-input/src/number-input.types.ts
+++ b/packages/machines/number-input/src/number-input.types.ts
@@ -44,6 +44,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * Whether the number input is disabled.
      */
     disabled?: boolean

--- a/packages/machines/number-input/src/number-input.types.ts
+++ b/packages/machines/number-input/src/number-input.types.ts
@@ -44,11 +44,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
-     * The associate form of the underlying input.
-=======
      * The associate form of the input element.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
     /**

--- a/packages/machines/pin-input/src/pin-input.connect.ts
+++ b/packages/machines/pin-input/src/pin-input.connect.ts
@@ -68,6 +68,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       tabIndex: -1,
       id: dom.getHiddenInputId(state.context),
       name: state.context.name,
+      form: state.context.form,
       style: visuallyHiddenStyle,
       maxLength: state.context.valueLength,
       defaultValue: state.context.valueAsString,

--- a/packages/machines/pin-input/src/pin-input.types.ts
+++ b/packages/machines/pin-input/src/pin-input.types.ts
@@ -19,6 +19,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * The regular expression that the user-entered input value is checked against.
      */
     pattern?: string

--- a/packages/machines/pin-input/src/pin-input.types.ts
+++ b/packages/machines/pin-input/src/pin-input.types.ts
@@ -19,11 +19,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
-     * The associate form of the underlying input.
-=======
      * The associate form of the underlying input element.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
     /**

--- a/packages/machines/pin-input/src/pin-input.types.ts
+++ b/packages/machines/pin-input/src/pin-input.types.ts
@@ -19,7 +19,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the underlying input.
      */
     form?: string
     /**

--- a/packages/machines/radio/src/radio.connect.ts
+++ b/packages/machines/radio/src/radio.connect.ts
@@ -139,6 +139,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
 
         type: "radio",
         name: state.context.name || state.context.id,
+        form: state.context.form,
         value: props.value,
         onChange(event) {
           if (inputState.isReadOnly || inputState.isDisabled) {

--- a/packages/machines/radio/src/radio.types.ts
+++ b/packages/machines/radio/src/radio.types.ts
@@ -27,11 +27,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
-     * The associate form of the underlying radio.
-=======
      * The associate form of the underlying input.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
     /**

--- a/packages/machines/radio/src/radio.types.ts
+++ b/packages/machines/radio/src/radio.types.ts
@@ -27,7 +27,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the underlying radio.
      */
     form?: string
     /**

--- a/packages/machines/radio/src/radio.types.ts
+++ b/packages/machines/radio/src/radio.types.ts
@@ -27,6 +27,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * If `true`, the radio group will be disabled
      */
     disabled?: boolean

--- a/packages/machines/range-slider/src/range-slider.connect.ts
+++ b/packages/machines/range-slider/src/range-slider.connect.ts
@@ -199,6 +199,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       return normalize.input({
         "data-part": "input",
         name: `${state.context.name}[${index}]`,
+        form: state.context.form,
         type: "text",
         hidden: true,
         defaultValue: state.context.values[index],

--- a/packages/machines/range-slider/src/range-slider.types.ts
+++ b/packages/machines/range-slider/src/range-slider.types.ts
@@ -30,11 +30,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
-     * The associate form of the range slider.
-=======
      * The associate form of the underlying input element.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
     /**

--- a/packages/machines/range-slider/src/range-slider.types.ts
+++ b/packages/machines/range-slider/src/range-slider.types.ts
@@ -30,7 +30,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the range slider.
      */
     form?: string
     /**

--- a/packages/machines/range-slider/src/range-slider.types.ts
+++ b/packages/machines/range-slider/src/range-slider.types.ts
@@ -30,6 +30,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * The value of the range slider
      */
     values: number[]

--- a/packages/machines/rating/src/rating.connect.ts
+++ b/packages/machines/rating/src/rating.connect.ts
@@ -50,6 +50,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     inputProps: normalize.input({
       "data-part": "input",
       name: state.context.name,
+      form: state.context.form,
       type: "text",
       hidden: true,
       id: dom.getInputId(state.context),

--- a/packages/machines/rating/src/rating.types.ts
+++ b/packages/machines/rating/src/rating.types.ts
@@ -32,6 +32,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * The current rating value.
      */
     value: number

--- a/packages/machines/rating/src/rating.types.ts
+++ b/packages/machines/rating/src/rating.types.ts
@@ -32,7 +32,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the rating.
      */
     form?: string
     /**

--- a/packages/machines/rating/src/rating.types.ts
+++ b/packages/machines/rating/src/rating.types.ts
@@ -32,11 +32,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
-     * The associate form of the rating.
-=======
      * The associate form of the underlying input element.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
     /**

--- a/packages/machines/slider/src/slider.connect.ts
+++ b/packages/machines/slider/src/slider.connect.ts
@@ -151,6 +151,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       type: "text",
       defaultValue: state.context.value,
       name: state.context.name,
+      form: state.context.form,
       id: dom.getInputId(state.context),
       hidden: true,
     }),

--- a/packages/machines/slider/src/slider.types.ts
+++ b/packages/machines/slider/src/slider.types.ts
@@ -26,7 +26,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the slider.
      */
     form?: string
     /**

--- a/packages/machines/slider/src/slider.types.ts
+++ b/packages/machines/slider/src/slider.types.ts
@@ -26,11 +26,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
-     * The associate form of the slider.
-=======
      * The associate form of the underlying input element.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
     /**

--- a/packages/machines/slider/src/slider.types.ts
+++ b/packages/machines/slider/src/slider.types.ts
@@ -26,6 +26,10 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
+     * The associate form of the underlying select.
+     */
+    form?: string
+    /**
      * Whether the slider is disabled
      */
     disabled?: boolean

--- a/packages/machines/tags-input/src/tags-input.connect.ts
+++ b/packages/machines/tags-input/src/tags-input.connect.ts
@@ -164,6 +164,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       type: "text",
       hidden: true,
       name: state.context.name,
+      form: state.context.form,
       id: dom.getHiddenInputId(state.context),
       defaultValue: state.context.valueAsString,
     }),

--- a/packages/machines/tags-input/src/tags-input.types.ts
+++ b/packages/machines/tags-input/src/tags-input.types.ts
@@ -131,11 +131,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-<<<<<<< HEAD
-     * The associate form of the underlying input.
-=======
      * The associate form of the underlying input element.
->>>>>>> 692f20e2b47114c2f0e0b276dad9be6a79acfd77
      */
     form?: string
   }

--- a/packages/machines/tags-input/src/tags-input.types.ts
+++ b/packages/machines/tags-input/src/tags-input.types.ts
@@ -130,6 +130,10 @@ type PublicContext = DirectionProperty &
      * The name attribute for the input. Useful for form submissions
      */
     name?: string
+    /**
+     * The associate form of the underlying select.
+     */
+    form?: string
   }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">

--- a/packages/machines/tags-input/src/tags-input.types.ts
+++ b/packages/machines/tags-input/src/tags-input.types.ts
@@ -131,7 +131,7 @@ type PublicContext = DirectionProperty &
      */
     name?: string
     /**
-     * The associate form of the underlying select.
+     * The associate form of the underlying input.
      */
     form?: string
   }


### PR DESCRIPTION
Add `form` attribute to all form related elements