### PR TITLE
feat: expose interact outside in context

### DIFF
--- a/.changeset/ten-items-yell.md
+++ b/.changeset/ten-items-yell.md
@@ -1,0 +1,23 @@
+---
+"@zag-js/tags-input": minor
+"@zag-js/combobox": minor
+"@zag-js/editable": minor
+"@zag-js/select": minor
+---
+
+Add `onInteractOutside` hook to context.
+
+This can be used to prevent loosing focus when composing with other components.
+
+Example usage:
+
+```ts
+{
+  onInteractOutside(event) {
+    // Prevent loosing focus when interacting with related popup
+    if (popupElement.contains(event.target)) {
+      event.preventDefault()
+    }
+  }
+}
+```

--- a/packages/machines/combobox/src/combobox.machine.ts
+++ b/packages/machines/combobox/src/combobox.machine.ts
@@ -369,7 +369,9 @@ export function machine(userContext: UserDefinedContext) {
               const ignore = [dom.getContentEl(ctx), dom.getTriggerEl(ctx)]
               return ignore.some((el) => contains(el, target))
             },
-            onInteractOutside() {
+            onInteractOutside(event) {
+              ctx.onInteractOutside?.(event)
+              if (event.defaultPrevented) return
               send({ type: "BLUR", src: "interact-outside" })
             },
           })

--- a/packages/machines/combobox/src/combobox.types.ts
+++ b/packages/machines/combobox/src/combobox.types.ts
@@ -139,7 +139,7 @@ type PublicContext = DirectionProperty &
     onClose?: () => void
     /**
      * Callback fired when an outside interaction was triggered.
-     * Useful for preventing blur on editable when composing it with other components.
+     * Useful for preventing blur on combobox when composing it with other components.
      */
     onInteractOutside?(event: InteractOutsideEvent): void
     /**

--- a/packages/machines/combobox/src/combobox.types.ts
+++ b/packages/machines/combobox/src/combobox.types.ts
@@ -1,4 +1,5 @@
 import type { StateMachine as S } from "@zag-js/core"
+import type { InteractOutsideEvent } from "@zag-js/interact-outside"
 import type { LiveRegion } from "@zag-js/live-region"
 import type { Placement, PositioningOptions } from "@zag-js/popper"
 import type { CommonProperties, Context, DirectionProperty, RequiredBy } from "@zag-js/types"
@@ -136,6 +137,11 @@ type PublicContext = DirectionProperty &
      * Function called when the popup is closed
      */
     onClose?: () => void
+    /**
+     * Callback fired when an outside interaction was triggered.
+     * Useful for preventing blur on editable when composing it with other components.
+     */
+    onInteractOutside?(event: InteractOutsideEvent): void
     /**
      * Specifies the localized strings that identifies the accessibility elements and their states
      */

--- a/packages/machines/editable/src/editable.machine.ts
+++ b/packages/machines/editable/src/editable.machine.ts
@@ -117,7 +117,9 @@ export function machine(userContext: UserDefinedContext) {
               const ignore = [dom.getCancelTriggerEl(ctx), dom.getSubmitTriggerEl(ctx)]
               return ignore.some((el) => contains(el, target))
             },
-            onInteractOutside() {
+            onInteractOutside(event) {
+              ctx.onInteractOutside?.(event)
+              if (event.defaultPrevented) return
               send({ type: "BLUR", src: "interact-outside" })
             },
           })

--- a/packages/machines/editable/src/editable.types.ts
+++ b/packages/machines/editable/src/editable.types.ts
@@ -1,4 +1,5 @@
 import type { StateMachine as S } from "@zag-js/core"
+import type { InteractOutsideEvent } from "@zag-js/interact-outside"
 import type { CommonProperties, Context, DirectionProperty, RequiredBy } from "@zag-js/types"
 
 export type ActivationMode = "focus" | "dblclick" | "none"
@@ -107,6 +108,11 @@ type PublicContext = DirectionProperty &
      * The callback that is called when in the edit mode.
      */
     onEdit?: () => void
+    /**
+     * Callback fired when an outside interaction was triggered.
+     * Useful for preventing blur on editable when composing it with other components.
+     */
+    onInteractOutside?(event: InteractOutsideEvent): void
     /**
      * The placeholder value to show when the `value` is empty
      */

--- a/packages/machines/select/src/select.machine.ts
+++ b/packages/machines/select/src/select.machine.ts
@@ -249,7 +249,9 @@ export function machine(userContext: UserDefinedContext) {
               const ignore = [dom.getTriggerElement(ctx)]
               return ignore.some((el) => contains(el, target))
             },
-            onInteractOutside() {
+            onInteractOutside(event) {
+              ctx.onInteractOutside?.(event)
+              if (event.defaultPrevented) return
               send({ type: "BLUR", src: "interact-outside" })
             },
           })

--- a/packages/machines/select/src/select.types.ts
+++ b/packages/machines/select/src/select.types.ts
@@ -1,5 +1,6 @@
 import type { StateMachine as S } from "@zag-js/core"
 import type { TypeaheadState } from "@zag-js/dom-query"
+import type { InteractOutsideEvent } from "@zag-js/interact-outside"
 import type { Placement, PositioningOptions } from "@zag-js/popper"
 import type { CommonProperties, Context, DirectionProperty, RequiredBy } from "@zag-js/types"
 
@@ -61,6 +62,11 @@ type PublicContext = DirectionProperty &
      * The callback fired when the menu is closed.
      */
     onClose?: () => void
+    /**
+     * Callback fired when an outside interaction was triggered.
+     * Useful for preventing blur on select when composing it with other components.
+     */
+    onInteractOutside?(event: InteractOutsideEvent): void
     /**
      * The positioning options of the menu.
      */

--- a/packages/machines/tags-input/src/tags-input.machine.ts
+++ b/packages/machines/tags-input/src/tags-input.machine.ts
@@ -270,7 +270,9 @@ export function machine(userContext: UserDefinedContext) {
             exclude(target) {
               return contains(dom.getRootEl(ctx), target)
             },
-            onInteractOutside() {
+            onInteractOutside(event) {
+              ctx.onInteractOutside?.(event)
+              if (event.defaultPrevented) return
               send({ type: "BLUR", src: "interact-outside" })
             },
           })

--- a/packages/machines/tags-input/src/tags-input.types.ts
+++ b/packages/machines/tags-input/src/tags-input.types.ts
@@ -1,6 +1,7 @@
 import type { StateMachine as S } from "@zag-js/core"
 import type { LiveRegion } from "@zag-js/live-region"
 import type { CommonProperties, Context, DirectionProperty, RequiredBy } from "@zag-js/types"
+import type { InteractOutsideEvent } from "@zag-js/interact-outside"
 
 type IntlTranslations = {
   clearTriggerLabel: string
@@ -94,7 +95,7 @@ type PublicContext = DirectionProperty &
     /**
      * Callback fired when the max tag count is reached or the `validateTag` function returns `false`
      */
-    onInvalid?: (details: { reason: ValidityState }) => void
+    onInvalid?(details: { reason: ValidityState }): void
     /**
      * Callback fired when a tag's value is updated
      */
@@ -104,6 +105,11 @@ type PublicContext = DirectionProperty &
      * Useful for preventing duplicates or invalid tag values.
      */
     validate?(details: { inputValue: string; values: string[] }): boolean
+    /**
+     * Callback fired when an outside interaction was triggered.
+     * Useful for preventing blur on the tags input when composing it with other components (e.g. combobox).
+     */
+    onInteractOutside?(event: InteractOutsideEvent): void
     /**
      * The behavior of the tags input when the input is blurred
      * - `"add"`: add the input value as a new tag


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This adds an `onInteractOutside ` hook to the context of tags-input, select, combobox and editable, to enable composition with other components (e.g. `combobox`).

Related PR: #522

## 🚀 New behavior

By adding an `onInteractOutside ` to the tags input context, users can hook into the logic, which determines if an event should be treated as an outside interaction.

Example:

```ts
import { useId } from "react"
import * as tagsInput from "@zag-js/tags-input"

tagsInput.machine({
  id: useId(),
  onInteractOutside(event) {
    if (comboboxContentEl.contains(event.target)) {
      event.preventDefault()
    }
  },
})
```

## 💣 Is this a breaking change (Yes/No):

No
