### PR TITLE
fix(slider, range-slider): prevent thumb drag when disabled true

### DIFF
--- a/.changeset/perfect-games-train.md
+++ b/.changeset/perfect-games-train.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/range-slider": patch
+"@zag-js/slider": patch
+---
+
+Fix issue where slider interaction works when `disabled` is set

--- a/packages/machines/range-slider/src/range-slider.connect.ts
+++ b/packages/machines/range-slider/src/range-slider.connect.ts
@@ -163,6 +163,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         tabIndex: isDisabled ? undefined : 0,
         style: dom.getThumbStyle(state.context, index),
         onPointerDown(event) {
+          if (!isInteractive) return
           send({ type: "THUMB_POINTER_DOWN", index })
           event.stopPropagation()
         },

--- a/packages/machines/slider/src/slider.connect.ts
+++ b/packages/machines/slider/src/slider.connect.ts
@@ -107,6 +107,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       role: "slider",
       tabIndex: isDisabled ? undefined : 0,
       onPointerDown(event) {
+        if (!isInteractive) return
         send({ type: "THUMB_POINTER_DOWN" })
         event.stopPropagation()
       },


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixes an issue where thumb drag works and onChange occurs when <Slider/> and <RangeSlider /> are `disabled` in the current `@ark-ui/react` version 0.14.0 and `@zag-js/slider`, `@zag-js/range-slider` version 0.19.1.

## 📝 Additional Information

Add a guard for `isInteractive` to `onPointerDown` to prevent it from falling into a dragging state.

You can see demo in [here](https://stackblitz.com/edit/stackblitz-starters-kjjwdw?description=React%20%20%20TypeScript%20starter%20project&file=src%2FApp.tsx&title=React%20Starter)


cc. @malangcat 