### PR TITLE
refactor: switch machine, add switch test

### DIFF
--- a/.xstate/switch.js
+++ b/.xstate/switch.js
@@ -1,42 +1,45 @@
-"use strict"
+"use strict";
 
-var _xstate = require("xstate")
-const { actions, createMachine, assign } = _xstate
-const { choose } = actions
-const fetchMachine = createMachine(
-  {
-    id: "switch",
-    initial: "ready",
-    context: {},
-    activities: ["trackFormControlState"],
-    on: {
-      "CHECKED.TOGGLE": {
-        actions: ["toggleChecked"],
-      },
-      "CHECKED.SET": {
-        actions: ["dispatchChangeEvent"],
-      },
-      "CONTEXT.SET": {
-        actions: ["setContext"],
-      },
+var _xstate = require("xstate");
+const {
+  actions,
+  createMachine,
+  assign
+} = _xstate;
+const {
+  choose
+} = actions;
+const fetchMachine = createMachine({
+  id: "switch",
+  initial: "ready",
+  context: {},
+  activities: ["trackFormControlState"],
+  on: {
+    "CHECKED.TOGGLE": {
+      actions: ["toggleChecked"]
     },
-    on: {
-      UPDATE_CONTEXT: {
-        actions: "updateContext",
-      },
+    "CHECKED.SET": {
+      actions: ["dispatchChangeEvent"]
     },
-    states: {
-      ready: {},
-    },
+    "CONTEXT.SET": {
+      actions: ["setContext"]
+    }
   },
-  {
-    actions: {
-      updateContext: assign((context, event) => {
-        return {
-          [event.contextKey]: true,
-        }
-      }),
-    },
-    guards: {},
+  on: {
+    UPDATE_CONTEXT: {
+      actions: "updateContext"
+    }
   },
-)
+  states: {
+    ready: {}
+  }
+}, {
+  actions: {
+    updateContext: assign((context, event) => {
+      return {
+        [event.contextKey]: true
+      };
+    })
+  },
+  guards: {}
+});

--- a/.xstate/switch.js
+++ b/.xstate/switch.js
@@ -1,79 +1,42 @@
-"use strict";
+"use strict"
 
-var _xstate = require("xstate");
-const {
-  actions,
-  createMachine,
-  assign
-} = _xstate;
-const {
-  choose
-} = actions;
-const fetchMachine = createMachine({
-  id: "switch",
-  initial: ctx.checked ? "checked" : "unchecked",
-  context: {
-    "shouldCheck && isInteractive": false,
-    "isInteractive": false,
-    "isInteractive": false,
-    "isInteractive": false
-  },
-  activities: ["trackFormControlState"],
-  on: {
-    SET_STATE: [{
-      cond: "shouldCheck && isInteractive",
-      target: "checked",
-      actions: ["invokeOnChange", "dispatchChangeEvent"]
-    }, {
-      cond: "isInteractive",
-      target: "unchecked",
-      actions: ["invokeOnChange", "dispatchChangeEvent"]
-    }],
-    SET_ACTIVE: {
-      actions: "setActive"
+var _xstate = require("xstate")
+const { actions, createMachine, assign } = _xstate
+const { choose } = actions
+const fetchMachine = createMachine(
+  {
+    id: "switch",
+    initial: "ready",
+    context: {},
+    activities: ["trackFormControlState"],
+    on: {
+      "CHECKED.TOGGLE": {
+        actions: ["toggleChecked"],
+      },
+      "CHECKED.SET": {
+        actions: ["dispatchChangeEvent"],
+      },
+      "CONTEXT.SET": {
+        actions: ["setContext"],
+      },
     },
-    SET_HOVERED: {
-      actions: "setHovered"
+    on: {
+      UPDATE_CONTEXT: {
+        actions: "updateContext",
+      },
     },
-    SET_FOCUSED: {
-      actions: "setFocused"
-    }
+    states: {
+      ready: {},
+    },
   },
-  on: {
-    UPDATE_CONTEXT: {
-      actions: "updateContext"
-    }
-  },
-  states: {
-    checked: {
-      on: {
-        TOGGLE: {
-          target: "unchecked",
-          cond: "isInteractive",
-          actions: ["invokeOnChange"]
+  {
+    actions: {
+      updateContext: assign((context, event) => {
+        return {
+          [event.contextKey]: true,
         }
-      }
+      }),
     },
-    unchecked: {
-      on: {
-        TOGGLE: {
-          target: "checked",
-          cond: "isInteractive",
-          actions: ["invokeOnChange"]
-        }
-      }
-    }
-  }
-}, {
-  actions: {
-    updateContext: assign((context, event) => {
-      return {
-        [event.contextKey]: true
-      };
-    })
+    guards: {},
   },
-  guards: {
-    "shouldCheck && isInteractive": ctx => ctx["shouldCheck && isInteractive"],
-    "isInteractive": ctx => ctx["isInteractive"]
-  }
-});
+)

--- a/e2e/switch.e2e.ts
+++ b/e2e/switch.e2e.ts
@@ -1,0 +1,65 @@
+import { expect, Page, test } from "@playwright/test"
+import { a11y, controls, part } from "./__utils"
+
+const root = part("root")
+const label = part("label")
+const control = part("control")
+const input = part("input")
+
+const expectToBeChecked = async (page: Page) => {
+  await expect(page.locator(root)).toHaveAttribute("data-checked", "")
+  await expect(page.locator(label)).toHaveAttribute("data-checked", "")
+  await expect(page.locator(control)).toHaveAttribute("data-checked", "")
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/switch")
+})
+
+test("should have no accessibility violation", async ({ page }) => {
+  await a11y(page)
+})
+
+test("should be checked when clicked", async ({ page }) => {
+  await page.click(root)
+  await expectToBeChecked(page)
+})
+
+test("should be focused when page is tabbed", async ({ page }) => {
+  await page.click("main")
+  await page.keyboard.press("Tab")
+  await expect(page.locator(input)).toBeFocused()
+  await expect(page.locator(control)).toHaveAttribute("data-focus", "")
+})
+
+test("should be checked when spacebar is pressed while focused", async ({ page }) => {
+  await page.click("main")
+  await page.keyboard.press("Tab")
+  await page.keyboard.press(" ")
+  await expectToBeChecked(page)
+})
+
+test("should have disabled attributes when disabled", async ({ page }) => {
+  await controls(page).bool("disabled")
+  await expect(page.locator(input)).toHaveAttribute("data-disabled", "")
+  await expect(page.locator(input)).toBeDisabled()
+})
+
+test("should not be focusable when disabled", async ({ page }) => {
+  await controls(page).bool("disabled")
+  await page.click("main")
+  await page.keyboard.press("Tab")
+  await expect(page.locator(input)).not.toBeFocused()
+})
+
+test("input is not blurred on label click", async ({ page }) => {
+  let blurCount = 0
+  await page.exposeFunction("trackBlur", () => blurCount++)
+  await page.locator(input).evaluate((input) => {
+    input.addEventListener("blur", (window as any).trackBlur)
+  })
+  await page.click(label)
+  await page.click(label)
+  await page.click(label)
+  expect(blurCount).toBe(0)
+})

--- a/examples/next-ts/pages/switch.tsx
+++ b/examples/next-ts/pages/switch.tsx
@@ -9,9 +9,15 @@ import { useControls } from "../hooks/use-controls"
 export default function Page() {
   const controls = useControls(switchControls)
 
-  const [state, send] = useMachine(zagSwitch.machine({ id: useId() }), {
-    context: controls.context,
-  })
+  const [state, send] = useMachine(
+    zagSwitch.machine({
+      id: useId(),
+      name: "switch",
+    }),
+    {
+      context: controls.context,
+    },
+  )
 
   const api = zagSwitch.connect(state, send, normalizeProps)
 

--- a/examples/solid-ts/src/pages/switch.tsx
+++ b/examples/solid-ts/src/pages/switch.tsx
@@ -9,9 +9,15 @@ import { useControls } from "../hooks/use-controls"
 export default function Page() {
   const controls = useControls(switchControls)
 
-  const [state, send] = useMachine(zagSwitch.machine({ id: createUniqueId() }), {
-    context: controls.context,
-  })
+  const [state, send] = useMachine(
+    zagSwitch.machine({
+      name: "switch",
+      id: createUniqueId(),
+    }),
+    {
+      context: controls.context,
+    },
+  )
 
   const api = createMemo(() => zagSwitch.connect(state, send, normalizeProps))
 

--- a/examples/vue-ts/src/pages/switch.tsx
+++ b/examples/vue-ts/src/pages/switch.tsx
@@ -7,13 +7,19 @@ import { Toolbar } from "../components/toolbar"
 import { useControls } from "../hooks/use-controls"
 
 export default defineComponent({
-  name: "switch",
+  name: "Switch",
   setup() {
     const controls = useControls(switchControls)
 
-    const [state, send] = useMachine(zagSwitch.machine({ id: "1" }), {
-      context: controls.context,
-    })
+    const [state, send] = useMachine(
+      zagSwitch.machine({
+        name: "switch",
+        id: "v1",
+      }),
+      {
+        context: controls.context,
+      },
+    )
 
     const apiRef = computed(() => zagSwitch.connect(state.value, send, normalizeProps))
 

--- a/packages/docs/api.json
+++ b/packages/docs/api.json
@@ -14,7 +14,7 @@
         "description": "Sets the value of the accordion."
       },
       "getItemState": {
-        "type": "(props: ItemProps) => { isOpen: boolean; isFocused: boolean; isDisabled: boolean; }",
+        "type": "(props: ItemState",
         "description": "Gets the state of an accordion item."
       }
     },
@@ -77,6 +77,10 @@
         "type": "number",
         "description": "The current index of the carousel"
       },
+      "scrollProgress": {
+        "type": "number",
+        "description": "The current scroll progress of the carousel"
+      },
       "isAutoplay": {
         "type": "boolean",
         "description": "Whether the carousel is currently auto-playing"
@@ -85,12 +89,12 @@
         "type": "boolean",
         "description": "Whether the carousel is can scroll to the next slide"
       },
-      "canScrollPrevious": {
+      "canScrollPrev": {
         "type": "boolean",
         "description": "Whether the carousel is can scroll to the previous slide"
       },
       "scrollTo": {
-        "type": "(index: number) => void",
+        "type": "(index: number, jump?: boolean) => void",
         "description": "Function to scroll to a specific slide index"
       },
       "scrollToNext": {
@@ -102,8 +106,16 @@
         "description": "Function to scroll to the previous slide"
       },
       "getSlideState": {
-        "type": "(props: SlideProps) => { valueText: string; isCurrent: boolean; isNext: boolean; isPrevious: boolean; }",
+        "type": "(props: SlideProps) => { valueText: string; isCurrent: boolean; isNext: boolean; isPrevious: boolean; isInView: boolean; }",
         "description": "Returns the state of a specific slide"
+      },
+      "play": {
+        "type": "() => void",
+        "description": "Function to start/resume autoplay"
+      },
+      "pause": {
+        "type": "() => void",
+        "description": "Function to pause autoplay"
       }
     },
     "context": {
@@ -120,6 +132,46 @@
       "getRootNode": {
         "type": "() => Node | ShadowRoot | Document",
         "description": "A root node to correctly resolve document in custom environments. E.x.: Iframes, Electron.",
+        "defaultValue": null
+      },
+      "orientation": {
+        "type": "\"horizontal\" | \"vertical\"",
+        "description": "The orientation of the carousel.",
+        "defaultValue": "\"horizontal\""
+      },
+      "align": {
+        "type": "\"start\" | \"end\" | \"center\"",
+        "description": "The alignment of the slides in the carousel.",
+        "defaultValue": null
+      },
+      "slidesPerView": {
+        "type": "number | \"auto\"",
+        "description": "The number of slides to show at a time.",
+        "defaultValue": null
+      },
+      "loop": {
+        "type": "boolean",
+        "description": "Whether the carousel should loop around.",
+        "defaultValue": null
+      },
+      "index": {
+        "type": "number",
+        "description": "The current slide index.",
+        "defaultValue": null
+      },
+      "spacing": {
+        "type": "string",
+        "description": "The amount of space between slides.",
+        "defaultValue": null
+      },
+      "onSlideChange": {
+        "type": "(details: ChangeDetails) => void",
+        "description": "Function called when the slide changes.",
+        "defaultValue": null
+      },
+      "ids": {
+        "type": "Partial<{ root: string; viewport: string; slide(index: number): string; slideGroup: string; nextTrigger: string; prevTrigger: string; indicatorGroup: string; indicator(index: number): string; }>",
+        "description": "The ids of the elements in the carousel. Useful for composition.",
         "defaultValue": null
       }
     }
@@ -142,21 +194,13 @@
         "type": "boolean",
         "description": "Whether the checkbox is focused"
       },
-      "isReadOnly": {
-        "type": "boolean",
-        "description": "Whether the checkbox is readonly"
-      },
-      "view": {
-        "type": "string",
-        "description": "The current view of the checkbox (checked, unchecked, mixed)"
+      "checkedState": {
+        "type": "CheckedState",
+        "description": "The checked state of the checkbox"
       },
       "setChecked": {
-        "type": "(checked: boolean) => void",
+        "type": "(checked: CheckedState) => void",
         "description": "Function to set the checked state of the checkbox"
-      },
-      "setIndeterminate": {
-        "type": "(indeterminate: boolean) => void",
-        "description": "Function to set the indeterminate state of the checkbox"
       }
     },
     "context": {
@@ -180,24 +224,9 @@
         "description": "The ids of the elements in the checkbox. Useful for composition.",
         "defaultValue": null
       },
-      "indeterminate": {
-        "type": "boolean",
-        "description": "If `true`, the checkbox will be indeterminate.\nThis only affects the icon shown inside checkbox\nand does not modify the isChecked property.",
-        "defaultValue": null
-      },
       "disabled": {
         "type": "boolean",
         "description": "If `true`, the checkbox will be disabled",
-        "defaultValue": null
-      },
-      "focusable": {
-        "type": "boolean",
-        "description": "If `true` and `disabled` is passed, the checkbox will\nremain tabbable but not interactive",
-        "defaultValue": null
-      },
-      "readOnly": {
-        "type": "boolean",
-        "description": "If `true`, the checkbox will be readonly",
         "defaultValue": null
       },
       "invalid": {
@@ -211,34 +240,29 @@
         "defaultValue": null
       },
       "checked": {
-        "type": "boolean",
+        "type": "CheckedState",
         "description": "If `true`, the checkbox will be checked.",
         "defaultValue": null
       },
       "onChange": {
-        "type": "(details: { checked: boolean | \"indeterminate\"; }) => void",
+        "type": "(details: { checked: CheckedState; }) => void",
         "description": "The callback invoked when the checked state of the `Checkbox` changes.",
         "defaultValue": null
       },
       "name": {
         "type": "string",
-        "description": "The name of the input field in a checkbox\n(Useful for form submission).",
+        "description": "The name of the input field in a checkbox. Useful for form submission.",
         "defaultValue": null
       },
       "form": {
         "type": "string",
-        "description": "The associate form of the underlying checkbox.",
+        "description": "The id of the form that the checkbox belongs to.",
         "defaultValue": null
       },
       "value": {
-        "type": "string | number",
-        "description": "The value to be used in the checkbox input.\nThis is the value that will be returned on form submission.",
-        "defaultValue": null
-      },
-      "aria-label": {
         "type": "string",
-        "description": "Defines the string that labels the checkbox element.",
-        "defaultValue": null
+        "description": "The value of checkbox input. Useful for form submission.",
+        "defaultValue": "\"on\""
       }
     }
   },
@@ -282,6 +306,11 @@
       "getRootNode": {
         "type": "() => Node | ShadowRoot | Document",
         "description": "A root node to correctly resolve document in custom environments. E.x.: Iframes, Electron.",
+        "defaultValue": null
+      },
+      "ids": {
+        "type": "Partial<{ content: string; area: string; areaGradient: string; areaThumb: string; channelInput(id: string): string; channelSliderTrack(id: ColorChannel): string; }>",
+        "description": "The ids of the elements in the color picker. Useful for composition.",
         "defaultValue": null
       },
       "dir": {
@@ -376,7 +405,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ root: string; label: string; control: string; input: string; content: string; trigger: string; clearTrigger: string; option(id: string, index?: number): string; }>",
+        "type": "Partial<{ root: string; label: string; control: string; input: string; content: string; trigger: string; clearTrigger: string; option(id: string, index?: number): string; positioner: string; }>",
         "description": "The ids of the elements in the combobox. Useful for composition.",
         "defaultValue": null
       },
@@ -678,6 +707,11 @@
         "description": "The localized messages to use.",
         "defaultValue": null
       },
+      "ids": {
+        "type": "Partial<{ grid(id: string): string; header: string; content: string; cellTrigger(id: string): string; prevTrigger(view: DateView): string; clearTrigger: string; control: string; input: string; trigger: string; monthSelect: string; yearSelect: string; }>",
+        "description": "The ids of the elements in the date picker. Useful for composition.",
+        "defaultValue": null
+      },
       "name": {
         "type": "string",
         "description": "The `name` attribute of the input element.",
@@ -764,7 +798,7 @@
         "defaultValue": null
       },
       "selectionMode": {
-        "type": "\"single\" | \"multiple\" | \"range\"",
+        "type": "SelectionMode",
         "description": "The selection mode of the calendar.\n- `single` - only one date can be selected\n- `multiple` - multiple dates can be selected\n- `range` - a range of dates can be selected",
         "defaultValue": null
       },
@@ -1053,6 +1087,11 @@
         "type": "IntlTranslations",
         "description": "Specifies the localized strings that identifies the accessibility elements and their states",
         "defaultValue": null
+      },
+      "finalFocusEl": {
+        "type": "() => HTMLElement",
+        "description": "The element that should receive focus when the editable is closed.\nBy default, it will focus on the trigger element.",
+        "defaultValue": null
       }
     }
   },
@@ -1071,7 +1110,7 @@
         "description": "Function to close the hover card"
       },
       "setPositioning": {
-        "type": "(options: Partial<PositioningOptions>) => void",
+        "type": "(options?: Partial<PositioningOptions>) => void",
         "description": "Function to reposition the popover"
       }
     },
@@ -1092,13 +1131,18 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ trigger: string; content: string; }>",
+        "type": "Partial<{ trigger: string; content: string; positioner: string; arrow: string; }>",
         "description": "The ids of the elements in the popover. Useful for composition.",
         "defaultValue": null
       },
-      "onOpenChange": {
-        "type": "(open: boolean) => void",
+      "onOpen": {
+        "type": "VoidFunction",
         "description": "Function invoked when the hover card is opened.",
+        "defaultValue": null
+      },
+      "onClose": {
+        "type": "VoidFunction",
+        "description": "Function invoked when the hover card is closed.",
         "defaultValue": null
       },
       "openDelay": {
@@ -1166,7 +1210,7 @@
         "description": "Function to check if an option is checked"
       },
       "setPositioning": {
-        "type": "(options: Partial<PositioningOptions>) => void",
+        "type": "(options?: Partial<PositioningOptions>) => void",
         "description": "Function to reposition the popover"
       }
     },
@@ -1187,7 +1231,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ trigger: string; contextTrigger: string; content: string; label(id: string): string; group(id: string): string; }>",
+        "type": "Partial<{ trigger: string; contextTrigger: string; content: string; label(id: string): string; group(id: string): string; positioner: string; arrow: string; }>",
         "description": "The ids of the elements in the menu. Useful for composition.",
         "defaultValue": null
       },
@@ -1557,6 +1601,11 @@
         "type": "(details: { page: number; pageSize: number; srcElement: HTMLElement; }) => void",
         "description": "Called when the page number is changed, and it takes the resulting page number argument",
         "defaultValue": null
+      },
+      "type": {
+        "type": "\"button\" | \"link\"",
+        "description": "The type of the trigger element",
+        "defaultValue": "\"button\""
       }
     }
   },
@@ -1718,7 +1767,7 @@
         "description": "Function to close the popover"
       },
       "setPositioning": {
-        "type": "(options: Partial<PositioningOptions>) => void",
+        "type": "(options?: Partial<PositioningOptions>) => void",
         "description": "Function to reposition the popover"
       }
     },
@@ -1734,7 +1783,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ anchor: string; trigger: string; content: string; title: string; description: string; closeTrigger: string; }>",
+        "type": "Partial<{ anchor: string; trigger: string; content: string; title: string; description: string; closeTrigger: string; positioner: string; arrow: string; }>",
         "description": "The ids of the elements in the popover. Useful for composition.",
         "defaultValue": null
       },
@@ -1904,7 +1953,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ root: string; label: string; radio(value: string): string; radioLabel(value: string): string; radioControl(value: string): string; radioInput(value: string): string; }>",
+        "type": "Partial<{ root: string; label: string; indicator: string; radio(value: string): string; radioLabel(value: string): string; radioControl(value: string): string; radioInput(value: string): string; }>",
         "description": "The ids of the elements in the radio. Useful for composition.",
         "defaultValue": null
       },
@@ -2025,7 +2074,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ root: string; thumb(index: number): string; control: string; track: string; range: string; label: string; output: string; }>",
+        "type": "Partial<{ root: string; thumb(index: number): string; control: string; track: string; range: string; label: string; output: string; marker(index: number): string; }>",
         "description": "The ids of the elements in the range slider. Useful for composition.",
         "defaultValue": null
       },
@@ -2152,7 +2201,7 @@
         "description": "The array of rating values. Returns an array of numbers from 1 to the max value."
       },
       "getRatingState": {
-        "type": "(index: number) => { isEqual: boolean; isValueEmpty: boolean; isHighlighted: boolean; isHalf: boolean; isChecked: boolean; }",
+        "type": "(props: ItemState",
         "description": "Returns the state of a rating item"
       }
     },
@@ -2294,7 +2343,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ content: string; trigger: string; label: string; option(id: string | number): string; }>",
+        "type": "Partial<{ content: string; trigger: string; label: string; option(id: string | number): string; hiddenSelect: string; positioner: string; optionGroup(id: string | number): string; optionGroupLabel(id: string | number): string; }>",
         "description": "The ids of the elements in the accordion. Useful for composition.",
         "defaultValue": null
       },
@@ -2440,7 +2489,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ root: string; thumb: string; control: string; track: string; range: string; label: string; output: string; }>",
+        "type": "Partial<{ root: string; thumb: string; control: string; track: string; range: string; label: string; output: string; hiddenInput: string; }>",
         "description": "The ids of the elements in the slider. Useful for composition.",
         "defaultValue": null
       },
@@ -2591,6 +2640,36 @@
         "type": "() => Node | ShadowRoot | Document",
         "description": "A root node to correctly resolve document in custom environments. E.x.: Iframes, Electron.",
         "defaultValue": null
+      },
+      "orientation": {
+        "type": "\"horizontal\" | \"vertical\"",
+        "description": "The orientation of the splitter. Can be `horizontal` or `vertical`",
+        "defaultValue": null
+      },
+      "size": {
+        "type": "PanelSizeData[]",
+        "description": "The size data of the panels",
+        "defaultValue": null
+      },
+      "onResize": {
+        "type": "(details: ResizeDetails) => void",
+        "description": "Function called when the splitter is resized.",
+        "defaultValue": null
+      },
+      "onResizeStart": {
+        "type": "(details: ResizeDetails) => void",
+        "description": "Function called when the splitter resize starts.",
+        "defaultValue": null
+      },
+      "onResizeEnd": {
+        "type": "(details: ResizeDetails) => void",
+        "description": "Function called when the splitter resize ends.",
+        "defaultValue": null
+      },
+      "ids": {
+        "type": "Partial<{ root: string; resizeTrigger(id: string): string; toggleTrigger(id: string): string; label(id: string): string; panel(id: string | number): string; }>",
+        "description": "The ids of the elements in the splitter. Useful for composition.",
+        "defaultValue": null
       }
     }
   },
@@ -2685,13 +2764,13 @@
       },
       "form": {
         "type": "string",
-        "description": "The associate form of the underlying input.",
+        "description": "The id of the form that the switch belongs to",
         "defaultValue": null
       },
       "value": {
         "type": "string | number",
-        "description": "The value to be used in the switch input.\nThis is the value that will be returned on form submission.",
-        "defaultValue": null
+        "description": "The value of switch input. Useful for form submission.",
+        "defaultValue": "\"on\""
       },
       "aria-label": {
         "type": "string",
@@ -2721,6 +2800,10 @@
       "clearValue": {
         "type": "() => void",
         "description": "Clears the value of the tabs."
+      },
+      "setIndicatorRect": {
+        "type": "(id: string) => void",
+        "description": "Sets the indicator rect to the tab with the given id."
       }
     },
     "context": {
@@ -2740,7 +2823,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ root: string; trigger: string; tablist: string; contentGroup: string; content: string; }>",
+        "type": "Partial<{ root: string; trigger: string; tablist: string; contentGroup: string; content: string; indicator: string; }>",
         "description": "The ids of the elements in the tabs. Useful for composition.",
         "defaultValue": null
       },
@@ -3030,7 +3113,7 @@
         "description": "Whether the toggle is pressed."
       },
       "setPressed": {
-        "type": "(value: boolean) => void",
+        "type": "(pressed: boolean) => void",
         "description": "Function to set the pressed state of the toggle."
       }
     },
@@ -3051,11 +3134,11 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ root: string; button: string; }>",
+        "type": "Partial<{ button: string; }>",
         "description": "The ids of the elements in the toggle. Useful for composition.",
         "defaultValue": null
       },
-      "label": {
+      "aria-label": {
         "type": "string",
         "description": "Specifies the localized strings that identifies the accessibility elements and their states",
         "defaultValue": null
@@ -3070,7 +3153,7 @@
         "description": "Function to call when the toggle is clicked.",
         "defaultValue": null
       },
-      "defaultPressed": {
+      "pressed": {
         "type": "boolean",
         "description": "Whether the toggle is initially pressed.",
         "defaultValue": null
@@ -3096,7 +3179,7 @@
         "description": "Returns the animation state of the tooltip."
       },
       "setPositioning": {
-        "type": "(options: Partial<PositioningOptions>) => void",
+        "type": "(options?: Partial<PositioningOptions>) => void",
         "description": "Function to reposition the popover"
       }
     },
@@ -3107,7 +3190,7 @@
         "defaultValue": null
       },
       "ids": {
-        "type": "Partial<{ trigger: string; content: string; }>",
+        "type": "Partial<{ trigger: string; content: string; arrow: string; positioner: string; }>",
         "description": "The ids of the elements in the tooltip. Useful for composition.",
         "defaultValue": null
       },

--- a/packages/machines/switch/src/index.ts
+++ b/packages/machines/switch/src/index.ts
@@ -1,3 +1,4 @@
+export { anatomy } from "./switch.anatomy"
 export { connect } from "./switch.connect"
 export { machine } from "./switch.machine"
 export type { UserDefinedContext as Context } from "./switch.types"

--- a/packages/machines/switch/src/switch.connect.ts
+++ b/packages/machines/switch/src/switch.connect.ts
@@ -6,26 +6,22 @@ import { parts } from "./switch.anatomy"
 import { visuallyHiddenStyle } from "@zag-js/visually-hidden"
 
 export function connect<T extends PropTypes>(state: State, send: Send, normalize: NormalizeProps<T>) {
-  const isChecked = state.matches("checked")
-
-  const isInteractive = state.context.isInteractive
   const isDisabled = state.context.disabled
-  const isInvalid = state.context.invalid
   const isReadOnly = state.context.readOnly
-  const isRequired = state.context.required
-  const isFocusable = state.context.focusable
+  const isInteractive = !(isReadOnly || isDisabled)
 
-  const isActive = state.context.active
-  const isHovered = state.context.hovered
+  const isFocusable = state.context.focusable
   const isFocused = !isDisabled && state.context.focused
 
-  const ariaLabel = state.context["aria-label"]
-  const ariaLabelledBy = state.context["aria-labelledby"] ?? dom.getLabelId(state.context)
-  const ariaDescribedBy = state.context["aria-describedby"]
-
-  const name = state.context.name
-  const form = state.context.form
-  const value = state.context.value
+  const dataAttrs = {
+    "data-active": dataAttr(state.context.active),
+    "data-focus": dataAttr(isFocused),
+    "data-hover": dataAttr(state.context.hovered),
+    "data-readonly": dataAttr(isReadOnly),
+    "data-disabled": dataAttr(isDisabled),
+    "data-checked": dataAttr(state.context.checked),
+    "data-invalid": dataAttr(state.context.invalid),
+  }
 
   const trulyDisabled = isDisabled && !isFocusable
 
@@ -33,7 +29,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     /**
      * Whether the checkbox is checked
      */
-    isChecked,
+    isChecked: state.context.checked,
     /**
      * Whether the checkbox is disabled
      */
@@ -50,112 +46,90 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
      * Function to set the checked state of the switch.
      */
     setChecked(value: boolean) {
-      send({ type: "SET_STATE", checked: value })
+      if (isDisabled) return
+      send({ type: "CHECKED.SET", checked: value })
     },
 
     rootProps: normalize.label({
       ...parts.root.attrs,
+      ...dataAttrs,
       id: dom.getRootId(state.context),
       htmlFor: dom.getInputId(state.context),
-      "data-focus": dataAttr(isFocused),
-      "data-hover": dataAttr(isHovered),
-      "data-disabled": dataAttr(isDisabled),
-      "data-checked": dataAttr(isChecked),
-      "data-invalid": dataAttr(isInvalid),
-      "data-readonly": dataAttr(isReadOnly),
       onPointerMove() {
         if (!isInteractive) return
-        send({ type: "SET_HOVERED", value: true })
+        send({ type: "CONTEXT.SET", context: { hovered: true } })
       },
       onPointerLeave() {
         if (!isInteractive) return
-        send({ type: "SET_HOVERED", value: false })
+        send({ type: "CONTEXT.SET", context: { hovered: false } })
       },
       onPointerDown(event) {
         if (!isInteractive) return
         // On pointerdown, the input blurs and returns focus to the `body`,
         // we need to prevent this.
         if (isFocused) event.preventDefault()
-        send({ type: "SET_ACTIVE", value: true })
+        send({ type: "CONTEXT.SET", context: { active: true } })
       },
       onPointerUp() {
         if (!isInteractive) return
-        send({ type: "SET_ACTIVE", value: false })
+        send({ type: "CONTEXT.SET", context: { active: false } })
       },
     }),
 
     labelProps: normalize.element({
       ...parts.label.attrs,
+      ...dataAttrs,
       id: dom.getLabelId(state.context),
-      "data-focus": dataAttr(isFocused),
-      "data-hover": dataAttr(isHovered),
-      "data-readonly": dataAttr(isReadOnly),
-      "data-disabled": dataAttr(isDisabled),
-      "data-checked": dataAttr(isChecked),
-      "data-invalid": dataAttr(isInvalid),
     }),
 
     thumbProps: normalize.element({
       ...parts.thumb.attrs,
+      ...dataAttrs,
       id: dom.getThumbId(state.context),
-      "data-focus": dataAttr(isFocused),
-      "data-hover": dataAttr(isHovered),
-      "data-disabled": dataAttr(isDisabled),
-      "data-invalid": dataAttr(isInvalid),
-      "data-checked": dataAttr(isChecked),
-      "data-readonly": dataAttr(isReadOnly),
       "aria-hidden": true,
     }),
 
     controlProps: normalize.element({
       ...parts.control.attrs,
+      ...dataAttrs,
       id: dom.getControlId(state.context),
-      "data-focus": dataAttr(isFocused),
-      "data-hover": dataAttr(isHovered),
-      "data-disabled": dataAttr(isDisabled),
-      "data-invalid": dataAttr(isInvalid),
-      "data-checked": dataAttr(isChecked),
-      "data-readonly": dataAttr(isReadOnly),
       "aria-hidden": true,
-      "data-active": dataAttr(isActive),
     }),
 
     inputProps: normalize.input({
       ...parts.input.attrs,
       id: dom.getInputId(state.context),
       type: "checkbox",
-      required: isRequired,
-      defaultChecked: isChecked,
+      required: state.context.required,
+      defaultChecked: state.context.checked,
       "data-focus": dataAttr(isFocused),
-      "data-hover": dataAttr(isHovered),
+      "data-hover": dataAttr(state.context.hovered),
       disabled: trulyDisabled,
       "data-disabled": dataAttr(isDisabled),
       "aria-readonly": ariaAttr(isReadOnly),
-      "aria-label": ariaLabel,
-      "aria-labelledby": ariaLabelledBy,
-      "aria-invalid": isInvalid,
-      "aria-describedby": ariaDescribedBy,
-      name,
-      form,
-      value,
+      "aria-labelledby": dom.getLabelId(state.context),
+      "aria-invalid": state.context.invalid,
+      name: state.context.name,
+      form: state.context.form,
+      value: state.context.value,
       style: visuallyHiddenStyle,
       onChange() {
-        send({ type: "TOGGLE" })
+        send({ type: "CHECKED.TOGGLE" })
       },
       onBlur() {
-        send({ type: "SET_FOCUSED", value: false })
+        send({ type: "CONTEXT.SET", context: { focused: false } })
       },
       onFocus() {
-        send({ type: "SET_FOCUSED", value: true })
+        send({ type: "CONTEXT.SET", context: { focused: true } })
       },
       onKeyDown(event) {
         if (event.key === " ") {
-          send({ type: "SET_ACTIVE", value: true })
+          send({ type: "CONTEXT.SET", context: { active: true } })
         }
       },
       onKeyUp(event) {
         if (event.key === " ") {
-          send({ type: "SET_ACTIVE", value: false })
+          send({ type: "CONTEXT.SET", context: { active: false } })
         }
       },
     }),

--- a/packages/machines/switch/src/switch.dom.ts
+++ b/packages/machines/switch/src/switch.dom.ts
@@ -7,6 +7,5 @@ export const dom = createScope({
   getThumbId: (ctx: Ctx) => ctx.ids?.thumb ?? `checkbox:${ctx.id}:thumb`,
   getControlId: (ctx: Ctx) => ctx.ids?.control ?? `checkbox:${ctx.id}:control`,
   getInputId: (ctx: Ctx) => ctx.ids?.input ?? `checkbox:${ctx.id}:input`,
-
-  getInputEl: (ctx: Ctx) => dom.getById<HTMLInputElement>(ctx, dom.getInputId(ctx)),
+  getInputEl: (ctx: Ctx) => dom.queryById<HTMLInputElement>(ctx, dom.getInputId(ctx)),
 })

--- a/packages/machines/switch/src/switch.types.ts
+++ b/packages/machines/switch/src/switch.types.ts
@@ -47,19 +47,19 @@ type PublicContext = DirectionProperty &
     /**
      * Whether the switch is checked.
      */
-    checked?: boolean
+    checked: boolean
     /**
      * The name of the input field in a switch
      * (Useful for form submission).
      */
     name?: string
     /**
-     * The associate form of the underlying input.
+     * The id of the form that the switch belongs to
      */
     form?: string
     /**
-     * The value to be used in the switch input.
-     * This is the value that will be returned on form submission.
+     * The value of switch input. Useful for form submission.
+     * @default "on"
      */
     value?: string | number
     /**
@@ -72,36 +72,30 @@ type PublicContext = DirectionProperty &
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
 
-type ComputedContext = Readonly<{
-  /**
-   * @computed
-   * Whether the checkbox is interactive
-   */
-  readonly isInteractive: boolean
-}>
+type ComputedContext = Readonly<{}>
 
 type PrivateContext = Context<{
   /**
    * @internal
    * Whether the checkbox is pressed
    */
-  active: boolean
+  active?: boolean
   /**
    * @internal
    * Whether the checkbox has focus
    */
-  focused: boolean
+  focused?: boolean
   /**
    * @internal
    * Whether the checkbox is hovered
    */
-  hovered: boolean
+  hovered?: boolean
 }>
 
 export type MachineContext = PublicContext & PrivateContext & ComputedContext
 
 export type MachineState = {
-  value: "checked" | "unchecked"
+  value: "ready"
 }
 
 export type State = S.State<MachineContext, MachineState>

--- a/shared/src/style.css
+++ b/shared/src/style.css
@@ -595,7 +595,6 @@ main [data-testid="scrubber"] {
   display: flex;
   align-items: center;
   position: relative;
-  line-height: 0;
   width: fit-content;
 
   --switch-track-diff: calc(var(--switch-track-width) - var(--switch-track-height));


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

As with [commit 415509](https://github.com/chakra-ui/zag/commit/41550949e16b9f4879b89ed7e3658271912ebfaf), I fixed machine and transition in switch.

## ⛳️ Current behavior (updates)

Same with before

## 🚀 New behavior

- I added a test for switch, which is no different than checkbox, so I configured it the same.
- Removed `line-height: 0` that was being held by shared css on switch. I removed it because the test was failing because it didn't find the label when I tested it.
- I've added tests to test it, and I've tested it myself for each framework in the examples, so let me know if you see anything that doesn't work.

## 💣 Is this a breaking change (Yes/No):

No
