### PR TITLE
fix(checkbox): move for to label - rootprops

### DIFF
--- a/.changeset/warm-pumas-type.md
+++ b/.changeset/warm-pumas-type.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/checkbox": patch
+---
+
+Move html `for` attribute to `rootProps` so it targets label elements.

--- a/examples/solid-ts/tsconfig.json
+++ b/examples/solid-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "node",

--- a/examples/vue-ts/tsconfig.json
+++ b/examples/vue-ts/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@vue/tsconfig/tsconfig.web.json",
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
   "compilerOptions": {
+    "strict": true,
     "baseUrl": ".",
     "paths": {
       "@zag-js/*": ["../../node_modules/@zag-js/*"]

--- a/packages/machines/checkbox/src/checkbox.connect.ts
+++ b/packages/machines/checkbox/src/checkbox.connect.ts
@@ -45,9 +45,10 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       send({ type: "SET_INDETERMINATE", value: indeterminate })
     },
 
-    rootProps: normalize.element({
+    rootProps: normalize.label({
       "data-part": "root",
       id: dom.getRootId(state.context),
+      htmlFor: dom.getInputId(state.context),
       "data-focus": dataAttr(isFocused),
       "data-disabled": dataAttr(isDisabled),
       "data-checked": dataAttr(isChecked),
@@ -75,9 +76,8 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       },
     }),
 
-    labelProps: normalize.label({
+    labelProps: normalize.element({
       "data-part": "label",
-      htmlFor: dom.getInputId(state.context),
       id: dom.getLabelId(state.context),
       "data-focus": dataAttr(isFocused),
       "data-hover": dataAttr(isHovered),


### PR DESCRIPTION
Closes #411 

Updated rootprops to always target `label` html element and hold the html `for` attribute