### PR TITLE
Refactor slider calculations

### DIFF
--- a/.changeset/poor-dryers-hug.md
+++ b/.changeset/poor-dryers-hug.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/dom-utils": patch
+---
+
+- Fix issue where `requestPointerLock` could throw in a sandbox environment
+- Remove unused `createEmitter` and `createListener`

--- a/.changeset/rude-cycles-clean.md
+++ b/.changeset/rude-cycles-clean.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/numeric-range": minor
+---
+
+Initial release

--- a/.changeset/serious-impalas-look.md
+++ b/.changeset/serious-impalas-look.md
@@ -3,5 +3,5 @@
 "@zag-js/slider": patch
 ---
 
-- Redesiged style calculations for consistency
-- Fixed issue where thumb cannot go back to original position when `min` is greater than `0`
+- Redesigned style calculations for consistency
+- Fixed issue where the thumb cannot go back to its original position when `min` is greater than `0`

--- a/.changeset/serious-impalas-look.md
+++ b/.changeset/serious-impalas-look.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/range-slider": patch
+"@zag-js/slider": patch
+---
+
+- Redesiged style calculations for consistency
+- Fixed issue where thumb cannot go back to original position when `min` is greater than `0`

--- a/.xstate/range-slider.js
+++ b/.xstate/range-slider.js
@@ -48,7 +48,7 @@ const fetchMachine = createMachine({
       on: {
         POINTER_DOWN: {
           target: "dragging",
-          actions: ["setActiveIndex", "invokeOnChangeStart", "setPointerValue", "focusActiveThumb"]
+          actions: ["setActiveIndex", "setPointerValue", "invokeOnChangeStart", "focusActiveThumb"]
         },
         FOCUS: {
           target: "focus",
@@ -61,7 +61,7 @@ const fetchMachine = createMachine({
       on: {
         POINTER_DOWN: {
           target: "dragging",
-          actions: ["setActiveIndex", "invokeOnChangeStart", "setPointerValue", "focusActiveThumb"]
+          actions: ["setActiveIndex", "setPointerValue", "invokeOnChangeStart", "focusActiveThumb"]
         },
         ARROW_LEFT: {
           cond: "isHorizontal",

--- a/examples/next-ts/package.json
+++ b/examples/next-ts/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@zag-js/accordion": "workspace:*",
+    "@zag-js/anatomy": "workspace:*",
     "@zag-js/aria-hidden": "workspace:*",
     "@zag-js/auto-resize": "workspace:*",
     "@zag-js/checkbox": "workspace:*",
@@ -32,6 +33,7 @@
     "@zag-js/menu": "workspace:*",
     "@zag-js/number-input": "workspace:*",
     "@zag-js/number-utils": "workspace:*",
+    "@zag-js/numeric-range": "workspace:*",
     "@zag-js/pagination": "workspace:*",
     "@zag-js/pin-input": "workspace:*",
     "@zag-js/popover": "workspace:*",

--- a/examples/next-ts/pages/range-slider.tsx
+++ b/examples/next-ts/pages/range-slider.tsx
@@ -14,7 +14,7 @@ export default function Page() {
     slider.machine({
       id: useId(),
       name: "quantity",
-      value: [10, 60],
+      value: [30, 60],
     }),
     { context: controls.context },
   )

--- a/examples/solid-ts/package.json
+++ b/examples/solid-ts/package.json
@@ -40,6 +40,7 @@
     "@zag-js/menu": "workspace:*",
     "@zag-js/number-input": "workspace:*",
     "@zag-js/number-utils": "workspace:*",
+    "@zag-js/numeric-range": "workspace:*",
     "@zag-js/pagination": "workspace:*",
     "@zag-js/pin-input": "workspace:*",
     "@zag-js/popover": "workspace:*",

--- a/examples/vue-ts/package.json
+++ b/examples/vue-ts/package.json
@@ -33,6 +33,7 @@
     "@zag-js/menu": "workspace:*",
     "@zag-js/number-input": "workspace:*",
     "@zag-js/number-utils": "workspace:*",
+    "@zag-js/numeric-range": "workspace:*",
     "@zag-js/pagination": "workspace:*",
     "@zag-js/pin-input": "workspace:*",
     "@zag-js/popover": "workspace:*",

--- a/packages/machines/range-slider/package.json
+++ b/packages/machines/range-slider/package.json
@@ -28,16 +28,15 @@
   "dependencies": {
     "@zag-js/anatomy": "workspace:*",
     "@zag-js/core": "workspace:*",
+    "@zag-js/form-utils": "workspace:*",
+    "@zag-js/numeric-range": "workspace:*",
     "@zag-js/element-size": "workspace:*",
     "@zag-js/slider": "workspace:*",
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
     "@zag-js/dom-utils": "workspace:*",
-    "@zag-js/form-utils": "workspace:*",
-    "@zag-js/number-utils": "workspace:*",
     "@zag-js/utils": "workspace:*",
-    "@zag-js/rect-utils": "workspace:*",
     "clean-package": "2.2.0"
   },
   "scripts": {

--- a/packages/machines/range-slider/src/range-slider.style.ts
+++ b/packages/machines/range-slider/src/range-slider.style.ts
@@ -6,20 +6,33 @@ import type { MachineContext as Ctx } from "./range-slider.types"
  * Range style calculations
  * -----------------------------------------------------------------------------*/
 
+function getBounds<T>(value: T[]): [T, T] {
+  const firstValue = value[0]
+  const lastThumb = value[value.length - 1]
+  return [firstValue, lastThumb]
+}
+
 export function getRangeOffsets(ctx: Ctx) {
-  let start = ((ctx.value[0] - ctx.min) / (ctx.max - ctx.min)) * 100
-  let end = 100 - (ctx.value[ctx.value.length - 1] / ctx.max) * 100
-  return { start: `${start}%`, end: `${end}%` }
+  const [firstPercent, lastPercent] = getBounds(ctx.valuePercent)
+  return { start: `${firstPercent}%`, end: `${100 - lastPercent}%` }
 }
 
 /* -----------------------------------------------------------------------------
  * Thumb style calculations
  * -----------------------------------------------------------------------------*/
 
+function getVisibility(ctx: Ctx) {
+  let visibility: "visible" | "hidden" = "visible"
+  if (ctx.thumbAlignment === "contain" && !ctx.hasMeasuredThumbSize) {
+    visibility = "hidden"
+  }
+  return visibility
+}
+
 function getThumbStyle(ctx: Ctx, index: number): Style {
   const placementProp = ctx.isVertical ? "bottom" : ctx.isRtl ? "right" : "left"
   return {
-    visibility: ctx.hasMeasuredThumbSize ? "visible" : "hidden",
+    visibility: getVisibility(ctx),
     position: "absolute",
     transform: "var(--slider-thumb-transform)",
     [placementProp]: `var(--slider-thumb-offset-${index})`,

--- a/packages/machines/range-slider/src/range-slider.types.ts
+++ b/packages/machines/range-slider/src/range-slider.types.ts
@@ -126,6 +126,11 @@ type ComputedContext = Readonly<{
    * Whether the slider is in RTL mode
    */
   readonly isRtl: boolean
+  /**
+   * @computed
+   * The percentage of the slider value relative to the slider min/max
+   */
+  readonly valuePercent: number[]
 }>
 
 type PrivateContext = Context<{

--- a/packages/machines/range-slider/src/range-slider.utils.ts
+++ b/packages/machines/range-slider/src/range-slider.utils.ts
@@ -1,43 +1,53 @@
-import { clamp, decrement, increment, percentToValue, snapToStep, toRanges } from "@zag-js/number-utils"
+import {
+  clampValue,
+  getClosestValueIndex,
+  getNextStepValue,
+  getPreviousStepValue,
+  getValueRanges,
+  snapValueToStep,
+} from "@zag-js/numeric-range"
 import type { MachineContext as Ctx } from "./range-slider.types"
 
-export const utils = {
-  check(ctx: Ctx, value: number[]) {
-    return value.map((value, index, _value) => {
-      return utils.convert({ ...ctx, value: _value }, value, index)
-    })
-  },
-  clampPercent(value: number) {
-    return clamp(value, { min: 0, max: 1 })
-  },
-  getRangeAtIndex(ctx: Ctx, index: number) {
-    return toRanges(ctx)[index]
-  },
-  fromPercent(ctx: Ctx, percent: number) {
-    const range = utils.getRangeAtIndex(ctx, ctx.activeIndex)
+export function normalizeValues(ctx: Ctx, _values: number[]) {
+  return _values.map((value, index, values) => {
+    return constrainValue({ ...ctx, value: values }, value, index)
+  })
+}
 
-    const maxPercent = range.max / ctx.max
-    const minPercent = range.min / ctx.max
+export function clampPercent(percent: number) {
+  return clampValue(percent, 0, 1)
+}
 
-    percent = clamp(percent, { min: minPercent, max: maxPercent })
-    const value = percentToValue(percent, ctx)
+export function getRangeAtIndex(ctx: Ctx, index: number) {
+  return getValueRanges(ctx.value, ctx.min, ctx.max, ctx.minStepsBetweenThumbs)[index]
+}
 
-    return parseFloat(snapToStep(value, ctx.step))
-  },
-  convert(ctx: Ctx, value: number, index: number) {
-    const range = utils.getRangeAtIndex(ctx, index)
-    return clamp(snapToStep(value, ctx.step), range)
-  },
-  decrement(ctx: Ctx, idx?: number, step?: number) {
-    const index = idx ?? ctx.activeIndex
-    const range = utils.getRangeAtIndex(ctx, index)
-    let value = decrement(range.value, step ?? ctx.step)
-    return utils.convert(ctx, value, index)
-  },
-  increment(ctx: Ctx, idx?: number, step?: number) {
-    const index = idx ?? ctx.activeIndex
-    const range = utils.getRangeAtIndex(ctx, index)
-    let value = increment(range.value, step ?? ctx.step)
-    return utils.convert(ctx, value, index)
-  },
+export function constrainValue(ctx: Ctx, value: number, index: number) {
+  const range = getRangeAtIndex(ctx, index)
+  const snapValue = snapValueToStep(value, ctx.min, ctx.max, ctx.step)
+  return clampValue(snapValue, range.min, range.max)
+}
+
+export function decrement(ctx: Ctx, index?: number, step?: number) {
+  const idx = index ?? ctx.activeIndex
+  const range = getRangeAtIndex(ctx, idx)
+  return getPreviousStepValue(idx, {
+    ...range,
+    step: step ?? ctx.step,
+    values: ctx.value,
+  })
+}
+
+export function increment(ctx: Ctx, index?: number, step?: number) {
+  const idx = index ?? ctx.activeIndex
+  const range = getRangeAtIndex(ctx, idx)
+  return getNextStepValue(idx, {
+    ...range,
+    step: step ?? ctx.step,
+    values: ctx.value,
+  })
+}
+
+export function getClosestIndex(ctx: Ctx, pointValue: number) {
+  return getClosestValueIndex(ctx.value, pointValue)
 }

--- a/packages/machines/slider/package.json
+++ b/packages/machines/slider/package.json
@@ -29,13 +29,13 @@
     "@zag-js/anatomy": "workspace:*",
     "@zag-js/core": "workspace:*",
     "@zag-js/element-size": "workspace:*",
+    "@zag-js/numeric-range": "workspace:*",
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {
     "@zag-js/dom-utils": "workspace:*",
     "@zag-js/form-utils": "workspace:*",
     "@zag-js/utils": "workspace:*",
-    "@zag-js/number-utils": "workspace:*",
     "clean-package": "2.2.0"
   },
   "scripts": {

--- a/packages/machines/slider/src/slider.connect.ts
+++ b/packages/machines/slider/src/slider.connect.ts
@@ -8,7 +8,7 @@ import {
   isLeftClick,
   isModifiedEvent,
 } from "@zag-js/dom-utils"
-import { percentToValue, valueToPercent } from "@zag-js/number-utils"
+import { getPercentValue, getValuePercent } from "@zag-js/numeric-range"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { parts } from "./slider.anatomy"
 import { dom } from "./slider.dom"
@@ -29,12 +29,15 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     isFocused,
     isDragging,
     value: state.context.value,
-    percent: valueToPercent(state.context.value, state.context),
+    percent: getValuePercent(state.context.value, state.context.min, state.context.max),
     setValue(value: number) {
       send({ type: "SET_VALUE", value })
     },
     getPercentValue(percent: number) {
-      return percentToValue(percent, state.context)
+      return getPercentValue(percent, state.context.min, state.context.max, state.context.step)
+    },
+    getValuePercent(value: number) {
+      return getValuePercent(value, state.context.min, state.context.max)
     },
     focus() {
       dom.getThumbEl(state.context)?.focus()
@@ -217,7 +220,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     }),
 
     getMarkerProps({ value }: { value: number }) {
-      const percent = valueToPercent(value, state.context)
+      const percent = this.getValuePercent(value)
       const style = dom.getMarkerStyle(state.context, percent)
       const markerState =
         value > state.context.value ? "over-value" : value < state.context.value ? "under-value" : "at-value"

--- a/packages/machines/slider/src/slider.dom.ts
+++ b/packages/machines/slider/src/slider.dom.ts
@@ -1,8 +1,8 @@
-import { getPointRelativeToNode, defineDomHelpers } from "@zag-js/dom-utils"
+import { defineDomHelpers, getPointRelativeToNode } from "@zag-js/dom-utils"
 import { dispatchInputValueEvent } from "@zag-js/form-utils"
+import { getPercentValue } from "@zag-js/numeric-range"
 import { styles } from "./slider.style"
 import type { MachineContext as Ctx, Point } from "./slider.types"
-import { utils } from "./slider.utils"
 
 export const dom = defineDomHelpers({
   ...styles,
@@ -41,7 +41,7 @@ export const dom = defineDomHelpers({
       percent = 1 - percentY
     }
 
-    return utils.fromPercent(ctx, percent)
+    return getPercentValue(percent, ctx.min, ctx.max, ctx.step)
   },
 
   dispatchChangeEvent(ctx: Ctx) {

--- a/packages/machines/slider/src/slider.style.ts
+++ b/packages/machines/slider/src/slider.style.ts
@@ -1,4 +1,4 @@
-import { transform, valueToPercent } from "@zag-js/number-utils"
+import { getValuePercent, getValueTransformer } from "@zag-js/numeric-range"
 import type { Style } from "@zag-js/types"
 import type { MachineContext as Ctx, SharedContext } from "./slider.types"
 
@@ -8,7 +8,7 @@ import type { MachineContext as Ctx, SharedContext } from "./slider.types"
 
 function getVerticalThumbOffset(ctx: SharedContext) {
   const { height = 0 } = ctx.thumbSize ?? {}
-  const getValue = transform([ctx.min, ctx.max], [-height / 2, height / 2])
+  const getValue = getValueTransformer([ctx.min, ctx.max], [-height / 2, height / 2])
   return parseFloat(getValue(ctx.value).toFixed(2))
 }
 
@@ -16,17 +16,21 @@ function getHorizontalThumbOffset(ctx: SharedContext) {
   const { width = 0 } = ctx.thumbSize ?? {}
 
   if (ctx.isRtl) {
-    const getValue = transform([ctx.max, ctx.min], [-width * 1.5, -width / 2])
+    const getValue = getValueTransformer([ctx.max, ctx.min], [-width * 1.5, -width / 2])
     return -1 * parseFloat(getValue(ctx.value).toFixed(2))
   }
 
-  const getValue = transform([ctx.min, ctx.max], [-width / 2, width / 2])
+  const getValue = getValueTransformer([ctx.min, ctx.max], [-width / 2, width / 2])
   return parseFloat(getValue(ctx.value).toFixed(2))
 }
 
 function getThumbOffset(ctx: SharedContext) {
-  const percent = valueToPercent(ctx.value, ctx)
-  if (ctx.thumbAlignment === "center") return `${percent}%`
+  const percent = getValuePercent(ctx.value, ctx.min, ctx.max) * 100
+
+  if (ctx.thumbAlignment === "center") {
+    return `${percent}%`
+  }
+
   const offset = ctx.isVertical ? getVerticalThumbOffset(ctx) : getHorizontalThumbOffset(ctx)
   return `calc(${percent}% - ${offset}px)`
 }
@@ -46,14 +50,12 @@ function getThumbStyle(ctx: SharedContext): Style {
  * -----------------------------------------------------------------------------*/
 
 function getRangeOffsets(ctx: Ctx) {
-  const percent = valueToPercent(ctx.value, ctx)
-
   let start = "0%"
-  let end = `${100 - percent}%`
+  let end = `${100 - ctx.valuePercent}%`
 
   if (ctx.origin === "center") {
-    const isNegative = percent < 50
-    start = isNegative ? `${percent}%` : "50%"
+    const isNegative = ctx.valuePercent < 50
+    start = isNegative ? `${ctx.valuePercent}%` : "50%"
     end = isNegative ? "50%" : end
   }
 
@@ -110,7 +112,7 @@ function getMarkerStyle(ctx: Pick<SharedContext, "isHorizontal" | "isRtl">, perc
   return {
     position: "absolute",
     pointerEvents: "none",
-    [ctx.isHorizontal ? "left" : "bottom"]: `${ctx.isRtl ? 100 - percent : percent}%`,
+    [ctx.isHorizontal ? "left" : "bottom"]: `${(ctx.isRtl ? 1 - percent : percent) * 100}%`,
   }
 }
 

--- a/packages/machines/slider/src/slider.types.ts
+++ b/packages/machines/slider/src/slider.types.ts
@@ -126,6 +126,11 @@ type ComputedContext = Readonly<{
    * Whether the slider is in RTL mode
    */
   readonly isRtl: boolean
+  /**
+   * @computed
+   * The value of the slider as a percentage
+   */
+  readonly valuePercent: number
 }>
 
 type PrivateContext = Context<{

--- a/packages/machines/slider/src/slider.utils.ts
+++ b/packages/machines/slider/src/slider.utils.ts
@@ -1,23 +1,31 @@
-import { clamp, decrement, increment, percentToValue, snapToStep } from "@zag-js/number-utils"
+import { clampValue, getNextStepValue, getPreviousStepValue, snapValueToStep } from "@zag-js/numeric-range"
 import type { MachineContext as Ctx } from "./slider.types"
 
-export const utils = {
-  fromPercent(ctx: Ctx, percent: number) {
-    percent = clamp(percent, { min: 0, max: 1 })
-    return parseFloat(snapToStep(percentToValue(percent, ctx), ctx.step))
-  },
-  clamp(ctx: Ctx, value: number) {
-    return clamp(value, ctx)
-  },
-  convert(ctx: Ctx, value: number) {
-    return clamp(parseFloat(snapToStep(value, ctx.step)), ctx)
-  },
-  decrement(ctx: Ctx, step?: number) {
-    let value = decrement(ctx.value, step ?? ctx.step)
-    return utils.convert(ctx, value)
-  },
-  increment(ctx: Ctx, step?: number) {
-    let value = increment(ctx.value, step ?? ctx.step)
-    return utils.convert(ctx, value)
-  },
+export function clampPercent(percent: number) {
+  return clampValue(percent, 0, 1)
+}
+
+export function constrainValue(ctx: Ctx, value: number) {
+  const snapValue = snapValueToStep(value, ctx.min, ctx.max, ctx.step)
+  return clampValue(snapValue, ctx.min, ctx.max)
+}
+
+export function decrement(ctx: Ctx, step?: number) {
+  const index = 0
+  const values = getPreviousStepValue(index, {
+    ...ctx,
+    step: step ?? ctx.step,
+    values: [ctx.value],
+  })
+  return values[index]
+}
+
+export function increment(ctx: Ctx, step?: number) {
+  const index = 0
+  const values = getNextStepValue(index, {
+    ...ctx,
+    step: step ?? ctx.step,
+    values: [ctx.value],
+  })
+  return values[index]
 }

--- a/packages/utilities/dom/src/get-point-relative-to-element.ts
+++ b/packages/utilities/dom/src/get-point-relative-to-element.ts
@@ -12,9 +12,9 @@ export function getPointRelativeToNode(point: Point, element: HTMLElement) {
 const clampPercent = (value: number) => Math.max(0, Math.min(100, value))
 
 export function getPointPercentRelativeToNode(point: Point, element: HTMLElement) {
-  const pt = getPointRelativeToNode(point, element)
-  const x = (pt.x / element.offsetWidth) * 100
-  const y = (pt.y / element.offsetHeight) * 100
+  const relativePoint = getPointRelativeToNode(point, element)
+  const x = (relativePoint.x / element.offsetWidth) * 100
+  const y = (relativePoint.y / element.offsetHeight) * 100
   return { x: clampPercent(x), y: clampPercent(y) }
 }
 

--- a/packages/utilities/dom/src/pointerlock.ts
+++ b/packages/utilities/dom/src/pointerlock.ts
@@ -41,7 +41,9 @@ export function requestPointerLock(doc: Document, handlers: PointerLockHandlers 
 
   if (!supported) return
 
-  body.requestPointerLock()
+  try {
+    body.requestPointerLock()
+  } catch {}
 
   const cleanup = callAll(
     addPointerlockChangeListener(doc, onPointerChange),

--- a/packages/utilities/dom/src/query.ts
+++ b/packages/utilities/dom/src/query.ts
@@ -87,24 +87,6 @@ export function defineDomHelpers<T>(helpers: T) {
     getWin: (ctx: Ctx) => dom.getDoc(ctx).defaultView ?? window,
     getActiveElement: (ctx: Ctx) => dom.getDoc(ctx).activeElement as HTMLElement | null,
     getById: <T = HTMLElement>(ctx: Ctx, id: string) => dom.getRootNode(ctx).getElementById(id) as T | null,
-    createEmitter: (ctx: Ctx, target: HTMLElement) => {
-      const win = dom.getWin(ctx)
-      return function emit(evt: string, detail: Record<string, any>, options?: EventInit) {
-        const { bubbles = true, cancelable, composed = true } = options ?? {}
-        const eventName = `zag:${evt}`
-        const init: CustomEventInit = { bubbles, cancelable, composed, detail }
-        const event = new win.CustomEvent(eventName, init)
-        target.dispatchEvent(event)
-      }
-    },
-    createListener: (target: HTMLElement) => {
-      return function listen<T = any>(evt: string, handler: (e: CustomEvent<T>) => void) {
-        const eventName = `zag:${evt}`
-        const listener: any = (e: CustomEvent) => handler(e)
-        target.addEventListener(eventName, listener)
-        return () => target.removeEventListener(eventName, listener)
-      }
-    },
   }
 
   return {

--- a/packages/utilities/numeric-range/README.md
+++ b/packages/utilities/numeric-range/README.md
@@ -1,0 +1,22 @@
+# @zag-js/numeric-range
+
+Numeric range utilities
+
+## Installation
+
+```sh
+yarn add  @zag-js/numeric-range
+# or
+npm i  @zag-js/numeric-range
+```
+
+## Contribution
+
+Yes please! See the
+[contributing guidelines](https://github.com/chakra-ui/zag/blob/main/CONTRIBUTING.md)
+for details.
+
+## Licence
+
+This project is licensed under the terms of the
+[MIT license](https://github.com/chakra-ui/zag/blob/main/LICENSE).

--- a/packages/utilities/numeric-range/package.json
+++ b/packages/utilities/numeric-range/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@zag-js/numeric-range",
+  "version": "0.0.0",
+  "description": "Numeric range utilities",
+  "keywords": [
+    "js",
+    "utils",
+    "numeric-range"
+  ],
+  "author": "Segun Adebayo <sage@adebayosegun.com>",
+  "homepage": "https://github.com/chakra-ui/zag#readme",
+  "license": "MIT",
+  "main": "src/index.ts",
+  "repository": "https://github.com/chakra-ui/zag/tree/main/packages/utilities/numeric-range",
+  "sideEffects": false,
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build-fast": "tsup src",
+    "start": "pnpm build --watch",
+    "build": "tsup src --dts",
+    "test": "jest --config ../../../jest.config.js --rootDir . --passWithNoTests",
+    "lint": "eslint src --ext .ts,.tsx",
+    "test-ci": "pnpm test --ci --runInBand",
+    "test-watch": "pnpm test --watch -u",
+    "typecheck": "tsc --noEmit",
+    "prepack": "clean-package",
+    "postpack": "clean-package restore"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/zag/issues"
+  },
+  "clean-package": "../../../clean-package.config.json",
+  "devDependencies": {
+    "clean-package": "2.2.0"
+  }
+}

--- a/packages/utilities/numeric-range/src/index.ts
+++ b/packages/utilities/numeric-range/src/index.ts
@@ -1,0 +1,142 @@
+export function getMinValueAtIndex(index: number, values: number[], minValue: number) {
+  return index === 0 ? minValue : values[index - 1]
+}
+
+export function getMaxValueAtIndex(index: number, values: number[], maxValue: number) {
+  return index === values.length - 1 ? maxValue : values[index + 1]
+}
+
+export function isValueAtMax(value: number, maxValue: number) {
+  return value >= maxValue
+}
+
+export function isValueAtMin(value: number, minValue: number) {
+  return value <= minValue
+}
+
+export function isValueWithinRange(value: number, minValue: number, maxValue: number) {
+  return value >= minValue && value <= maxValue
+}
+
+export function getRoundedValue(value: number, minValue: number, step: number) {
+  return Math.round((value - minValue) / step) * step + minValue
+}
+
+export function clampValue(value: number, minValue: number, maxValue: number) {
+  return Math.min(Math.max(value, minValue), maxValue)
+}
+
+export function getValuePercent(value: number, minValue: number, maxValue: number) {
+  return (value - minValue) / (maxValue - minValue)
+}
+
+export function getPercentValue(percent: number, minValue: number, maxValue: number, step: number) {
+  const value = percent * (maxValue - minValue) + minValue
+  const roundedValue = getRoundedValue(value, minValue, step)
+  return clampValue(roundedValue, minValue, maxValue)
+}
+
+export function snapValueToStep(value: number, min: number, max: number, step: number): number {
+  let remainder = (value - (isNaN(min) ? 0 : min)) % step
+  let snappedValue =
+    Math.abs(remainder) * 2 >= step ? value + Math.sign(remainder) * (step - Math.abs(remainder)) : value - remainder
+
+  if (!isNaN(min)) {
+    if (snappedValue < min) {
+      snappedValue = min
+    } else if (!isNaN(max) && snappedValue > max) {
+      snappedValue = min + Math.floor((max - min) / step) * step
+    }
+  } else if (!isNaN(max) && snappedValue > max) {
+    snappedValue = Math.floor(max / step) * step
+  }
+
+  let string = step.toString()
+  let index = string.indexOf(".")
+  let precision = index >= 0 ? string.length - index : 0
+
+  if (precision > 0) {
+    let pow = Math.pow(10, precision)
+    snappedValue = Math.round(snappedValue * pow) / pow
+  }
+
+  return snappedValue
+}
+
+function setValueAtIndex<T>(values: T[], index: number, value: T) {
+  if (values[index] === value) return values
+  return [...values.slice(0, index), value, ...values.slice(index + 1)]
+}
+
+type RangeContext = {
+  min: number
+  max: number
+  step: number
+  values: number[]
+}
+
+export function getValueSetterAtIndex(index: number, ctx: RangeContext) {
+  const minValueAtIndex = getMinValueAtIndex(index, ctx.values, ctx.min)
+  const maxValueAtIndex = getMaxValueAtIndex(index, ctx.values, ctx.max)
+  let nextValues = ctx.values.slice()
+
+  return function setValue(value: number) {
+    let nextValue = snapValueToStep(value, minValueAtIndex, maxValueAtIndex, ctx.step)
+    nextValues = setValueAtIndex(nextValues, index, value)
+    nextValues[index] = nextValue
+    return nextValues
+  }
+}
+
+export function getNextStepValue(index: number, ctx: RangeContext) {
+  const nextValue = ctx.values[index] + ctx.step
+  return getValueSetterAtIndex(index, ctx)(nextValue)
+}
+
+export function getPreviousStepValue(index: number, ctx: RangeContext) {
+  const nextValue = ctx.values[index] - ctx.step
+  return getValueSetterAtIndex(index, ctx)(nextValue)
+}
+
+export function getClosestValueIndex(values: number[], targetValue: number) {
+  let targetIndex = values.findIndex((value) => targetValue - value < 0)
+
+  // If the index is zero then the closetThumb is the first one
+  if (targetIndex === 0) {
+    return targetIndex
+  }
+
+  // If no index is found they've clicked past all the thumbs
+  if (targetIndex === -1) {
+    return values.length - 1
+  }
+
+  let valueBefore = values[targetIndex - 1]
+  let valueAfter = values[targetIndex]
+
+  // Pick the last left/start thumb, unless they are stacked on top of each other, then pick the right/end one
+  if (Math.abs(valueBefore - targetValue) < Math.abs(valueAfter - targetValue)) {
+    return targetIndex - 1
+  }
+
+  return targetIndex
+}
+
+export function getValueRanges(values: number[], minValue: number, maxValue: number, gap: number) {
+  return values.map((value, index) => {
+    const min = index === 0 ? minValue : values[index - 1] + gap
+    const max = index === values.length - 1 ? maxValue : values[index + 1] - gap
+    return { min, max, value }
+  })
+}
+
+export function getValueTransformer(valueA: number[], valueB: number[]) {
+  const input = { min: valueA[0], max: valueA[1] }
+  const output = { min: valueB[0], max: valueB[1] }
+
+  return function getValue(value: number) {
+    if (input.min === input.max || output.min === output.max) return output.min
+    const ratio = (output.max - output.min) / (input.max - input.min)
+    return output.min + ratio * (value - input.min)
+  }
+}

--- a/packages/utilities/numeric-range/tsconfig.json
+++ b/packages/utilities/numeric-range/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "tsBuildInfoFile": "node_modules/.cache/.tsbuildinfo"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,7 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.10
       '@zag-js/accordion': workspace:*
+      '@zag-js/anatomy': workspace:*
       '@zag-js/aria-hidden': workspace:*
       '@zag-js/auto-resize': workspace:*
       '@zag-js/checkbox': workspace:*
@@ -112,6 +113,7 @@ importers:
       '@zag-js/menu': workspace:*
       '@zag-js/number-input': workspace:*
       '@zag-js/number-utils': workspace:*
+      '@zag-js/numeric-range': workspace:*
       '@zag-js/pagination': workspace:*
       '@zag-js/pin-input': workspace:*
       '@zag-js/popover': workspace:*
@@ -145,6 +147,7 @@ importers:
       typescript: 4.9.4
     dependencies:
       '@zag-js/accordion': link:../../packages/machines/accordion
+      '@zag-js/anatomy': link:../../packages/anatomy
       '@zag-js/aria-hidden': link:../../packages/utilities/aria-hidden
       '@zag-js/auto-resize': link:../../packages/utilities/auto-resize
       '@zag-js/checkbox': link:../../packages/machines/checkbox
@@ -166,6 +169,7 @@ importers:
       '@zag-js/menu': link:../../packages/machines/menu
       '@zag-js/number-input': link:../../packages/machines/number-input
       '@zag-js/number-utils': link:../../packages/utilities/number
+      '@zag-js/numeric-range': link:../../packages/utilities/numeric-range
       '@zag-js/pagination': link:../../packages/machines/pagination
       '@zag-js/pin-input': link:../../packages/machines/pin-input
       '@zag-js/popover': link:../../packages/machines/popover
@@ -229,6 +233,7 @@ importers:
       '@zag-js/menu': workspace:*
       '@zag-js/number-input': workspace:*
       '@zag-js/number-utils': workspace:*
+      '@zag-js/numeric-range': workspace:*
       '@zag-js/pagination': workspace:*
       '@zag-js/pin-input': workspace:*
       '@zag-js/popover': workspace:*
@@ -281,6 +286,7 @@ importers:
       '@zag-js/menu': link:../../packages/machines/menu
       '@zag-js/number-input': link:../../packages/machines/number-input
       '@zag-js/number-utils': link:../../packages/utilities/number
+      '@zag-js/numeric-range': link:../../packages/utilities/numeric-range
       '@zag-js/pagination': link:../../packages/machines/pagination
       '@zag-js/pin-input': link:../../packages/machines/pin-input
       '@zag-js/popover': link:../../packages/machines/popover
@@ -345,6 +351,7 @@ importers:
       '@zag-js/menu': workspace:*
       '@zag-js/number-input': workspace:*
       '@zag-js/number-utils': workspace:*
+      '@zag-js/numeric-range': workspace:*
       '@zag-js/pagination': workspace:*
       '@zag-js/pin-input': workspace:*
       '@zag-js/popover': workspace:*
@@ -401,6 +408,7 @@ importers:
       '@zag-js/menu': link:../../packages/machines/menu
       '@zag-js/number-input': link:../../packages/machines/number-input
       '@zag-js/number-utils': link:../../packages/utilities/number
+      '@zag-js/numeric-range': link:../../packages/utilities/numeric-range
       '@zag-js/pagination': link:../../packages/machines/pagination
       '@zag-js/pin-input': link:../../packages/machines/pin-input
       '@zag-js/popover': link:../../packages/machines/popover
@@ -812,8 +820,7 @@ importers:
       '@zag-js/dom-utils': workspace:*
       '@zag-js/element-size': workspace:*
       '@zag-js/form-utils': workspace:*
-      '@zag-js/number-utils': workspace:*
-      '@zag-js/rect-utils': workspace:*
+      '@zag-js/numeric-range': workspace:*
       '@zag-js/slider': workspace:*
       '@zag-js/types': workspace:*
       '@zag-js/utils': workspace:*
@@ -822,13 +829,12 @@ importers:
       '@zag-js/anatomy': link:../../anatomy
       '@zag-js/core': link:../../core
       '@zag-js/element-size': link:../../utilities/element-size
+      '@zag-js/form-utils': link:../../utilities/form-utils
+      '@zag-js/numeric-range': link:../../utilities/numeric-range
       '@zag-js/slider': link:../slider
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
-      '@zag-js/form-utils': link:../../utilities/form-utils
-      '@zag-js/number-utils': link:../../utilities/number
-      '@zag-js/rect-utils': link:../../utilities/rect
       '@zag-js/utils': link:../../utilities/core
       clean-package: 2.2.0
 
@@ -881,7 +887,7 @@ importers:
       '@zag-js/dom-utils': workspace:*
       '@zag-js/element-size': workspace:*
       '@zag-js/form-utils': workspace:*
-      '@zag-js/number-utils': workspace:*
+      '@zag-js/numeric-range': workspace:*
       '@zag-js/types': workspace:*
       '@zag-js/utils': workspace:*
       clean-package: 2.2.0
@@ -889,11 +895,11 @@ importers:
       '@zag-js/anatomy': link:../../anatomy
       '@zag-js/core': link:../../core
       '@zag-js/element-size': link:../../utilities/element-size
+      '@zag-js/numeric-range': link:../../utilities/numeric-range
       '@zag-js/types': link:../../types
     devDependencies:
       '@zag-js/dom-utils': link:../../utilities/dom
       '@zag-js/form-utils': link:../../utilities/form-utils
-      '@zag-js/number-utils': link:../../utilities/number
       '@zag-js/utils': link:../../utilities/core
       clean-package: 2.2.0
 
@@ -1134,6 +1140,12 @@ importers:
       clean-package: 2.2.0
 
   packages/utilities/number:
+    specifiers:
+      clean-package: 2.2.0
+    devDependencies:
+      clean-package: 2.2.0
+
+  packages/utilities/numeric-range:
     specifiers:
       clean-package: 2.2.0
     devDependencies:

--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -91,6 +91,8 @@ export const sliderControls = defineControls({
   dir: { type: "select", options: ["ltr", "rtl"] as const, defaultValue: "ltr" },
   origin: { type: "select", options: ["center", "start"] as const, defaultValue: "start" },
   step: { type: "number", defaultValue: 1 },
+  min: { type: "number", defaultValue: 0 },
+  max: { type: "number", defaultValue: 100 },
 })
 
 export const radioControls = defineControls({
@@ -104,6 +106,8 @@ export const rangeSliderControls = defineControls({
   orientation: { type: "select", options: ["horizontal", "vertical"] as const, defaultValue: "horizontal" },
   thumbAlignment: { type: "select", options: ["contain", "center"] as const, defaultValue: "contain" },
   dir: { type: "select", options: ["ltr", "rtl"] as const, defaultValue: "ltr" },
+  min: { type: "number", defaultValue: 0 },
+  max: { type: "number", defaultValue: 100 },
   step: { type: "number", defaultValue: 1 },
 })
 

--- a/shared/src/style.css
+++ b/shared/src/style.css
@@ -3,6 +3,7 @@
 }
 
 * {
+  box-sizing: border-box;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans",
     "Helvetica Neue", sans-serif;
 }


### PR DESCRIPTION
Closes #466 

## 📝 Description

- Redesigned style calculations for consistency
- Fixed issue where the thumb cannot go back to its original position when `min` is greater than `0.`

## ⛳️ Current behavior (updates)

Cannot go back to the original position

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
