### PR TITLE
fix(types): fix handlers and attributes types

### DIFF
--- a/.changeset/six-humans-agree.md
+++ b/.changeset/six-humans-agree.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"@zag-js/svelte": patch
 ---
 
 Fix handlers and attributes types for `normalizeProps`

--- a/.changeset/six-humans-agree.md
+++ b/.changeset/six-humans-agree.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Fix handlers and attributes types for `normalizeProps`

--- a/.changeset/six-humans-agree.md
+++ b/.changeset/six-humans-agree.md
@@ -1,5 +1,6 @@
 ---
 "@zag-js/svelte": patch
+"@zag-js/types": patch
 ---
 
 Fix handlers and attributes types for `normalizeProps`

--- a/examples/svelte-ts/src/pages/Accordion.svelte
+++ b/examples/svelte-ts/src/pages/Accordion.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import * as accordion from "@zag-js/accordion"
   import { useMachine, normalizeProps, zag } from "@zag-js/svelte"
   import StateVisualizer from "../components/state-visualizer.svelte"

--- a/examples/svelte-ts/src/pages/Select.svelte
+++ b/examples/svelte-ts/src/pages/Select.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import * as select from "@zag-js/select"
   import { zag, useMachine, normalizeProps } from "@zag-js/svelte"
   import StateVisualizer from "../components/state-visualizer.svelte"
@@ -31,7 +31,6 @@
       {/if}
     </button>
   </div>
-  <!-- <Portal> -->
   <div use:zag={api.positionerProps.handlers} {...api.positionerProps.attributes}>
     <ul use:zag={api.contentProps.handlers} {...api.contentProps.attributes}>
       {#each selectData as { label, value }}
@@ -45,7 +44,6 @@
       {/each}
     </ul>
   </div>
-  <!-- </Portal> -->
 </div>
 
 <Toolbar>

--- a/packages/frameworks/svelte/src/get-attributes-and-handlers.ts
+++ b/packages/frameworks/svelte/src/get-attributes-and-handlers.ts
@@ -1,6 +1,8 @@
-export function getAttributesAndHandlers(props: Record<string, any>) {
-  const handlers = {} as Record<string, any>
-  const attributes = {}
+import type { Dict } from "@zag-js/core/src/types"
+
+export function getAttributesAndHandlers(props: Dict) {
+  const handlers: Dict = {}
+  const attributes: Dict = {}
 
   Object.keys(props).forEach((key) => {
     // this is probably not a safe way to distiguish handlers

--- a/packages/frameworks/svelte/src/get-attributes-and-handlers.ts
+++ b/packages/frameworks/svelte/src/get-attributes-and-handlers.ts
@@ -1,5 +1,5 @@
 export function getAttributesAndHandlers(props: Record<string, any>) {
-  const handlers = {}
+  const handlers = {} as Record<string, any>
   const attributes = {}
 
   Object.keys(props).forEach((key) => {

--- a/packages/frameworks/svelte/src/normalize-attributes.ts
+++ b/packages/frameworks/svelte/src/normalize-attributes.ts
@@ -14,7 +14,6 @@ export function normalizeAttributes(attributes: Record<string, any>) {
 
   for (const [key, value] of Object.entries(attributes)) {
     if (key === "style") {
-      console.log("style", styleObjectToString(value))
       normalizedAttributes[key] = styleObjectToString(value)
       // filter out falsy values as html attributes like undefined are still applied
       // even if their value is falsy

--- a/packages/frameworks/svelte/src/normalize-attributes.ts
+++ b/packages/frameworks/svelte/src/normalize-attributes.ts
@@ -1,16 +1,18 @@
+import type { Dict } from "@zag-js/core/src/types"
+
 function camelCaseToDash(str: string) {
   return str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase()
 }
 
-function styleObjectToString(styleObject: Record<string, any>) {
+function styleObjectToString(styleObject: Dict) {
   return Object.entries(styleObject)
     .filter(([_, value]) => value !== undefined)
     .map(([key, value]) => `${camelCaseToDash(key)}: ${value}${typeof value === "number" ? "px" : ""}`)
     .join("; ")
 }
 
-export function normalizeAttributes(attributes: Record<string, any>) {
-  const normalizedAttributes: Record<string, any> = {}
+export function normalizeAttributes(attributes: Dict) {
+  const normalizedAttributes: Dict = {}
 
   for (const [key, value] of Object.entries(attributes)) {
     if (key === "style") {

--- a/packages/frameworks/svelte/src/normalize-handlers.ts
+++ b/packages/frameworks/svelte/src/normalize-handlers.ts
@@ -1,5 +1,5 @@
-export function normalizeHandlers(handlers: Record<string, () => void>) {
-  const normalizedHandlers: Record<string, () => void> = {}
+export function normalizeHandlers(handlers: Record<string, EventListener>) {
+  const normalizedHandlers: Record<string, EventListener> = {}
 
   for (const [key, value] of Object.entries(handlers)) {
     const eventName = key.replace(/^on/, "").toLowerCase()

--- a/packages/frameworks/svelte/src/normalize-props.ts
+++ b/packages/frameworks/svelte/src/normalize-props.ts
@@ -1,15 +1,10 @@
-import { createNormalizer, JSX } from "@zag-js/types"
+import { createNormalizer, PropTypes, SplitArgs } from "@zag-js/types"
 import type {} from "svelte"
 import { getAttributesAndHandlers } from "./get-attributes-and-handlers"
 import { normalizeAttributes } from "./normalize-attributes"
 import { normalizeHandlers } from "./normalize-handlers"
 
-type PropTypes = JSX.IntrinsicElements & {
-  element: JSX.HTMLAttributes<any>
-  style: JSX.CSSProperties
-}
-
-export const normalizeProps = createNormalizer<PropTypes>((v) => {
+export const normalizeProps = createNormalizer<PropTypes<SplitArgs>>((v) => {
   const { handlers, attributes } = getAttributesAndHandlers(v)
   const normalizedAttributes = normalizeAttributes(attributes)
   const normalizedHandlers = normalizeHandlers(handlers)

--- a/packages/frameworks/svelte/src/normalize-props.ts
+++ b/packages/frameworks/svelte/src/normalize-props.ts
@@ -1,13 +1,14 @@
-import { createNormalizer, PropTypes, SplitArgs } from "@zag-js/types"
-import type {} from "svelte"
+import type { SplitArgs } from "./types"
+import { createNormalizer, PropTypes } from "@zag-js/types"
+import type { Dict } from "@zag-js/core/src/types"
 import { getAttributesAndHandlers } from "./get-attributes-and-handlers"
 import { normalizeAttributes } from "./normalize-attributes"
 import { normalizeHandlers } from "./normalize-handlers"
 
-export const normalizeProps = createNormalizer<PropTypes<SplitArgs>>((v) => {
+export const normalizeProps = createNormalizer<PropTypes<SplitArgs<Dict>>>((v: Dict) => {
   const { handlers, attributes } = getAttributesAndHandlers(v)
-  const normalizedAttributes = normalizeAttributes(attributes)
-  const normalizedHandlers = normalizeHandlers(handlers)
+  const normalizedAttributes = normalizeAttributes(attributes) as SplitArgs["attributes"]
+  const normalizedHandlers = normalizeHandlers(handlers) as SplitArgs["handlers"]
 
   return {
     handlers: normalizedHandlers,

--- a/packages/frameworks/svelte/src/types.ts
+++ b/packages/frameworks/svelte/src/types.ts
@@ -1,0 +1,4 @@
+export type SplitArgs<T = any> = {
+  attributes: T
+  handlers: Record<string, EventListener>
+}

--- a/packages/frameworks/svelte/src/zag.ts
+++ b/packages/frameworks/svelte/src/zag.ts
@@ -1,4 +1,4 @@
-export function zag(node: Element, handlers: Record<string, () => void>) {
+export function zag(node: Element, handlers: Record<string, EventListener>) {
   Object.entries(handlers).forEach(([key, value]) => {
     node.addEventListener(key, value)
   })

--- a/packages/types/src/prop-types.ts
+++ b/packages/types/src/prop-types.ts
@@ -1,6 +1,10 @@
 import type { JSX } from "./jsx"
 
 type Dict<T = any> = Record<string, T>
+export type SplitArgs<T = any> = {
+  attributes: Record<string, T>
+  handlers: Record<string, EventListener>
+}
 
 type Booleanish = boolean | "true" | "false"
 
@@ -44,7 +48,10 @@ type DataAttr = {
   [key in `data-${string}`]?: string | number | Booleanish
 }
 
-export type PropTypes = Record<"button" | "label" | "input" | "output" | "element" | "select" | "style", Dict>
+export type PropTypes<T = any> = Record<
+  "button" | "label" | "input" | "output" | "element" | "select" | "style",
+  T extends SplitArgs ? SplitArgs : Dict
+>
 
 export type NormalizeProps<T extends PropTypes> = {
   [K in keyof T]: (props: K extends keyof JSX.IntrinsicElements ? DataAttr & JSX.IntrinsicElements[K] : never) => T[K]
@@ -52,7 +59,6 @@ export type NormalizeProps<T extends PropTypes> = {
   element(props: DataAttr & JSX.HTMLAttributes<HTMLElement>): T["element"]
   style: JSX.CSSProperties
 }
-
 export function createNormalizer<T extends PropTypes>(fn: (props: Dict) => Dict): NormalizeProps<T> {
   return new Proxy({} as any, {
     get() {

--- a/packages/types/src/prop-types.ts
+++ b/packages/types/src/prop-types.ts
@@ -1,10 +1,6 @@
 import type { JSX } from "./jsx"
 
 type Dict<T = any> = Record<string, T>
-export type SplitArgs<T = any> = {
-  attributes: Record<string, T>
-  handlers: Record<string, EventListener>
-}
 
 type Booleanish = boolean | "true" | "false"
 
@@ -48,10 +44,7 @@ type DataAttr = {
   [key in `data-${string}`]?: string | number | Booleanish
 }
 
-export type PropTypes<T = any> = Record<
-  "button" | "label" | "input" | "output" | "element" | "select" | "style",
-  T extends SplitArgs ? SplitArgs : Dict
->
+export type PropTypes<T = Dict> = Record<"button" | "label" | "input" | "output" | "element" | "select" | "style", T>
 
 export type NormalizeProps<T extends PropTypes> = {
   [K in keyof T]: (props: K extends keyof JSX.IntrinsicElements ? DataAttr & JSX.IntrinsicElements[K] : never) => T[K]


### PR DESCRIPTION
## 📝 Description

> Add TS support for Svelte normalizer
## ⛳️ Current behavior (updates)

Current behavior returns errors on TS with the "attributes" and "handlers". This modifications aims to solve that.

## 🚀 New behavior

> When using the svelte normalizer, we expect the return to be an object with "attributes" and "handlers" instead.

## 💣 Is this a breaking change (Yes/No):

No
