### PR TITLE
fix(select, combobox, menu): implicit click -> explicit send

### DIFF
--- a/.changeset/good-hornets-grow.md
+++ b/.changeset/good-hornets-grow.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/combobox": patch
+"@zag-js/select": patch
+"@zag-js/menu": patch
+---
+
+Fix issue where element triggers double click events due to the internal `.click()` calls

--- a/.xstate/menu.js
+++ b/.xstate/menu.js
@@ -174,7 +174,6 @@ const fetchMachine = createMachine({
       tags: ["visible"],
       activities: ["trackInteractOutside", "computePlacement"],
       entry: ["focusMenu", "resumePointer"],
-      exit: ["clearPointerdownNode"],
       on: {
         TRIGGER_CLICK: {
           cond: "!isTriggerItem",
@@ -241,14 +240,14 @@ const fetchMachine = createMachine({
           cond: "!isTriggerItemFocused && !isFocusedItemEditable",
           actions: ["invokeOnSelect", "changeOptionValue", "invokeOnValueChange"]
         }, {
-          actions: ["focusItem"]
+          actions: "focusItem"
         }],
         TRIGGER_POINTERLEAVE: {
           target: "closing",
           actions: "setIntentPolygon"
         },
         ITEM_POINTERDOWN: {
-          actions: ["setPointerdownNode", "focusItem"]
+          actions: "focusItem"
         },
         TYPEAHEAD: {
           actions: "focusMatchedItem"

--- a/examples/vue-ts/src/pages/menu-options.tsx
+++ b/examples/vue-ts/src/pages/menu-options.tsx
@@ -1,7 +1,7 @@
 import * as menu from "@zag-js/menu"
 import { menuControls, menuOptionData as data } from "@zag-js/shared"
 import { normalizeProps, useMachine } from "@zag-js/vue"
-import { useControls } from "src/hooks/use-controls"
+import { useControls } from "../hooks/use-controls"
 import { computed, defineComponent, Teleport } from "vue"
 import { StateVisualizer } from "../components/state-visualizer"
 

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -297,18 +297,18 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
           if (optionState.disabled) return
           send({ type: "POINTEROVER_OPTION", id, value, label })
         },
-        onPointerUp(event) {
+        onPointerUp() {
           if (optionState.disabled) return
-          event.currentTarget.click()
+          send({ type: "CLICK_OPTION", src: "pointerup", id, value, label })
         },
         onClick() {
           if (optionState.disabled) return
-          send({ type: "CLICK_OPTION", id, value, label })
+          send({ type: "CLICK_OPTION", src: "click", id, value, label })
         },
         onAuxClick(event) {
           if (optionState.disabled) return
           event.preventDefault()
-          event.currentTarget.click()
+          send({ type: "CLICK_OPTION", src: "auxclick", id, value, label })
         },
       })
     },

--- a/packages/machines/menu/src/menu.connect.ts
+++ b/packages/machines/menu/src/menu.connect.ts
@@ -310,7 +310,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         "data-valuetext": valueText,
         onClick(event) {
           if (disabled) return
-          send({ type: "ITEM_CLICK", target: event.currentTarget, id })
+          send({ type: "ITEM_CLICK", src: "click", target: event.currentTarget, id })
         },
         onPointerDown(event) {
           if (disabled) return
@@ -318,8 +318,8 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         },
         onPointerUp(event) {
           const evt = getNativeEvent(event)
-          if (!isLeftClick(evt) || disabled || state.context.pointerdownNode === event.currentTarget) return
-          event.currentTarget.click()
+          if (!isLeftClick(evt) || disabled) return
+          send({ type: "ITEM_CLICK", src: "pointerup", target: event.currentTarget, id })
         },
         onPointerLeave(event) {
           if (disabled || event.pointerType !== "mouse") return
@@ -336,7 +336,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         onAuxClick(event) {
           if (disabled) return
           event.preventDefault()
-          event.currentTarget.click()
+          send({ type: "ITEM_CLICK", src: "auxclick", target: event.currentTarget, id })
         },
       })
     },

--- a/packages/machines/menu/src/menu.machine.ts
+++ b/packages/machines/menu/src/menu.machine.ts
@@ -29,7 +29,6 @@ export function machine(userContext: UserDefinedContext) {
         isPlacementComplete: false,
         focusTriggerOnClose: true,
         ...ctx,
-        pointerdownNode: null,
         typeahead: getByTypeahead.defaultOptions,
         positioning: {
           placement: "bottom-start",
@@ -196,7 +195,6 @@ export function machine(userContext: UserDefinedContext) {
           tags: ["visible"],
           activities: ["trackInteractOutside", "computePlacement"],
           entry: ["focusMenu", "resumePointer"],
-          exit: ["clearPointerdownNode"],
           on: {
             TRIGGER_CLICK: {
               guard: not("isTriggerItem"),
@@ -279,14 +277,14 @@ export function machine(userContext: UserDefinedContext) {
                 guard: and(not("isTriggerItemFocused"), not("isFocusedItemEditable")),
                 actions: ["invokeOnSelect", "changeOptionValue", "invokeOnValueChange"],
               },
-              { actions: ["focusItem"] },
+              { actions: "focusItem" },
             ],
             TRIGGER_POINTERLEAVE: {
               target: "closing",
               actions: "setIntentPolygon",
             },
             ITEM_POINTERDOWN: {
-              actions: ["setPointerdownNode", "focusItem"],
+              actions: "focusItem",
             },
             TYPEAHEAD: {
               actions: "focusMatchedItem",
@@ -486,9 +484,6 @@ export function machine(userContext: UserDefinedContext) {
         invokeOnSelect(ctx) {
           if (!ctx.highlightedId) return
           ctx.onSelect?.({ value: ctx.highlightedId })
-          if (!ctx.closeOnSelect) {
-            ctx.pointerdownNode = null
-          }
         },
         focusItem(ctx, event) {
           ctx.highlightedId = event.id
@@ -529,12 +524,6 @@ export function machine(userContext: UserDefinedContext) {
         },
         restoreParentFocus(ctx) {
           ctx.parent?.send("RESTORE_FOCUS")
-        },
-        setPointerdownNode(ctx, evt) {
-          ctx.pointerdownNode = ref(evt.target)
-        },
-        clearPointerdownNode(ctx) {
-          ctx.pointerdownNode = null
         },
         invokeOnOpen(ctx) {
           ctx.onOpen?.()

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -275,7 +275,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         if (!isInteractive) return
         const option = dom.getClosestOption(event.target)
         if (!option || option.hasAttribute("data-disabled")) return
-        option?.click()
+        send({ type: "OPTION_CLICK", src: "pointerup", id: option.id })
       },
       onPointerLeave() {
         send({ type: "POINTER_LEAVE" })
@@ -284,7 +284,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         if (!isInteractive) return
         const option = dom.getClosestOption(event.target)
         if (!option || option.hasAttribute("data-disabled")) return
-        send({ type: "OPTION_CLICK", id: option.id })
+        send({ type: "OPTION_CLICK", src: "click", id: option.id })
       },
       onKeyDown(event) {
         if (!isInteractive) return


### PR DESCRIPTION
Closes #237

## 📝 Description

This PR fixes a long-standing issue where elements trigger a double-click event due to the implicit invocation of `element.click()` inside the actions.

## ⛳️ Current behavior (updates)

Take this snippet of code:

```jsx
<div>
      <button {...api.triggerProps}>
        Actions <span aria-hidden>▾</span>
      </button>
      <div {...api.positionerProps}>
        <ul {...api.contentProps} onClick={(e) => console.log("clicked", e)}>
          <li {...api.getItemProps({ id: "edit" })}>Edit</li>
          <li {...api.getItemProps({ id: "duplicate" })}>Duplicate</li>
          <li {...api.getItemProps({ id: "delete" })}>Delete</li>
          <li {...api.getItemProps({ id: "export" })}>Export...</li>
        </ul>
      </div>
    </div>
```

The `onClick` will be fired twice due to the mentioned reason.

## 🚀 New behavior

We now use the machine's send function to invoke the transition in the `onClick` function. This is more explicit and is consistent with the state-machine approach.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
