### PR TITLE
fix(interact-outside): fix app breaking error with cross origin iframes

### DIFF
--- a/.changeset/silly-planets-run.md
+++ b/.changeset/silly-planets-run.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/interact-outside": patch
+---
+
+Fixes app breaking error when cross origin frames are present on the page

--- a/packages/utilities/interact-outside/src/get-window-frames.ts
+++ b/packages/utilities/interact-outside/src/get-window-frames.ts
@@ -8,15 +8,27 @@ export function getWindowFrames(win: Window) {
     },
     addEventListener(event: string, listener: any, options?: any) {
       frames.each((frame) => {
-        frame.document.addEventListener(event, listener, options)
+        try {
+          frame.document.addEventListener(event, listener, options)
+        } catch (err) {
+          console.warn(err)
+        }
       })
       return () => {
-        frames.removeEventListener(event, listener, options)
+        try {
+          frames.removeEventListener(event, listener, options)
+        } catch (err) {
+          console.warn(err)
+        }
       }
     },
     removeEventListener(event: string, listener: any, options?: any) {
       frames.each((frame) => {
-        frame.document.removeEventListener(event, listener, options)
+        try {
+          frame.document.removeEventListener(event, listener, options)
+        } catch (err) {
+          console.warn(err)
+        }
       })
     },
   }


### PR DESCRIPTION
## 📝 Description
Fixes an app breaking issue when cross origin frames are present on the page

## ⛳️ Current behavior (updates)
Currently a DOMException error is thrown
> Uncaught DOMException: Permission denied to access property "document" on cross-origin object

## 🚀 New behavior
The error is now caught allowing the app to continue working without those iframes

## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information
