### PR TITLE
Fix removeDelay docs inconsistency for toasts

### DIFF
--- a/.changeset/popular-chefs-march.md
+++ b/.changeset/popular-chefs-march.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/toast": patch
+---
+
+Fix removeDelay docs inconsistency for toasts

--- a/packages/machines/toast/src/toast.machine.ts
+++ b/packages/machines/toast/src/toast.machine.ts
@@ -8,7 +8,7 @@ import { getToastDuration } from "./toast.utils"
 const { not, and, or } = guards
 
 export function createToastMachine(options: Options = {}) {
-  const { type = "info", duration, id = "toast", placement = "bottom", removeDelay = 0, ...restProps } = options
+  const { type = "info", duration, id = "toast", placement = "bottom", removeDelay = 500, ...restProps } = options
   const ctx = compact(restProps)
 
   const computedDuration = getToastDuration(duration, type)


### PR DESCRIPTION
## 📝 Description

The toast documentation states that there is added 500ms of delay when a toast is removed, but the codes doesn't reflect that.

## ⛳️ Current behavior (updates)

the removeDelay is always 0ms

## 🚀 New behavior

removeDelay is 500ms by default

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
