### PR TITLE
Fix/prevent blur when focused

### DIFF
--- a/.changeset/silver-kids-remember.md
+++ b/.changeset/silver-kids-remember.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/checkbox": patch
+---
+
+Fixes triggering of onBlur on input element when clicking checkbox label

--- a/e2e/checkbox.e2e.ts
+++ b/e2e/checkbox.e2e.ts
@@ -70,3 +70,15 @@ test("should not be changeable when readonly", async ({ page }) => {
   await page.click(root)
   await expectNotToBeChecked(page)
 })
+
+test("input is not blurred on label click", async ({ page }) => {
+  let blurCount = 0
+  await page.exposeFunction("trackBlur", () => blurCount++)
+  await page.locator(input).evaluate((input) => {
+    input.addEventListener("blur", (window as any).trackBlur)
+  })
+  await page.click(label)
+  await page.click(label)
+  await page.click(label)
+  expect(blurCount).toBe(0)
+})

--- a/packages/machines/checkbox/src/checkbox.connect.ts
+++ b/packages/machines/checkbox/src/checkbox.connect.ts
@@ -88,6 +88,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       "data-invalid": dataAttr(isInvalid),
       onPointerDown(event) {
         if (!isInteractive) return
+        // On pointerdown, the input blurs and returns focus to the `body`,
+        // we need to prevent this.
+        if (isFocused) event.preventDefault()
         event.stopPropagation()
       },
     }),


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This fixes a bug that got introduced by #516

We still need to prevent triggering `onBlur` on the input element, when clicking on the checkbox label. This however should only happen if the input element is already focused.

## ⛳️ Current behavior (updates)

Input element fires `onBlur` when the checkbox label is clicked.

## 🚀 New behavior

Input element does not fire `onBlur` when the checkbox label is clicked.

## 💣 Is this a breaking change (Yes/No):

No