### PR TITLE
fix(tags-input): ignore key during composition in `onKeyDown` event

### DIFF
--- a/.changeset/mean-items-act.md
+++ b/.changeset/mean-items-act.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/tags-input": patch
+---
+
+Ignore key during composition in `onKeyDown` event

--- a/packages/machines/tags-input/src/tags-input.connect.ts
+++ b/packages/machines/tags-input/src/tags-input.connect.ts
@@ -123,6 +123,9 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         send({ type: "PASTE", value })
       },
       onKeyDown(event) {
+        const evt = getNativeEvent(event)
+        if (evt.isComposing) return
+
         // handle composition when used as combobox
         const target = event.currentTarget as HTMLElement
         const isCombobox = target.getAttribute("role") === "combobox"


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #804 

## 📝 Description

Currently, Tags Input allows keys during the compositions in `onKeyDown` event.
This behavior cause the above bug since it is not possible to distinguish between keys entered by the user and keys for IME combinations.
So this PR fixes it by ignoring `onKeyDown` events whose `isComposing` property is true.

## ⛳️ Current behavior (updates)

Allow keys during the compositions in `onKeyDown` event.

## 🚀 New behavior

Ignore keys during the compositions in `onKeyDown` event.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

None
