### PR TITLE
fix(switch): setChecked not working issue

### DIFF
--- a/.changeset/olive-geese-fly.md
+++ b/.changeset/olive-geese-fly.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/switch": patch
+---
+
+Fix issue where `setChecked` doesn't work

--- a/packages/machines/switch/src/switch.machine.ts
+++ b/packages/machines/switch/src/switch.machine.ts
@@ -72,7 +72,7 @@ export function machine(userContext: UserDefinedContext) {
         dispatchChangeEvent(ctx, evt) {
           const inputEl = dom.getInputEl(ctx)
           const checked = evt.checked
-          dispatchInputCheckedEvent(inputEl, checked)
+          dispatchInputCheckedEvent(inputEl, { checked, bubbles: true })
         },
         removeFocusIfNeeded(ctx) {
           if (ctx.disabled && ctx.focused) {


### PR DESCRIPTION
This PR resolves the issue with the Switch `setChecked` not working, which was introduced in commit 7eaa3539bf11f97bf1d0f8c5cdbbe848e24f7f0b. The cause was a change in the `dispatchInputCheckedEvent` function, but the corresponding function call in the Switch component was not updated. This PR updates the function call to ensure the `setChecked` works as expected.