### PR TITLE
docs: fix imports in vue sfc code snippets

### DIFF
--- a/website/data/snippets/vue-sfc/radio-group/usage.mdx
+++ b/website/data/snippets/vue-sfc/radio-group/usage.mdx
@@ -1,6 +1,6 @@
 ```md
 <script setup>
-import * as checkbox from "@zag-js/checkbox"
+import * as radio from "@zag-js/radio-group"
 import { normalizeProps, useMachine } from "@zag-js/vue"
 import { computed } from "vue"
 
@@ -11,9 +11,9 @@ const items = [
   { id: "grape", label: "Grapes" },
 ]
 
-const [state, send] = useMachine(checkbox.machine({ id: "1" }))
+const [state, send] = useMachine(radio.machine({ id: "1" }))
 
-const api = computed(() => checkbox.connect(state.value, send, normalizeProps))
+const api = computed(() => radio.connect(state.value, send, normalizeProps))
 </script>
 
 <template>

--- a/website/data/snippets/vue-sfc/segmented-control/usage.mdx
+++ b/website/data/snippets/vue-sfc/segmented-control/usage.mdx
@@ -1,6 +1,6 @@
 ```md
 <script setup>
-import * as checkbox from "@zag-js/checkbox";
+import * as radio from "@zag-js/radio-group"
 import { normalizeProps, useMachine } from "@zag-js/vue";
 import { computed } from "vue";
 
@@ -11,9 +11,9 @@ const items = [
   { label: "Svelte", value: "svelte" },
 ];
 
-const [state, send] = useMachine(checkbox.machine({ id: "1" }));
+const [state, send] = useMachine(radio.machine({ id: "1" }));
 
-const api = computed(() => checkbox.connect(state.value, send, normalizeProps));
+const api = computed(() => radio.connect(state.value, send, normalizeProps));
 </script>
 
 <template>


### PR DESCRIPTION
## 📝 Description

The usage code snippets for the  `radio-button` and `segmented-control` components are importing the wrong component (`checkbox`)

## ⛳️ Current behavior (updates)

Wrong imports in usage code snippets for the  `radio-button` and `segmented-control` components

## 🚀 New behavior

Corrected imports in usage code snippets for the  `radio-button` and `segmented-control` components

## 💣 Is this a breaking change (Yes/No):

No