### PR TITLE
fix(checkbox): use aria-readonly instead of readonly attribute

### DIFF
--- a/.changeset/clever-baboons-do.md
+++ b/.changeset/clever-baboons-do.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/checkbox": patch
+---
+
+Use aria-readonly instead of readOnly attribute. `readonly` attribute only applies to text inputs, not checkboxes and
+radios according to the [HTML spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)

--- a/e2e/checkbox.e2e.ts
+++ b/e2e/checkbox.e2e.ts
@@ -12,6 +12,12 @@ const expectToBeChecked = async (page: Page) => {
   await expect(page.locator(control)).toHaveAttribute("data-checked", "")
 }
 
+const expectNotToBeChecked = async (page: Page) => {
+  await expect(page.locator(root)).not.toHaveAttribute("data-checked", "")
+  await expect(page.locator(label)).not.toHaveAttribute("data-checked", "")
+  await expect(page.locator(control)).not.toHaveAttribute("data-checked", "")
+}
+
 test.beforeEach(async ({ page }) => {
   await page.goto("/checkbox")
 })
@@ -39,11 +45,6 @@ test("should be checked when spacebar is pressed while focused", async ({ page }
   await expectToBeChecked(page)
 })
 
-test("should have aria-checked as mixed when indeterminate ", async ({ page }) => {
-  await controls(page).bool("indeterminate")
-  await expect(page.locator(input)).toHaveAttribute("aria-checked", "mixed")
-})
-
 test("should have disabled attributes when disabled", async ({ page }) => {
   await controls(page).bool("disabled")
   await expect(page.locator(input)).toHaveAttribute("data-disabled", "")
@@ -67,5 +68,5 @@ test("should be focusable when readonly", async ({ page }) => {
 test("should not be changeable when readonly", async ({ page }) => {
   await controls(page).bool("readOnly")
   await page.click(root)
-  await expect(page.locator(input)).toHaveAttribute("aria-checked", "false")
+  await expectNotToBeChecked(page)
 })

--- a/packages/machines/checkbox/src/checkbox.connect.ts
+++ b/packages/machines/checkbox/src/checkbox.connect.ts
@@ -1,4 +1,4 @@
-import { dataAttr, visuallyHiddenStyle } from "@zag-js/dom-utils"
+import { ariaAttr, dataAttr, visuallyHiddenStyle } from "@zag-js/dom-utils"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { dom } from "./checkbox.dom"
 import type { Send, State } from "./checkbox.types"
@@ -114,7 +114,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       defaultChecked: isChecked,
       disabled: trulyDisabled,
       "data-disabled": dataAttr(isDisabled),
-      readOnly: isReadOnly,
+      "aria-readonly": ariaAttr(isReadOnly),
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledBy,
       "aria-invalid": isInvalid,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`readonly` attribute only applies to text inputs, not checkboxes and radios according to the [HTML spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)

related issue in react-aria: https://github.com/adobe/react-spectrum/issues/1413

## ⛳️ Current behavior (updates)

checkbox inputProps has unsupported attribute `readonly`.

## 🚀 New behavior

checkbox inputProps has `aria-readonly` which is allowed on checkbox role.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
