### PR TITLE
feat: add radio clearValue api

### DIFF
--- a/.changeset/spotty-pugs-add.md
+++ b/.changeset/spotty-pugs-add.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/radio-group": patch
+---
+
+- Add `clearValue` api
+- Fix radio inputs not syncing when radio group value is cleared,

--- a/examples/next-ts/pages/radio-group.tsx
+++ b/examples/next-ts/pages/radio-group.tsx
@@ -40,6 +40,9 @@ export default function Page() {
 
             {/*  */}
             <button type="reset">Reset</button>
+            <button type="button" onClick={() => api.clearValue()}>
+              Clear
+            </button>
             <button type="button" onClick={() => api.setValue("mango")}>
               Set to Mangoes
             </button>

--- a/packages/machines/radio-group/src/radio-group.connect.ts
+++ b/packages/machines/radio-group/src/radio-group.connect.ts
@@ -53,6 +53,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     setValue(value: string) {
       send({ type: "SET_VALUE", value, manual: true })
     },
+    clearValue() {
+      send({ type: "SET_VALUE", value: null, manual: true })
+    },
     focus,
     blur() {
       const focusedElement = dom.getActiveElement(state.context)

--- a/packages/machines/radio-group/src/radio-group.dom.ts
+++ b/packages/machines/radio-group/src/radio-group.dom.ts
@@ -22,6 +22,6 @@ export const dom = defineDomHelpers({
   getInputEls: (ctx: Ctx) => {
     const ownerId = CSS.escape(dom.getRootId(ctx))
     const selector = `input[type=radio][data-ownedby='${ownerId}']:not([disabled])`
-    return queryAll(dom.getRootEl(ctx), selector)
+    return queryAll<HTMLInputElement>(dom.getRootEl(ctx), selector)
   },
 })

--- a/packages/machines/radio-group/src/radio-group.machine.ts
+++ b/packages/machines/radio-group/src/radio-group.machine.ts
@@ -37,7 +37,7 @@ export function machine(userContext: UserDefinedContext) {
       },
 
       watch: {
-        value: ["dispatchChangeEvent", "invokeOnChange"],
+        value: ["dispatchChangeEvent", "invokeOnChange", "syncInputElements"],
       },
 
       entry: ["checkValue"],
@@ -84,6 +84,12 @@ export function machine(userContext: UserDefinedContext) {
           if (!evt.manual) return
           const el = dom.getRadioInputEl(ctx, evt.value)
           dispatchInputCheckedEvent(el, !!evt.value)
+        },
+        syncInputElements(ctx) {
+          const inputs = dom.getInputEls(ctx)
+          inputs.forEach((input) => {
+            input.checked = input.value === ctx.value
+          })
         },
       },
     },


### PR DESCRIPTION
Closes #501

- Add `clearValue` api
- Fix radio inputs not syncing when radio group value is cleared,