### PR TITLE
chore(switch): remove external input type from switch examples

### DIFF
--- a/examples/next-ts/pages/switch.tsx
+++ b/examples/next-ts/pages/switch.tsx
@@ -19,7 +19,7 @@ export default function Page() {
     <>
       <main className="switch">
         <label {...api.rootProps}>
-          <input type="checkbox" {...api.inputProps} />
+          <input {...api.inputProps} />
           <span {...api.controlProps}>
             <span {...api.thumbProps} />
           </span>

--- a/examples/solid-ts/src/pages/switch.tsx
+++ b/examples/solid-ts/src/pages/switch.tsx
@@ -19,7 +19,7 @@ export default function Page() {
     <>
       <main class="switch">
         <label {...api().rootProps}>
-          <input type="checkbox" {...api().inputProps} />
+          <input {...api().inputProps} />
           <span {...api().controlProps}>
             <span {...api().thumbProps} />
           </span>

--- a/examples/vue-ts/src/pages/switch.tsx
+++ b/examples/vue-ts/src/pages/switch.tsx
@@ -24,7 +24,7 @@ export default defineComponent({
         <>
           <main class="switch">
             <label {...api.rootProps}>
-              <input type="checkbox" {...api.inputProps} />
+              <input {...api.inputProps} />
               <span {...api.controlProps}>
                 <span {...api.thumbProps} />
               </span>


### PR DESCRIPTION
remove external input type from switch examples