### PR TITLE
fix(#531): clear selected option on clear value

### DIFF
--- a/.changeset/rotten-years-smell.md
+++ b/.changeset/rotten-years-smell.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/combobox": patch
+---
+
+Clear selected option on `clearValue`

--- a/.xstate/combobox.js
+++ b/.xstate/combobox.js
@@ -42,9 +42,9 @@ const fetchMachine = createMachine({
     CLEAR_VALUE: [{
       cond: "focusOnClear",
       target: "focused",
-      actions: "clearInputValue"
+      actions: ["clearInputValue", "clearSelectedValue"]
     }, {
-      actions: "clearInputValue"
+      actions: ["clearInputValue", "clearSelectedValue"]
     }],
     POINTER_OVER: {
       actions: "setIsHovering"

--- a/e2e/combobox.e2e.ts
+++ b/e2e/combobox.e2e.ts
@@ -4,12 +4,21 @@ import { a11y, controls, isInViewport, testid } from "./__utils"
 const input = testid("input")
 const trigger = testid("trigger")
 const content = testid("combobox-content")
+const clear_value_button = testid("clear-value-button")
 
 const options = "[data-part=option]:not([data-disabled])"
 const highlighted_option = "[data-part=option][data-highlighted]"
 
 const expectToBeHighlighted = async (el: Locator) => {
   await expect(el).toHaveAttribute("data-highlighted", "")
+}
+
+const expectToBeSelected = async (el: Locator) => {
+  await expect(el).toHaveAttribute("data-checked", "")
+}
+
+const expectNotToBeSelected = async (el: Locator) => {
+  await expect(el).not.toHaveAttribute("data-checked", "")
 }
 
 const expectToBeInViewport = async (viewport: Locator, option: Locator) => {
@@ -142,6 +151,25 @@ test.describe("combobox", () => {
     await controls(page).bool("openOnClick")
     await page.click(input, { force: true })
     await expect(page.locator(content)).toBeVisible()
+  })
+
+  test("selects value on click", async ({ page }) => {
+    await page.click(trigger)
+    const option_els = page.locator(options)
+    await option_els.first().click()
+    await page.click(trigger)
+    await expectToBeSelected(option_els.first())
+  })
+
+  test("can clear value", async ({ page }) => {
+    await page.click(trigger)
+    const option_els = page.locator(options)
+    await option_els.first().click()
+    await page.click(trigger)
+    await page.locator(clear_value_button).click()
+
+    await expect(page.locator(input)).toHaveValue("")
+    await expectNotToBeSelected(option_els.first())
   })
 
   test("should scroll selected option into view", async ({ page }) => {

--- a/examples/next-ts/pages/combobox.tsx
+++ b/examples/next-ts/pages/combobox.tsx
@@ -32,6 +32,9 @@ export default function Page() {
       <main className="combobox">
         <div>
           <button onClick={() => api.setValue("TG")}>Set to Togo</button>
+          <button data-testid="clear-value-button" onClick={() => api.clearValue()}>
+            Clear Value
+          </button>
           <br />
           <div {...api.rootProps}>
             <label {...api.labelProps}>Select country</label>

--- a/examples/solid-ts/src/pages/combobox.tsx
+++ b/examples/solid-ts/src/pages/combobox.tsx
@@ -32,19 +32,24 @@ export default function Page() {
       <main class="combobox">
         <div>
           <button onClick={() => api().setValue("Togo")}>Set to Togo</button>
+          <button data-testid="clear-value-button" onClick={() => api().clearValue()}>
+            Clear Value
+          </button>
           <br />
 
           <div {...api().rootProps}>
             <label {...api().labelProps}>Select country</label>
             <div {...api().controlProps}>
-              <input {...api().inputProps} />
-              <button {...api().triggerProps}>▼</button>
+              <input data-testid="input" {...api().inputProps} />
+              <button data-testid="trigger" {...api().triggerProps}>
+                ▼
+              </button>
             </div>
           </div>
 
           <div {...api().positionerProps}>
             <Show when={options().length > 0}>
-              <ul {...api().contentProps}>
+              <ul data-testid="combobox-content" {...api().contentProps}>
                 <For each={options()}>
                   {(item, index) => {
                     const options = { label: item.label, value: item.code, index: index(), disabled: item.disabled }

--- a/examples/vue-ts/src/pages/combobox.tsx
+++ b/examples/vue-ts/src/pages/combobox.tsx
@@ -36,6 +36,9 @@ export default defineComponent({
           <main class="combobox">
             <div>
               <button onClick={() => api.setValue("Togo")}>Set to Togo</button>
+              <button data-testid="clear-value-button" onClick={() => api.clearValue()}>
+                Clear Value
+              </button>
 
               <br />
 
@@ -43,14 +46,16 @@ export default defineComponent({
                 <label {...api.labelProps}>Select country</label>
 
                 <div {...api.controlProps}>
-                  <input {...api.inputProps} />
-                  <button {...api.triggerProps}>▼</button>
+                  <input data-testid="input" {...api.inputProps} />
+                  <button data-testid="trigger" {...api.triggerProps}>
+                    ▼
+                  </button>
                 </div>
               </div>
 
               <div {...api.positionerProps}>
                 {options.value.length > 0 && (
-                  <ul {...api.contentProps}>
+                  <ul data-testid="combobox-content" {...api.contentProps}>
                     {options.value.map((item, index) => (
                       <li
                         key={`${item.code}:${index}`}

--- a/packages/machines/combobox/src/combobox.machine.ts
+++ b/packages/machines/combobox/src/combobox.machine.ts
@@ -84,10 +84,10 @@ export function machine(userContext: UserDefinedContext) {
           {
             guard: "focusOnClear",
             target: "focused",
-            actions: "clearInputValue",
+            actions: ["clearInputValue", "clearSelectedValue"],
           },
           {
-            actions: "clearInputValue",
+            actions: ["clearInputValue", "clearSelectedValue"],
           },
         ],
         POINTER_OVER: {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #531

## 📝 Description

Combobox API clears selected option on `clearValue`

## ⛳️ Current behavior (updates)

Selected option is not cleared on `clearValue`

## 🚀 New behavior

Selected option is cleared on `clearValue`

## 💣 Is this a breaking change (Yes/No):

No