### PR TITLE
chore: change `values` to `value` in rangeslider

### DIFF
--- a/.changeset/curvy-frogs-swim.md
+++ b/.changeset/curvy-frogs-swim.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/range-slider": patch
+---
+
+Change `values` to `value`

--- a/.changeset/old-lies-tap.md
+++ b/.changeset/old-lies-tap.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/number-utils": patch
+---
+
+Change `values` to `value` in utils context

--- a/examples/next-ts/pages/range-slider.tsx
+++ b/examples/next-ts/pages/range-slider.tsx
@@ -14,7 +14,7 @@ export default function Page() {
     slider.machine({
       id: useId(),
       name: "quantity",
-      values: [10, 60],
+      value: [10, 60],
     }),
     { context: controls.context },
   )
@@ -34,14 +34,14 @@ export default function Page() {
           <div {...api.rootProps}>
             <div>
               <label {...api.labelProps}>Quantity:</label>
-              <output {...api.outputProps}>{api.values.join(" - ")}</output>
+              <output {...api.outputProps}>{api.value.join(" - ")}</output>
             </div>
             <div className="control-area">
               <div {...api.controlProps}>
                 <div {...api.trackProps}>
                   <div {...api.rangeProps} />
                 </div>
-                {api.values.map((_, index) => (
+                {api.value.map((_, index) => (
                   <div key={index} {...api.getThumbProps(index)}>
                     <input {...api.getInputProps(index)} />
                   </div>

--- a/examples/solid-ts/src/pages/range-slider.tsx
+++ b/examples/solid-ts/src/pages/range-slider.tsx
@@ -14,7 +14,7 @@ export default function Page() {
     slider.machine({
       id: createUniqueId(),
       name: "quantity",
-      values: [10, 60],
+      value: [10, 60],
     }),
     { context: controls.context as any },
   )
@@ -34,14 +34,14 @@ export default function Page() {
           <div {...api().rootProps}>
             <div>
               <label {...api().labelProps}>Quantity:</label>
-              <output {...api().outputProps}>{api().values.join(" - ")}</output>
+              <output {...api().outputProps}>{api().value.join(" - ")}</output>
             </div>
             <div class="control-area">
               <div {...api().controlProps}>
                 <div {...api().trackProps}>
                   <div {...api().rangeProps} />
                 </div>
-                <For each={api().values}>
+                <For each={api().value}>
                   {(_, index) => (
                     <div class="slider__thumb" {...api().getThumbProps(index())}>
                       <input {...api().getInputProps(index())} />

--- a/examples/vue-ts/src/pages/range-slider.tsx
+++ b/examples/vue-ts/src/pages/range-slider.tsx
@@ -17,7 +17,7 @@ export default defineComponent({
       slider.machine({
         id: "range-slider",
         name: "quantity",
-        values: [10, 60],
+        value: [10, 60],
       }),
       { context: controls.context },
     )
@@ -40,14 +40,14 @@ export default defineComponent({
               <div {...api.rootProps}>
                 <div>
                   <label {...api.labelProps}>Quantity:</label>
-                  <output {...api.outputProps}>{api.values.join(" - ")}</output>
+                  <output {...api.outputProps}>{api.value.join(" - ")}</output>
                 </div>
                 <div class="control-area">
                   <div {...api.controlProps}>
                     <div {...api.trackProps}>
                       <div {...api.rangeProps} />
                     </div>
-                    {api.values.map((_, index) => (
+                    {api.value.map((_, index) => (
                       <div key={index} {...api.getThumbProps(index)}>
                         <input {...api.getInputProps(index)} />
                       </div>

--- a/packages/machines/range-slider/src/range-slider.connect.ts
+++ b/packages/machines/range-slider/src/range-slider.connect.ts
@@ -17,7 +17,7 @@ import { utils } from "./range-slider.utils"
 export function connect<T extends PropTypes>(state: State, send: Send, normalize: NormalizeProps<T>) {
   const ariaLabel = state.context["aria-label"]
   const ariaLabelledBy = state.context["aria-labelledby"]
-  const values = state.context.values
+  const sliderValue = state.context.value
 
   const isFocused = state.matches("focus")
   const isDragging = state.matches("dragging")
@@ -27,20 +27,20 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
   const isInteractive = state.context.isInteractive
 
   return {
-    values: state.context.values,
+    value: state.context.value,
     isDragging,
     isFocused,
-    setValue(values: number[]) {
-      send({ type: "SET_VALUE", value: values })
+    setValue(value: number[]) {
+      send({ type: "SET_VALUE", value: value })
     },
     getThumbValue(index: number) {
-      return values[index]
+      return sliderValue[index]
     },
     setThumbValue(index: number, value: number) {
       send({ type: "SET_VALUE", index, value })
     },
     getThumbPercent(index: number) {
-      return valueToPercent(values[index], state.context)
+      return valueToPercent(sliderValue[index], state.context)
     },
     setThumbPercent(index: number, percent: number) {
       const value = percentToValue(percent, state.context)
@@ -98,7 +98,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       "data-disabled": dataAttr(isDisabled),
       "data-invalid": dataAttr(isInvalid),
       id: dom.getOutputId(state.context),
-      htmlFor: values.map((_v, i) => dom.getInputId(state.context, i)).join(" "),
+      htmlFor: sliderValue.map((_v, i) => dom.getInputId(state.context, i)).join(" "),
       "aria-live": "off",
     }),
 
@@ -113,7 +113,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     }),
 
     getThumbProps(index: number) {
-      const value = values[index]
+      const value = sliderValue[index]
       const range = toRanges(state.context)[index]
       const ariaValueText = state.context.getAriaValueText?.(value, index)
       const _ariaLabel = Array.isArray(ariaLabel) ? ariaLabel[index] : ariaLabel
@@ -133,7 +133,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         "aria-orientation": state.context.orientation,
         "aria-valuemax": range.max,
         "aria-valuemin": range.min,
-        "aria-valuenow": values[index],
+        "aria-valuenow": sliderValue[index],
         "aria-valuetext": ariaValueText,
         role: "slider",
         tabIndex: isDisabled ? undefined : 0,
@@ -202,7 +202,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         form: state.context.form,
         type: "text",
         hidden: true,
-        defaultValue: state.context.values[index],
+        defaultValue: state.context.value[index],
         id: dom.getInputId(state.context, index),
       })
     },
@@ -251,9 +251,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       const style = dom.getMarkerStyle(state.context, percent)
       let markerState: "over-value" | "under-value" | "at-value"
 
-      if (Math.max(...state.context.values) < value) {
+      if (Math.max(...state.context.value) < value) {
         markerState = "over-value"
-      } else if (Math.min(...state.context.values) > value) {
+      } else if (Math.min(...state.context.value) > value) {
         markerState = "under-value"
       } else {
         markerState = "at-value"

--- a/packages/machines/range-slider/src/range-slider.dom.ts
+++ b/packages/machines/range-slider/src/range-slider.dom.ts
@@ -53,8 +53,8 @@ export const dom = defineDomHelpers({
 
   getValueFromPoint,
   dispatchChangeEvent(ctx: Ctx) {
-    const valuesArray = Array.from(ctx.values)
-    valuesArray.forEach((value, index) => {
+    const valueArray = Array.from(ctx.value)
+    valueArray.forEach((value, index) => {
       const input = dom.getInputEl(ctx, index)
       if (!input) return
       dispatchInputValueEvent(input, value)
@@ -92,8 +92,8 @@ export function getClosestIndex(ctx: Ctx, evt: StateMachine.AnyEventObject) {
 
   const isThumbStacked = new Set(axisPoints).size !== points.length
 
-  if (isThumbStacked && point > ctx.values[index]) {
-    index = clamp(index + 1, { min: 0, max: ctx.values.length - 1 })
+  if (isThumbStacked && point > ctx.value[index]) {
+    index = clamp(index + 1, { min: 0, max: ctx.value.length - 1 })
   }
 
   return index

--- a/packages/machines/range-slider/src/range-slider.machine.ts
+++ b/packages/machines/range-slider/src/range-slider.machine.ts
@@ -22,7 +22,7 @@ export function machine(userContext: UserDefinedContext) {
         min: 0,
         max: 100,
         step: 1,
-        values: [0, 100],
+        value: [0, 100],
         initialValues: [],
         orientation: "horizontal",
         dir: "ltr",
@@ -40,7 +40,7 @@ export function machine(userContext: UserDefinedContext) {
       },
 
       watch: {
-        values: ["invokeOnChange", "dispatchChangeEvent"],
+        value: ["invokeOnChange", "dispatchChangeEvent"],
       },
 
       activities: ["trackFormControlState", "trackThumbsSize"],
@@ -148,9 +148,9 @@ export function machine(userContext: UserDefinedContext) {
             onFormReset() {
               if (!ctx.name) return
 
-              ctx.values.forEach((_value, index) => {
+              ctx.value.forEach((_value, index) => {
                 if (ctx.initialValues[index] != null) {
-                  ctx.values[index] = ctx.initialValues[index]
+                  ctx.value[index] = ctx.initialValues[index]
                 }
               })
             },
@@ -184,14 +184,14 @@ export function machine(userContext: UserDefinedContext) {
       },
       actions: {
         invokeOnChangeStart(ctx) {
-          ctx.onChangeStart?.({ value: ctx.values })
+          ctx.onChangeStart?.({ value: ctx.value })
         },
         invokeOnChangeEnd(ctx) {
-          ctx.onChangeEnd?.({ value: ctx.values })
+          ctx.onChangeEnd?.({ value: ctx.value })
         },
         invokeOnChange(ctx, evt) {
           if (evt.type !== "SETUP") {
-            ctx.onChange?.({ value: ctx.values })
+            ctx.onChange?.({ value: ctx.value })
           }
         },
         dispatchChangeEvent(ctx, evt) {
@@ -210,7 +210,7 @@ export function machine(userContext: UserDefinedContext) {
         setPointerValue(ctx, evt) {
           const value = dom.getValueFromPoint(ctx, evt.point)
           if (value == null) return
-          ctx.values[ctx.activeIndex] = utils.convert(ctx, value, ctx.activeIndex)
+          ctx.value[ctx.activeIndex] = utils.convert(ctx, value, ctx.activeIndex)
         },
         focusActiveThumb(ctx) {
           raf(() => {
@@ -219,34 +219,34 @@ export function machine(userContext: UserDefinedContext) {
           })
         },
         decrementAtIndex(ctx, evt) {
-          ctx.values[ctx.activeIndex] = utils.decrement(ctx, evt.index, evt.step)
+          ctx.value[ctx.activeIndex] = utils.decrement(ctx, evt.index, evt.step)
         },
         incrementAtIndex(ctx, evt) {
-          ctx.values[ctx.activeIndex] = utils.increment(ctx, evt.index, evt.step)
+          ctx.value[ctx.activeIndex] = utils.increment(ctx, evt.index, evt.step)
         },
         setActiveThumbToMin(ctx) {
           const { min } = utils.getRangeAtIndex(ctx, ctx.activeIndex)
-          ctx.values[ctx.activeIndex] = min
+          ctx.value[ctx.activeIndex] = min
         },
         setActiveThumbToMax(ctx) {
           const { max } = utils.getRangeAtIndex(ctx, ctx.activeIndex)
-          ctx.values[ctx.activeIndex] = max
+          ctx.value[ctx.activeIndex] = max
         },
         checkValue(ctx) {
-          let values = utils.check(ctx, ctx.values)
-          ctx.values = values
-          ctx.initialValues = values.slice()
+          let value = utils.check(ctx, ctx.value)
+          ctx.value = value
+          ctx.initialValues = value.slice()
         },
         setValue(ctx, evt) {
           // set value at specified index
           if (typeof evt.index === "number" && typeof evt.value === "number") {
-            ctx.values[evt.index] = utils.convert(ctx, evt.value, evt.index)
+            ctx.value[evt.index] = utils.convert(ctx, evt.value, evt.index)
             return
           }
 
           // set values
           if (Array.isArray(evt.value)) {
-            ctx.values = utils.check(ctx, evt.value)
+            ctx.value = utils.check(ctx, evt.value)
           }
         },
       },

--- a/packages/machines/range-slider/src/range-slider.style.ts
+++ b/packages/machines/range-slider/src/range-slider.style.ts
@@ -7,8 +7,8 @@ import type { MachineContext as Ctx } from "./range-slider.types"
  * -----------------------------------------------------------------------------*/
 
 export function getRangeOffsets(ctx: Ctx) {
-  let start = (ctx.values[0] / ctx.max) * 100
-  let end = 100 - (ctx.values[ctx.values.length - 1] / ctx.max) * 100
+  let start = (ctx.value[0] / ctx.max) * 100
+  let end = 100 - (ctx.value[ctx.value.length - 1] / ctx.max) * 100
   return { start: `${start}%`, end: `${end}%` }
 }
 
@@ -33,7 +33,7 @@ function getThumbStyle(ctx: Ctx, index: number): Style {
 function getRootStyle(ctx: Ctx): Style {
   const range = getRangeOffsets(ctx)
 
-  const offsetStyles = ctx.values.reduce<Style>((styles, value, index) => {
+  const offsetStyles = ctx.value.reduce<Style>((styles, value, index) => {
     const thumbSize = ctx.thumbSizes[index] ?? { width: 0, height: 0 }
     const offset = sliderDom.getThumbOffset({ ...ctx, value, thumbSize })
     return { ...styles, [`--slider-thumb-offset-${index}`]: offset }

--- a/packages/machines/range-slider/src/range-slider.types.ts
+++ b/packages/machines/range-slider/src/range-slider.types.ts
@@ -36,7 +36,7 @@ type PublicContext = DirectionProperty &
     /**
      * The value of the range slider
      */
-    values: number[]
+    value: number[]
     /**
      * Whether the slider is disabled
      */

--- a/packages/machines/range-slider/src/range-slider.utils.ts
+++ b/packages/machines/range-slider/src/range-slider.utils.ts
@@ -2,9 +2,9 @@ import { clamp, decrement, increment, percentToValue, snapToStep, toRanges } fro
 import type { MachineContext as Ctx } from "./range-slider.types"
 
 export const utils = {
-  check(ctx: Ctx, values: number[]) {
-    return values.map((value, index, _values) => {
-      return utils.convert({ ...ctx, values: _values }, value, index)
+  check(ctx: Ctx, value: number[]) {
+    return value.map((value, index, _value) => {
+      return utils.convert({ ...ctx, value: _value }, value, index)
     })
   },
   clampPercent(value: number) {

--- a/packages/utilities/number/src/transform.ts
+++ b/packages/utilities/number/src/transform.ts
@@ -12,11 +12,11 @@ export const transform = (a: [number, number], b: [number, number]) => {
   }
 }
 
-export function toRanges(o: Num<"min" | "max"> & { values: number[]; spacing: number }) {
+export function toRanges(o: Num<"min" | "max"> & { value: number[]; spacing: number }) {
   const spacing = o.spacing ?? 0
-  return o.values.map((v, i) => {
-    const min = i === 0 ? o.min : o.values[i - 1] + spacing
-    const max = i === o.values.length - 1 ? o.max : o.values[i + 1] - spacing
+  return o.value.map((v, i) => {
+    const min = i === 0 ? o.min : o.value[i - 1] + spacing
+    const max = i === o.value.length - 1 ? o.max : o.value[i + 1] - spacing
     return { min, max, value: v }
   })
 }


### PR DESCRIPTION
change `values` to `value` in rangeslider