### PR TITLE
refactor(checkbox): remove unused aria-invalid property in PublicContext

### DIFF
--- a/.changeset/empty-weeks-tan.md
+++ b/.changeset/empty-weeks-tan.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/checkbox": patch
+---
+
+remove unused aria-invalid property in PublicContext

--- a/packages/machines/checkbox/src/checkbox.types.ts
+++ b/packages/machines/checkbox/src/checkbox.types.ts
@@ -68,7 +68,6 @@ type PublicContext = DirectionProperty &
      */
     "aria-label"?: string
     "aria-labelledby"?: string
-    "aria-invalid"?: boolean
     "aria-describedby"?: string
   }
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Remove unused `aria-invalid` property in PublicContext.

## ⛳️ Current behavior (updates)

`aria-invalid` property is included PublicContext, but `inputProps["aria-invalid"]` is determined from `isInvalid` and `aria-invalid` is never used in current code.

## 🚀 New behavior

`aria-invalid` property is removed from PublicContext.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
