### PR TITLE
fix(rating): fix arrow down navigation

### DIFF
--- a/.changeset/wise-turkeys-punch.md
+++ b/.changeset/wise-turkeys-punch.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/rating-group": patch
+---
+
+Fixed arrow down selecting previous instead of next star

--- a/packages/machines/rating-group/src/rating-group.connect.ts
+++ b/packages/machines/rating-group/src/rating-group.connect.ts
@@ -140,7 +140,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
               send("ARROW_LEFT")
             },
             ArrowDown() {
-              send("ARROW_LEFT")
+              send("ARROW_RIGHT")
             },
             Space() {
               send({ type: "SPACE", value: index })


### PR DESCRIPTION
Closes #566

## 📝 Description

Fixed arrow down selecting previous instead of next star
