### PR TITLE
docs: wrong import fixed

### DIFF
--- a/website/data/snippets/vue-sfc/hover-card/usage.mdx
+++ b/website/data/snippets/vue-sfc/hover-card/usage.mdx
@@ -1,8 +1,8 @@
 ```md
 <script setup>
 import * as hoverCard from "@zag-js/hover-card"
-import { normalizeProps, useMachine, Teleport } from "@zag-js/vue"
-import { computed } from "vue"
+import { normalizeProps, useMachine } from "@zag-js/vue"
+import { computed, Teleport } from "vue"
 
 const [state, send] = useMachine(hoverCard.machine({ id: "1" }))
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

The teleport in the Hover card (vue sfc) component's code sample is imported from @zag-js/vue, but must be imported from vue for it to work.

https://zagjs.com/components/react/hover-card
