### PR TITLE
fix(file-upload): fix reopening the system file picker on browsers other than Chrome

### DIFF
--- a/.changeset/unlucky-carrots-punch.md
+++ b/.changeset/unlucky-carrots-punch.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/file-upload": patch
+"@zag-js/docs": patch
+---
+
+Fix reopening the system file picker in file-upload on browsers other than Chrome

--- a/.xstate/file-upload.js
+++ b/.xstate/file-upload.js
@@ -13,6 +13,7 @@ const fetchMachine = createMachine({
   id: "fileupload",
   initial: "idle",
   context: {
+    "!isWithinRange": false,
     "!isWithinRange": false
   },
   on: {
@@ -31,8 +32,12 @@ const fetchMachine = createMachine({
   states: {
     idle: {
       on: {
-        OPEN: "open",
-        "DROPZONE.CLICK": "open",
+        OPEN: {
+          actions: ["openFilePicker"]
+        },
+        "DROPZONE.CLICK": {
+          actions: ["openFilePicker"]
+        },
         "DROPZONE.FOCUS": "focused",
         "DROPZONE.DRAG_OVER": [{
           cond: "!isWithinRange",
@@ -45,10 +50,19 @@ const fetchMachine = createMachine({
     },
     focused: {
       on: {
-        OPEN: "open",
-        "DROPZONE.CLICK": "open",
-        "DROPZONE.ENTER": "open",
-        "DROPZONE.BLUR": "idle"
+        OPEN: {
+          actions: ["openFilePicker"]
+        },
+        "DROPZONE.CLICK": {
+          actions: ["openFilePicker"]
+        },
+        "DROPZONE.DRAG_OVER": [{
+          cond: "!isWithinRange",
+          target: "dragging",
+          actions: ["setInvalid"]
+        }, {
+          target: "dragging"
+        }]
       }
     },
     dragging: {
@@ -61,13 +75,6 @@ const fetchMachine = createMachine({
           target: "idle",
           actions: ["clearInvalid"]
         }
-      }
-    },
-    open: {
-      activities: ["trackWindowFocus"],
-      entry: ["openFilePicker"],
-      on: {
-        CLOSE: "idle"
       }
     }
   }

--- a/packages/docs/api.json
+++ b/packages/docs/api.json
@@ -1096,7 +1096,7 @@
       },
       "isFocused": {
         "type": "boolean",
-        "description": "Whether the user is focused on the root element"
+        "description": "Whether the user is focused on the dropzone element"
       },
       "open": {
         "type": "() => void",

--- a/packages/machines/file-upload/src/file-upload.types.ts
+++ b/packages/machines/file-upload/src/file-upload.types.ts
@@ -110,7 +110,7 @@ export interface MachineApi<T extends PropTypes> {
    */
   isDragging: boolean
   /**
-   * Whether the user is focused on the root element
+   * Whether the user is focused on the dropzone element
    */
   isFocused: boolean
   /**


### PR DESCRIPTION
## 📝 Description

According to Павлюткин Артём from Discord (https://discord.com/channels/964648323304808488/964648323304808496/1151315874020605972):

> Hi, I have a problem. Through the Safari browser, I click on the "Download" button for the first time, a window appears to download the file. If you press the button again, nothing happens.
>I tried it on the official website from the Safari browser.
>The problem is only in the mobile browser on the iPhone.

I also discovered that the problem also occurs on Firefox and Safari on macOS and I confirm that it occurs on Safari on iOS.

## ⛳️ Current behavior (updates)

1. User gets stuck in the open state on the majority of the browsers, with no way to escape the open state.
2. There is no possibility to drag and drop files while dropzone is focused.
3. There is unused DROPZONE.ENTER transition.
4. Docs lie "isFiltered: Whether the user is focused on the root element"

## 🚀 New behavior

1. Open state got removed, since there seems to be no reliable way to detect whether the system file picker got closed by the user without choosing the file.
Instead of going into "open" state, existing idle/focused states are used. 
OPEN and DROPZONE.CLICK transitions (in idle/focused state) are bound to an action that opens the system file picker.
2. Allow to drag and drop files while dropzone is focused.
3. Remove DROPZONE.ENTER transition.
5. Fix the docs to say the truth: "isFiltered: Whether the user is focused on the dropzone element".

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
