### PR TITLE
fix(popper): offset is ignored from default gutter

### DIFF
--- a/.changeset/friendly-toys-hear.md
+++ b/.changeset/friendly-toys-hear.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/popper": patch
+---
+
+fix(popper): offset is ignored from default gutter

--- a/packages/utilities/popper/src/get-placement.ts
+++ b/packages/utilities/popper/src/get-placement.ts
@@ -45,7 +45,7 @@ function getPlacementImpl(reference: MaybeRectElement, floating: MaybeElement, o
 
   if (options.gutter || options.offset) {
     const arrowOffset = arrowEl ? arrowEl.offsetHeight / 2 : 0
-    const data = options.gutter ? { mainAxis: options.gutter } : options.offset
+    const data = options.offset ? options.offset : { mainAxis: options.gutter }
     if (data?.mainAxis != null) data.mainAxis += arrowOffset
     middleware.push(offset(data))
   }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`placement.offset` was not always being applied because `placement.gutter` took precedence over `placement.offset`

## ⛳️ Current behavior (updates)

`placement.gutter` is ignored when both `placement.offset` and `placement.gutter` are provided.
However, `placement.gutter` is provided from `defaultOptions`, so `placement.offset` is always ignored.

## 🚀 New behavior

`placement.offset` is applied when both `placement.offset` and `placement.gutter` are provided.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
