### PR TITLE
fix: accordion infinite loop

### DIFF
--- a/.changeset/slow-pugs-reflect.md
+++ b/.changeset/slow-pugs-reflect.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/accordion": patch
+---
+
+Fix issue where value was reset infinitely when `value: []` and `multiple: false` is passed to machine context.

--- a/.xstate/accordion.js
+++ b/.xstate/accordion.js
@@ -18,7 +18,7 @@ const fetchMachine = createMachine({
   },
   on: {
     SET_VALUE: {
-      actions: "setValue"
+      actions: ["setValue", "invokeOnChange"]
     }
   },
   on: {
@@ -50,10 +50,10 @@ const fetchMachine = createMachine({
         },
         CLICK: [{
           cond: "isExpanded && canToggle",
-          actions: "collapse"
+          actions: ["collapse", "invokeOnChange"]
         }, {
           cond: "!isExpanded",
-          actions: "expand"
+          actions: ["expand", "invokeOnChange"]
         }],
         HOME: {
           actions: "focusFirst"


### PR DESCRIPTION
Closes OSS-489

## 📝 Description

Fix the issue where the value was reset infinitely when `value: []` and `multiple: false` is passed to the machine context.

## ⛳️ Current behavior (updates)

Infinite loop

## 🚀 New behavior

Works

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
