### PR TITLE
feat: add aria-labelledby to radio group

### DIFF
--- a/.changeset/shy-ties-dance.md
+++ b/.changeset/shy-ties-dance.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/radio-group": minor
+---
+
+Add aria-labelledby to radio group for improved screenreader accessibility

--- a/e2e/radio-group.e2e.ts
+++ b/e2e/radio-group.e2e.ts
@@ -1,5 +1,8 @@
 import { expect, Page, test } from "@playwright/test"
-import { a11y, controls, testid } from "./__utils"
+import { a11y, controls, testid, part } from "./__utils"
+
+const root = part("root")
+const label = part("label")
 
 const apple = {
   radio: testid("radio-apple"),
@@ -27,6 +30,12 @@ test.beforeEach(async ({ page }) => {
 
 test("should have no accessibility violation", async ({ page }) => {
   await a11y(page)
+})
+
+test("should have aria-labelledby on root", async ({ page }) => {
+  const labelId = await page.locator(label).getAttribute("id")
+  expect(labelId).not.toBeNull()
+  await expect(page.locator(root)).toHaveAttribute("aria-labelledby", labelId as string)
 })
 
 test("should be checked when clicked", async ({ page }) => {

--- a/packages/machines/radio-group/src/radio-group.connect.ts
+++ b/packages/machines/radio-group/src/radio-group.connect.ts
@@ -68,6 +68,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       ...parts.root.attrs,
       role: "radiogroup",
       id: dom.getRootId(state.context),
+      "aria-labelledby": dom.getLabelId(state.context),
       "data-orientation": state.context.orientation,
       "aria-orientation": state.context.orientation,
       dir: state.context.dir,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #518

## 📝 Description

Added `aria-labelledby` to radio group for improved screen reader accessibility.

## ⛳️ Current behavior (updates)

Screen readers do not read the label of a radio group.

## 🚀 New behavior

Screen readers read the label of a radio group.

## 💣 Is this a breaking change (Yes/No):

No
