### PR TITLE
fix: checkbox onChange emitted value

### DIFF
--- a/.changeset/calm-rules-worry.md
+++ b/.changeset/calm-rules-worry.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/checkbox": patch
+---
+
+Fix issue where `onChange` is called with incorrect state

--- a/.xstate/checkbox.js
+++ b/.xstate/checkbox.js
@@ -49,20 +49,20 @@ const fetchMachine = createMachine({
   },
   states: {
     checked: {
+      entry: ["invokeOnChange"],
       on: {
         TOGGLE: {
           target: "unchecked",
-          cond: "isInteractive",
-          actions: ["invokeOnChange"]
+          cond: "isInteractive"
         }
       }
     },
     unchecked: {
+      entry: ["invokeOnChange"],
       on: {
         TOGGLE: {
           target: "checked",
-          cond: "isInteractive",
-          actions: ["invokeOnChange"]
+          cond: "isInteractive"
         }
       }
     }

--- a/packages/machines/checkbox/src/checkbox.machine.ts
+++ b/packages/machines/checkbox/src/checkbox.machine.ts
@@ -63,20 +63,20 @@ export function machine(userContext: UserDefinedContext) {
 
       states: {
         checked: {
+          entry: ["invokeOnChange"],
           on: {
             TOGGLE: {
               target: "unchecked",
               guard: "isInteractive",
-              actions: ["invokeOnChange"],
             },
           },
         },
         unchecked: {
+          entry: ["invokeOnChange"],
           on: {
             TOGGLE: {
               target: "checked",
               guard: "isInteractive",
-              actions: ["invokeOnChange"],
             },
           },
         },


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

state is not updated during transition, so invokeOnChange should be called on entry.

## ⛳️ Current behavior (updates)

onChange emits `false` when value turns `false` -> `true`,
and emits `true` when value turns `true` -> `false`.

## 🚀 New behavior

onChange emits `true` when value turns `false` -> `true`,
and emits `false` when value turns `true` -> `false`.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
