### PR TITLE
fix(store): move valtio to deps from devDeps

### DIFF
--- a/.changeset/sour-cats-repeat.md
+++ b/.changeset/sour-cats-repeat.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/store": patch
+---
+
+install valtio as dependencies, not devDependencies

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -34,12 +34,12 @@
     "url": "https://github.com/chakra-ui/zag/issues"
   },
   "dependencies": {
-    "proxy-compare": "2.4.0"
+    "proxy-compare": "2.4.0",
+    "valtio": "^1.9.0"
   },
   "clean-package": "../../clean-package.config.json",
   "main": "src/index.ts",
   "devDependencies": {
-    "clean-package": "2.2.0",
-    "valtio": "^1.9.0"
+    "clean-package": "2.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1086,9 +1086,9 @@ importers:
       valtio: ^1.9.0
     dependencies:
       proxy-compare: 2.4.0
+      valtio: 1.9.0
     devDependencies:
       clean-package: 2.2.0
-      valtio: 1.9.0
 
   packages/types:
     specifiers:
@@ -4699,8 +4699,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -8260,6 +8260,7 @@ packages:
 
   /proxy-compare/2.4.0:
     resolution: {integrity: sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg==}
+    dev: false
 
   /proxy-memoize/1.2.0:
     resolution: {integrity: sha512-0heYEZb4yMfhdduz8T+BPJOCKGukc81WRJaYF0k6ZsJz/NkPLhGFqe6OLdiZURr5kC1byps5wdqLN6DC2tYAFw==}
@@ -9330,7 +9331,7 @@ packages:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dev: true
+    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -9375,7 +9376,7 @@ packages:
     dependencies:
       proxy-compare: 2.4.0
       use-sync-external-store: 1.2.0
-    dev: true
+    dev: false
 
   /vite-plugin-solid/2.5.0_solid-js@1.6.6+vite@4.0.3:
     resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

`index.mjs` after `pnpm build`
```js
// src/index.ts
import { ref, snapshot, proxy, subscribe } from "valtio/vanilla";
import { proxyWithComputed, subscribeKey } from "valtio/utils";
export {
  proxy,
  proxyWithComputed,
  ref,
  snapshot,
  subscribe,
  subscribeKey
};
```
import from `valtio` is present in build result, `valtio` should be in `dependencies`, not `devDependencies`.

## ⛳️ Current behavior (updates)

Following error occurs when I try to import `@zag-js/store` or packages that imports store.
```
../../.yarn/cache/@zag-js-store-npm-0.2.5-72f8f309
     f2-7d41d3c8b7.zip/node_modules/@zag-js/store/dist/
     index.d.ts(2,49): error TS2307: Cannot find module
      'valtio/utils' or its corresponding type 
     declarations.
```

## 🚀 New behavior

Errors are resolved.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
