### PR TITLE
fix(checkbox): `slider` typo

### DIFF
--- a/.changeset/early-bananas-smash.md
+++ b/.changeset/early-bananas-smash.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/checkbox": patch
+---
+
+Fix typo in `interactive` type description.

--- a/packages/machines/checkbox/src/checkbox.types.ts
+++ b/packages/machines/checkbox/src/checkbox.types.ts
@@ -76,7 +76,7 @@ export type UserDefinedContext = RequiredBy<PublicContext, "id">
 type ComputedContext = Readonly<{
   /**
    * @computed
-   * Whether the slider is interactive
+   * Whether the checkbox is interactive
    */
   readonly isInteractive: boolean
 }>


### PR DESCRIPTION
Fix typo in `interactive` type description