### PR TITLE
fix: update casing typo in accordion machine

### DIFF
--- a/.changeset/poor-pillows-lay.md
+++ b/.changeset/poor-pillows-lay.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/accordion": patch
+---
+
+Fix case sensitivity typo in accordion machine where the `setValue` function could not send it's data to `value` because
+the `type` prop value `VALUE.SET` was lowercase.

--- a/packages/machines/accordion/src/accordion.reducer.ts
+++ b/packages/machines/accordion/src/accordion.reducer.ts
@@ -11,7 +11,7 @@ export function createReducer(state: State, send: Send) {
     if (multiple && !Array.isArray(nextValue)) {
       nextValue = [nextValue]
     }
-    send({ type: "value.set", value: nextValue })
+    send({ type: "VALUE.SET", value: nextValue })
   }
 
   function getItemState(props: ItemProps) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes typo of the `type` prop value of `send()` in the accordion machine's [setValue function](https://github.com/chakra-ui/zag/blob/7bef71ddaacf1997098b423dc7362477ebcee0a4/packages/machines/accordion/src/accordion.reducer.ts#L14) where the given value is lowercase, where it needs to be uppercase. (Case sensitivity)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

This is fixing a breaking change from [Commit f7bb988](https://github.com/chakra-ui/zag/commit/f7bb988aaeda6c6caebe95823f4cd44baa0d5e78)
