### PR TITLE
fix: adjust isDom detection

### DIFF
--- a/.changeset/light-beds-obey.md
+++ b/.changeset/light-beds-obey.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/dom-query": patch
+"@zag-js/focus-visible": patch
+"@zag-js/number-utils": patch
+---
+
+Improve DOM detection code

--- a/packages/utilities/dom-query/src/platform.ts
+++ b/packages/utilities/dom-query/src/platform.ts
@@ -1,4 +1,4 @@
-export const isDom = () => typeof window !== "undefined"
+export const isDom = () => typeof document !== "undefined"
 
 export function getPlatform() {
   const agent = (navigator as any).userAgentData

--- a/packages/utilities/focus-visible/package.json
+++ b/packages/utilities/focus-visible/package.json
@@ -34,6 +34,9 @@
   },
   "clean-package": "../../../clean-package.config.json",
   "main": "src/index.ts",
+  "dependencies": {
+    "@zag-js/dom-query": "workspace:*"
+  },
   "devDependencies": {
     "clean-package": "2.2.0"
   }

--- a/packages/utilities/focus-visible/src/index.ts
+++ b/packages/utilities/focus-visible/src/index.ts
@@ -1,3 +1,5 @@
+import { isDom } from "@zag-js/dom-query"
+
 type Modality = "keyboard" | "pointer" | "virtual"
 type HandlerEvent = PointerEvent | MouseEvent | KeyboardEvent | FocusEvent
 type Handler = (modality: Modality, e: HandlerEvent | null) => void
@@ -96,7 +98,7 @@ function isFocusVisible() {
 }
 
 function setupGlobalFocusEvents() {
-  if (typeof window === "undefined" || hasSetup) {
+  if (!isDom() || hasSetup) {
     return
   }
 

--- a/packages/utilities/number/src/number.ts
+++ b/packages/utilities/number/src/number.ts
@@ -12,7 +12,7 @@ export function round(v: number | string, t?: number) {
 }
 
 export function roundToDevicePixel(num: number) {
-  if (typeof window === "undefined") return Math.round(num)
+  if (typeof window.devicePixelRatio !== "number") return Math.round(num)
   const dp = window.devicePixelRatio
   return Math.floor(num * dp + 0.5) / dp
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2381,6 +2381,10 @@ importers:
         version: 2.2.0
 
   packages/utilities/focus-visible:
+    dependencies:
+      '@zag-js/dom-query':
+        specifier: workspace:*
+        version: link:../dom-query
     devDependencies:
       clean-package:
         specifier: 2.2.0


### PR DESCRIPTION
## 📝 Description

This PR adjusts isBrowser detection to not rely on the window variable, which can be declared in various environments, such as e.g. Deno.

## ⛳️ Current behavior (updates)

Currently the dom check will pass in environments that declare window variable despite not being a browser/not having a document. It can leads to the events being added on a server or a errors in case of reading values of document after checking if only window is declared.

## 🚀 New behavior

It adjusts the check to validate the existence of document variable, which is recommended afaik.
Prior art: https://github.com/TanStack/virtual/pull/516 https://github.com/framer/motion/pull/1522 https://remix.run/docs/en/1.16.1/pages/gotchas#typeof-window-checks

## 💣 Is this a breaking change (Yes/No):

I assume no 😃 

## 📝 Additional Information

I wasn't sure about the changesets tbh, so I didn't generate them.
