### PR TITLE
Vanilla events normalization

### DIFF
--- a/examples/svelte-kit/src/routes/checkbox/+page.svelte
+++ b/examples/svelte-kit/src/routes/checkbox/+page.svelte
@@ -30,7 +30,6 @@
         id="check-id"
         disabled={api.isChecked}
         on:click={() => {
-          console.log("in")
           api.setChecked(true)
         }}
       >

--- a/examples/svelte-kit/src/routes/checkbox/+page.svelte
+++ b/examples/svelte-kit/src/routes/checkbox/+page.svelte
@@ -2,7 +2,6 @@
   import * as checkbox from "@zag-js/checkbox"
   import { events, normalizeProps, useMachine } from "@zag-js/svelte"
   import { checkboxControls } from "@zag-js/shared"
-  import serialize from "form-serialize"
   import StateVisualizer from "../../components/state-visualizer.svelte"
   import Toolbar from "../../components/toolbar.svelte"
   import { ControlsUI, useControls } from "../../stores/controls"
@@ -16,12 +15,7 @@
 </script>
 
 <main class="checkbox">
-  <form
-    on:change={(e) => {
-      const result = serialize(e.currentTarget, { hash: true })
-      console.log(result)
-    }}
-  >
+  <form>
     <fieldset>
       <label {...api.rootProps.attrs} use:events={api.rootProps.handlers}>
         <div {...api.controlProps.attrs} use:events={api.controlProps.handlers} />
@@ -31,7 +25,17 @@
         <input {...api.inputProps.attrs} use:events={api.inputProps.handlers} />
       </label>
 
-      <button type="button" disabled={api.isChecked} on:click={() => api.setChecked(true)}> Check </button>
+      <button
+        type="button"
+        id="check-id"
+        disabled={api.isChecked}
+        on:click={() => {
+          console.log("in")
+          api.setChecked(true)
+        }}
+      >
+        Check
+      </button>
       <button type="button" disabled={!api.isChecked} on:click={() => api.setChecked(false)}> Uncheck </button>
       <button type="reset">Reset Form</button>
     </fieldset>

--- a/examples/svelte-kit/src/routes/select/+page.svelte
+++ b/examples/svelte-kit/src/routes/select/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import * as select from "@zag-js/select"
   import { events, useMachine, normalizeProps } from "@zag-js/svelte"
-  import { selectControls } from "@zag-js/shared"
+  import { selectControls, selectData } from "@zag-js/shared"
   import StateVisualizer from "../../components/state-visualizer.svelte"
   import Toolbar from "../../components/toolbar.svelte"
   import { ControlsUI, useControls } from "../../stores/controls"
@@ -29,12 +29,12 @@
 
   <div {...api.positionerProps.attrs} use:events={api.positionerProps.handlers}>
     <ul {...api.contentProps.attrs} use:events={api.contentProps.handlers}>
-      <!-- {#each selectData as { label, value }}
+      {#each selectData as { label, value }}
         <li {...api.getOptionProps({ label, value }).attrs} use:events={api.getOptionProps({ label, value }).handlers}>
           <span>{label}</span>
           {#if api.selectedOption && value === api.selectedOption.value}✓{/if}
         </li>
-      {/each} -->
+      {/each}
     </ul>
   </div>
 </div>

--- a/examples/svelte-kit/src/routes/select/+page.svelte
+++ b/examples/svelte-kit/src/routes/select/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import * as select from "@zag-js/select"
   import { events, useMachine, normalizeProps } from "@zag-js/svelte"
-  import { selectControls, selectData } from "@zag-js/shared"
+  import { selectControls } from "@zag-js/shared"
   import StateVisualizer from "../../components/state-visualizer.svelte"
   import Toolbar from "../../components/toolbar.svelte"
   import { ControlsUI, useControls } from "../../stores/controls"
@@ -29,12 +29,12 @@
 
   <div {...api.positionerProps.attrs} use:events={api.positionerProps.handlers}>
     <ul {...api.contentProps.attrs} use:events={api.contentProps.handlers}>
-      {#each selectData as { label, value }}
+      <!-- {#each selectData as { label, value }}
         <li {...api.getOptionProps({ label, value }).attrs} use:events={api.getOptionProps({ label, value }).handlers}>
           <span>{label}</span>
           {#if api.selectedOption && value === api.selectedOption.value}✓{/if}
         </li>
-      {/each}
+      {/each} -->
     </ul>
   </div>
 </div>

--- a/packages/frameworks/svelte/src/events.ts
+++ b/packages/frameworks/svelte/src/events.ts
@@ -1,6 +1,9 @@
+import { handleChangeEvents } from "./handle-change-events"
+
 export function events(node: HTMLElement, props: Record<string, any>) {
   const { events: handlers } = props
   let events = { ...handlers }
+  handleChangeEvents(node as HTMLInputElement)
 
   Object.entries(events).forEach(([key, value]) => {
     node.addEventListener(key, value as EventListener)

--- a/packages/frameworks/svelte/src/handle-change-events.ts
+++ b/packages/frameworks/svelte/src/handle-change-events.ts
@@ -1,0 +1,44 @@
+import { onDestroy } from "svelte/internal"
+import { get, writable } from "svelte/store"
+
+export function handleChangeEvents(node: HTMLInputElement) {
+  const prevChangedProp = writable(node.checked)
+  const clicked = writable(false)
+  const changed = writable(false)
+
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.type === "attributes" && mutation.target.nodeName === "INPUT") {
+        const target = mutation.target as HTMLInputElement
+        changed.set(get(prevChangedProp) !== target.checked)
+
+        prevChangedProp.set(target.checked)
+      }
+    })
+  })
+
+  observer.observe(node, {
+    attributes: true,
+  })
+
+  const handleInputClick = (e: Event) => {
+    if (e.isTrusted) clicked.set(true)
+    else clicked.set(false)
+  }
+
+  if (node.tagName === "INPUT") {
+    node.addEventListener("click", handleInputClick)
+  }
+
+  changed.subscribe((changeVal) => {
+    const isClicked = get(clicked)
+    if (changeVal && !isClicked) {
+      node.dispatchEvent(new Event("change"))
+      clicked.set(false)
+    }
+  })
+
+  onDestroy(() => {
+    node.removeEventListener("click", handleInputClick)
+  })
+}

--- a/shared/src/data.ts
+++ b/shared/src/data.ts
@@ -1,8 +1,8 @@
-import { getData } from "country-list"
+import data from "country-list/data.json"
 
 export { paginationData } from "./pagination-data"
 
-export const selectData = getData().map((country) => ({
+export const selectData = data.map((country) => ({
   label: `${country.name} (${country.code})`,
   value: country.code,
 }))


### PR DESCRIPTION
This PR is a POC that aims to resolve the change event not being triggered with vanilla JS. 

This triggers the change event when it is triggered programmatically rather than by the user. 

Currently, this is tailored for the checkbox, but we'd have to handle this generally for all the input elements that might trigger changes, such as `textarea` and the different input types such as `radio`, `text` etc.


## 📝 Description

## ⛳️ Current behavior (updates)

Programmatic events not triggered a change event in svelte

## 🚀 New behavior

Programmatic "change" event, triggered when the property "checked" of the input changed.

PS: This also contains a small fix for the playground as SvelteKit seems to have trouble with CJS packages such as the form serializer and the select data. 
I removed the serializer in svelte, and used the json data directly instead of calling the cjs function for the Select.
