### PR TITLE
fix: pressable event trigger

### DIFF
--- a/.changeset/itchy-timers-whisper.md
+++ b/.changeset/itchy-timers-whisper.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/pressable": patch
+---
+
+fix pressable event trigger

--- a/.xstate/pressable.js
+++ b/.xstate/pressable.js
@@ -60,7 +60,7 @@ const fetchMachine = createMachine({
           actions: ["clearPressedDown", "invokeOnPressEnd"]
         }, {
           target: "pressed:out",
-          actions: ["clearPressedDown", "invokeOnPressEnd"]
+          actions: ["invokeOnPressEnd"]
         }],
         DOC_POINTER_UP: [{
           cond: "wasPressedDown",
@@ -95,8 +95,7 @@ const fetchMachine = createMachine({
           actions: "invokeOnPressStart"
         },
         DOC_POINTER_UP: {
-          target: "idle",
-          actions: "invokeOnPressEnd"
+          target: "idle"
         },
         DOC_POINTER_CANCEL: "idle",
         DRAG_START: "idle"

--- a/packages/machines/pressable/src/pressable.machine.ts
+++ b/packages/machines/pressable/src/pressable.machine.ts
@@ -75,7 +75,7 @@ export function machine(userContext: UserDefinedContext) {
               },
               {
                 target: "pressed:out",
-                actions: ["clearPressedDown", "invokeOnPressEnd"],
+                actions: ["invokeOnPressEnd"],
               },
             ],
             DOC_POINTER_UP: [
@@ -110,7 +110,6 @@ export function machine(userContext: UserDefinedContext) {
             },
             DOC_POINTER_UP: {
               target: "idle",
-              actions: "invokeOnPressEnd",
             },
             DOC_POINTER_CANCEL: "idle",
             DRAG_START: "idle",


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

* onPressEnd is already invoked on `pressed:in` -> `pressed:out` transition,
invoking onPressEnd in pressed:out DOC_POINTER_UP is wrong.
* after `pressed:in` -> `pressed:out` -> `pressed:in` -> DOC_POINTER_UP,
onPress should be invoked.

These bahaviors are compared from React Aria [usePress](https://react-spectrum.adobe.com/react-aria/usePress.html).

## ⛳️ Current behavior (updates)

### onPressEnd

* POINTER_DOWN (idle -> pressed:in)
* POINTER_LEAVE (pressed:in -> pressed:out) [invoke onPressEnd]
* DOC_POINTER_UP (pressed:out -> idle) [invoke onPressEnd]

### onPress

* POINTER_DOWN (idle -> pressed:in)
* POINTER_LEAVE (pressed:in -> pressed:out)
* POINTER_ENTER (pressed:out -> pressed:in)
* DOC_POINTER_UP (pressed:out -> idle) [**NOT** invoke onPress]

## 🚀 New behavior

### onPressEnd

* POINTER_DOWN (idle -> pressed:in)
* POINTER_LEAVE (pressed:in -> pressed:out) [invoke onPressEnd]
* DOC_POINTER_UP (pressed:out -> idle) [**NOT** invoke onPressEnd]

### onPress

* POINTER_DOWN (idle -> pressed:in)
* POINTER_LEAVE (pressed:in -> pressed:out)
* POINTER_ENTER (pressed:out -> pressed:in)
* DOC_POINTER_UP (pressed:out -> idle) [invoke onPress]

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
