### PR TITLE
feat(hover-card): add manual open and close functions to the connect api

### DIFF
--- a/.changeset/kind-hounds-bathe.md
+++ b/.changeset/kind-hounds-bathe.md
@@ -1,0 +1,17 @@
+---
+"@zag-js/hover-card": minor
+---
+
+Add `open` and `close` functions to the connect api:
+
+```ts
+import * as hoverCard from "@zag-js/hover-card"
+
+const api = hoverCard.connect(state, send, normalizeProps)
+
+// call `open` to open the hover card
+api.open()
+
+// call `close` to close the hover card
+api.close()
+```

--- a/.xstate/hover-card.js
+++ b/.xstate/hover-card.js
@@ -41,7 +41,8 @@ const fetchMachine = createMachine({
           actions: ["setIsPointer"],
           target: "opening"
         },
-        TRIGGER_FOCUS: "opening"
+        TRIGGER_FOCUS: "opening",
+        OPEN: "opening"
       }
     },
     opening: {
@@ -54,7 +55,8 @@ const fetchMachine = createMachine({
         TRIGGER_BLUR: {
           cond: "!isPointer",
           target: "closed"
-        }
+        },
+        CLOSE: "closed"
       }
     },
     open: {

--- a/packages/machines/hover-card/src/hover-card.connect.ts
+++ b/packages/machines/hover-card/src/hover-card.connect.ts
@@ -15,6 +15,12 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
 
   return {
     isOpen,
+    open() {
+      send("OPEN")
+    },
+    close() {
+      send("CLOSE")
+    },
 
     arrowProps: normalize.element({
       id: dom.getArrowId(state.context),

--- a/packages/machines/hover-card/src/hover-card.machine.ts
+++ b/packages/machines/hover-card/src/hover-card.machine.ts
@@ -40,6 +40,7 @@ export function machine(userContext: UserDefinedContext) {
           on: {
             POINTER_ENTER: { actions: ["setIsPointer"], target: "opening" },
             TRIGGER_FOCUS: "opening",
+            OPEN: "opening",
           },
         },
 
@@ -54,6 +55,7 @@ export function machine(userContext: UserDefinedContext) {
               guard: not("isPointer"),
               target: "closed",
             },
+            CLOSE: "closed",
           },
         },
 


### PR DESCRIPTION
## 📝 Description

Add `open` and `close` functions to the hover card connect api:

## ⛳️ Current behavior (updates)

Missing way to control the machine.

## 🚀 New behavior

```ts
import * as hoverCard from "@zag-js/hover-card"
const api = hoverCard.connect(state, send, normalizeProps)
// call `open` to open the hover card
api.open()
// call `close` to close the hover card
api.close()
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Prerequisite to [OSS-518](https://linear.app/chakra/issue/OSS-518/featreact-controlled-usage-of-hovercard-component)