### PR TITLE
fix: dispatch change event in Checkbox and Switch

### DIFF
--- a/.changeset/wild-students-rush.md
+++ b/.changeset/wild-students-rush.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/form-utils": patch
+---
+
+Dispatch change event in Checkbox and Switch

--- a/packages/utilities/form-utils/src/input-event.ts
+++ b/packages/utilities/form-utils/src/input-event.ts
@@ -66,4 +66,8 @@ export function dispatchInputCheckedEvent(el: HTMLElement | null, options: Check
   // dispatch click event
   const event = new win.Event("click", { bubbles })
   el.dispatchEvent(event)
+
+  // dispatch change event
+  const changeEvent = new win.Event("change", { bubbles })
+  el.dispatchEvent(changeEvent)
 }


### PR DESCRIPTION
## 📝 Description

While using Checkbox (and the same goes for Switch) with an external form library (namely [Felte](https://felte.dev/), with SolidJS) I noticed that the Felte form is not getting the updated checkbox value after I change it programmatically using `api().setChecked(value)`.

The reason for that is that Felte is listening for `change` events, yet zag dispatches only a `click` event after any change of Checkboxes value.

A brief table displaying current behavior and requested changes:
|  For the input type: | checkbox/radio/file/hidden | text and the rest |
|--------|--------|--------|
| Zag currently dispatches an event of type | `click` | `input` |
| Felte listens for the event of type | `change` | `input` | 
| Zag after this change dispatches events of type | `click`, `change` | `input` | 

## ⛳️ Current behavior (updates)
For input type="checkbox", Zag currently dispatches an event of type `click`.

## 🚀 New behavior
For input type="checkbox", Zag dispatches an event of type `click` and `change`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Felte event handling code:
https://github.com/pablo-abc/felte/blob/0a9941032dcbef7285f114be04470cbef4b4bc5c/packages/core/src/create-form-action.ts#L208