### PR TITLE
Fix/double click outside breaks checkbox label

### DIFF
--- a/.changeset/curvy-days-sin.md
+++ b/.changeset/curvy-days-sin.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/checkbox": patch
+---
+
+Fix double click outside breaking click on checkbox label

--- a/packages/machines/checkbox/src/checkbox.connect.ts
+++ b/packages/machines/checkbox/src/checkbox.connect.ts
@@ -88,7 +88,6 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       "data-invalid": dataAttr(isInvalid),
       onPointerDown(event) {
         if (!isInteractive) return
-        event.preventDefault()
         event.stopPropagation()
       },
     }),


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #515

## ⛳️ Current behavior (updates)

Double click outside breaks click on checkbox label.

## 🚀 New behavior

Click on checkbox label works as expected.

## 💣 Is this a breaking change (Yes/No):

No
