### PR TITLE
fix(pagination): fix edge cases, refactor and simplify code, add tests

### DIFF
--- a/.changeset/five-moose-sin.md
+++ b/.changeset/five-moose-sin.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/pagination": patch
+---
+
+Fix a bug where pagination does not return any pages.

--- a/packages/machines/pagination/src/pagination.connect.ts
+++ b/packages/machines/pagination/src/pagination.connect.ts
@@ -23,7 +23,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
   return {
     page,
     totalPages,
-    pages: utils.getRange(state.context),
+    pages: utils.getTransformedRange(state.context),
     previousPage,
     nextPage,
     pageRange,

--- a/packages/machines/pagination/src/pagination.utils.ts
+++ b/packages/machines/pagination/src/pagination.utils.ts
@@ -18,9 +18,9 @@ export type PageContext = Pick<Ctx, "siblingCount" | "page" | "totalPages">
 
 export const getRange = (ctx: PageContext) => {
   /**
-   * `2 * ctx.siblingCount + 5`:
+   * `2 * ctx.siblingCount + 5` explanation:
    * 2 * ctx.siblingCount for left/right siblings
-   * 5 for 2x for left/right ellipsis, 2x first/last page + 1x current page
+   * 5 for 2x left/right ellipsis, 2x first/last page + 1x current page
    *
    * For some page counts (e.g. totalPages: 8, siblingCount: 2),
    * calculated max page is higher than total pages,
@@ -37,7 +37,7 @@ export const getRange = (ctx: PageContext) => {
   const showLeftEllipsis = leftSiblingIndex > firstPageIndex + 1
   const showRightEllipsis = rightSiblingIndex < lastPageIndex - 1
 
-  const itemCount = totalPageNumbers - 2 // 2 stands for ellipsis and either first or last page
+  const itemCount = totalPageNumbers - 2 // 2 stands for one ellipsis and either first or last page
 
   if (!showLeftEllipsis && showRightEllipsis) {
     const leftRange = range(1, itemCount)

--- a/packages/machines/pagination/src/pagination.utils.ts
+++ b/packages/machines/pagination/src/pagination.utils.ts
@@ -12,38 +12,50 @@ export const transform = (items: (string | number)[]): Pages => {
   })
 }
 
-export const getRange = (ctx: Omit<Ctx, "items">) => {
-  const totalPageNumbers = ctx.siblingCount + 5
-  if (totalPageNumbers >= ctx.totalPages) return transform(range(1, ctx.totalPages))
+const ELLIPSIS = "ellipsis"
 
-  const ELLIPSIS = "ellipsis"
+export type PageContext = Pick<Ctx, "siblingCount" | "page" | "totalPages">
 
-  const leftSiblingIndex = Math.max(ctx.page - ctx.siblingCount, 1)
-  const rightSiblingIndex = Math.min(ctx.page + ctx.siblingCount, ctx.totalPages)
-
-  const showLeftEllipsis = leftSiblingIndex > 2
-  const showRightEllipsis = rightSiblingIndex < ctx.totalPages - 2
+export const getRange = (ctx: PageContext) => {
+  /**
+   * `2 * ctx.siblingCount + 5`:
+   * 2 * ctx.siblingCount for left/right siblings
+   * 5 for 2x for left/right ellipsis, 2x first/last page + 1x current page
+   *
+   * For some page counts (e.g. totalPages: 8, siblingCount: 2),
+   * calculated max page is higher than total pages,
+   * so we need to take the minimum of both.
+   */
+  const totalPageNumbers = Math.min(2 * ctx.siblingCount + 5, ctx.totalPages)
 
   const firstPageIndex = 1
   const lastPageIndex = ctx.totalPages
 
-  if (!showLeftEllipsis && showRightEllipsis) {
-    let leftItemCount = 3 + 2 * ctx.siblingCount
-    let leftRange = range(1, leftItemCount)
+  const leftSiblingIndex = Math.max(ctx.page - ctx.siblingCount, firstPageIndex)
+  const rightSiblingIndex = Math.min(ctx.page + ctx.siblingCount, lastPageIndex)
 
-    return transform([...leftRange, ELLIPSIS, ctx.totalPages])
+  const showLeftEllipsis = leftSiblingIndex > firstPageIndex + 1
+  const showRightEllipsis = rightSiblingIndex < lastPageIndex - 1
+
+  const itemCount = totalPageNumbers - 2 // 2 stands for ellipsis and either first or last page
+
+  if (!showLeftEllipsis && showRightEllipsis) {
+    const leftRange = range(1, itemCount)
+    return [...leftRange, ELLIPSIS, lastPageIndex]
   }
 
   if (showLeftEllipsis && !showRightEllipsis) {
-    let rightItemCount = 3 + 2 * ctx.siblingCount
-    let rightRange = range(ctx.totalPages - rightItemCount + 1, ctx.totalPages)
-    return transform([firstPageIndex, ELLIPSIS, ...rightRange])
+    const rightRange = range(lastPageIndex - itemCount + 1, lastPageIndex)
+    return [firstPageIndex, ELLIPSIS, ...rightRange]
   }
 
   if (showLeftEllipsis && showRightEllipsis) {
-    let middleRange = range(leftSiblingIndex, rightSiblingIndex)
-    return transform([firstPageIndex, ELLIPSIS, ...middleRange, ELLIPSIS, lastPageIndex])
+    const middleRange = range(leftSiblingIndex, rightSiblingIndex)
+    return [firstPageIndex, ELLIPSIS, ...middleRange, ELLIPSIS, lastPageIndex]
   }
 
-  return []
+  const fullRange = range(firstPageIndex, lastPageIndex)
+  return fullRange
 }
+
+export const getTransformedRange = (ctx: PageContext) => transform(getRange(ctx))

--- a/packages/machines/pagination/tests/pagination.utils.test-cases.ts
+++ b/packages/machines/pagination/tests/pagination.utils.test-cases.ts
@@ -1,0 +1,345 @@
+import { getRange } from "../src/pagination.utils"
+
+interface GetRangeTestCase {
+  siblingCount: number
+  totalPages: number
+  pages: number[]
+  expected: ReturnType<typeof getRange>
+}
+
+const siblingCount1Tests = [
+  // totalPages: 1, totalPageNumbers: 1
+  {
+    siblingCount: 1,
+    pages: [1],
+    totalPages: 1,
+    expected: [1],
+  },
+  // totalPages: 2, totalPageNumbers: 2
+  {
+    siblingCount: 1,
+    pages: [1, 2],
+    totalPages: 2,
+    expected: [1, 2],
+  },
+  // totalPages: 3, totalPageNumbers: 3
+  {
+    siblingCount: 1,
+    pages: [1, 2, 3],
+    totalPages: 3,
+    expected: [1, 2, 3],
+  },
+  // totalPages: 4, totalPageNumbers: 4
+  {
+    siblingCount: 1,
+    pages: [1],
+    totalPages: 4,
+    expected: [1, 2, "ellipsis", 4],
+  },
+  {
+    siblingCount: 1,
+    pages: [2, 3],
+    totalPages: 4,
+    expected: [1, 2, 3, 4],
+  },
+  {
+    siblingCount: 1,
+    pages: [4],
+    totalPages: 4,
+    expected: [1, "ellipsis", 3, 4],
+  },
+  // totalPages: 5, totalPageNumbers: 5
+  {
+    siblingCount: 1,
+    pages: [1, 2],
+    totalPages: 5,
+    expected: [1, 2, 3, "ellipsis", 5],
+  },
+  {
+    siblingCount: 1,
+    pages: [3],
+    totalPages: 5,
+    expected: [1, 2, 3, 4, 5],
+  },
+  {
+    siblingCount: 1,
+    pages: [4, 5],
+    totalPages: 5,
+    expected: [1, "ellipsis", 3, 4, 5],
+  },
+  // totalPages: 6, totalPageNumbers: 6
+  {
+    siblingCount: 1,
+    pages: [1, 2, 3],
+    totalPages: 6,
+    expected: [1, 2, 3, 4, "ellipsis", 6],
+  },
+  {
+    siblingCount: 1,
+    pages: [4, 5, 6],
+    totalPages: 6,
+    expected: [1, "ellipsis", 3, 4, 5, 6],
+  },
+  // totalPages: 7, totalPageNumbers: 7
+  {
+    siblingCount: 1,
+    pages: [1, 2, 3],
+    totalPages: 7,
+    expected: [1, 2, 3, 4, 5, "ellipsis", 7],
+  },
+  {
+    siblingCount: 1,
+    pages: [4],
+    totalPages: 7,
+    expected: [1, "ellipsis", 3, 4, 5, "ellipsis", 7],
+  },
+  {
+    siblingCount: 1,
+    pages: [5, 6, 7],
+    totalPages: 7,
+    expected: [1, "ellipsis", 3, 4, 5, 6, 7],
+  },
+  // // totalPages: 8, totalPageNumbers: 7
+  {
+    siblingCount: 1,
+    pages: [1, 2, 3],
+    totalPages: 8,
+    expected: [1, 2, 3, 4, 5, "ellipsis", 8],
+  },
+  {
+    siblingCount: 1,
+    pages: [4],
+    totalPages: 8,
+    expected: [1, "ellipsis", 3, 4, 5, "ellipsis", 8],
+  },
+  {
+    siblingCount: 1,
+    pages: [5],
+    totalPages: 8,
+    expected: [1, "ellipsis", 4, 5, 6, "ellipsis", 8],
+  },
+  {
+    siblingCount: 1,
+    pages: [6],
+    totalPages: 8,
+    expected: [1, "ellipsis", 4, 5, 6, 7, 8],
+  },
+  // totalPages: 9, totalPageNumbers: 7
+  {
+    siblingCount: 1,
+    pages: [1, 2, 3],
+    totalPages: 9,
+    expected: [1, 2, 3, 4, 5, "ellipsis", 9],
+  },
+  {
+    siblingCount: 1,
+    pages: [4],
+    totalPages: 9,
+    expected: [1, "ellipsis", 3, 4, 5, "ellipsis", 9],
+  },
+  {
+    siblingCount: 1,
+    pages: [5],
+    totalPages: 9,
+    expected: [1, "ellipsis", 4, 5, 6, "ellipsis", 9],
+  },
+  {
+    siblingCount: 1,
+    pages: [6],
+    totalPages: 9,
+    expected: [1, "ellipsis", 5, 6, 7, "ellipsis", 9],
+  },
+  {
+    siblingCount: 1,
+    pages: [7, 8, 9],
+    totalPages: 9,
+    expected: [1, "ellipsis", 5, 6, 7, 8, 9],
+  },
+]
+
+const siblingCount2Tests = [
+  // totalPages: 1, totalPageNumbers: 1
+  {
+    siblingCount: 2,
+    pages: [1],
+    totalPages: 1,
+    expected: [1],
+  },
+  // totalPages: 2, totalPageNumbers: 2
+  {
+    siblingCount: 2,
+    pages: [1, 2],
+    totalPages: 2,
+    expected: [1, 2],
+  },
+  // totalPages: 3, totalPageNumbers: 3
+  {
+    siblingCount: 2,
+    pages: [1, 2, 3],
+    totalPages: 3,
+    expected: [1, 2, 3],
+  },
+  // totalPages: 4, totalPageNumbers: 4
+  {
+    siblingCount: 2,
+    pages: [1, 2, 3, 4],
+    totalPages: 4,
+    expected: [1, 2, 3, 4],
+  },
+  // totalPages: 5, totalPageNumbers: 5
+  {
+    siblingCount: 2,
+    pages: [1],
+    totalPages: 5,
+    expected: [1, 2, 3, "ellipsis", 5],
+  },
+  {
+    siblingCount: 2,
+    pages: [2, 3, 4],
+    totalPages: 5,
+    expected: [1, 2, 3, 4, 5],
+  },
+  {
+    siblingCount: 2,
+    pages: [5],
+    totalPages: 5,
+    expected: [1, "ellipsis", 3, 4, 5],
+  },
+  // totalPages: 6, totalPageNumbers: 6
+  {
+    siblingCount: 2,
+    pages: [1],
+    totalPages: 6,
+    expected: [1, 2, 3, 4, "ellipsis", 6],
+  },
+  {
+    siblingCount: 2,
+    pages: [3, 4],
+    totalPages: 6,
+    expected: [1, 2, 3, 4, 5, 6],
+  },
+  {
+    siblingCount: 2,
+    pages: [5, 6],
+    totalPages: 6,
+    expected: [1, "ellipsis", 3, 4, 5, 6],
+  },
+  // totalPages: 7, totalPageNumbers: 7
+  {
+    siblingCount: 2,
+    pages: [1, 2, 3],
+    totalPages: 7,
+    expected: [1, 2, 3, 4, 5, "ellipsis", 7],
+  },
+  {
+    siblingCount: 2,
+    pages: [4],
+    totalPages: 7,
+    expected: [1, 2, 3, 4, 5, 6, 7],
+  },
+  {
+    siblingCount: 2,
+    pages: [5, 6, 7],
+    totalPages: 7,
+    expected: [1, "ellipsis", 3, 4, 5, 6, 7],
+  },
+  // totalPages: 8, totalPageNumbers: 8
+  {
+    siblingCount: 2,
+    pages: [1, 2, 3, 4],
+    totalPages: 8,
+    expected: [1, 2, 3, 4, 5, 6, "ellipsis", 8],
+  },
+  {
+    siblingCount: 2,
+    pages: [5, 6, 7, 8],
+    totalPages: 8,
+    expected: [1, "ellipsis", 3, 4, 5, 6, 7, 8],
+  },
+  // totalPages: 9, totalPageNumbers: 9
+  {
+    siblingCount: 2,
+    pages: [1, 2, 3, 4],
+    totalPages: 9,
+    expected: [1, 2, 3, 4, 5, 6, 7, "ellipsis", 9],
+  },
+  {
+    siblingCount: 2,
+    pages: [5],
+    totalPages: 9,
+    expected: [1, "ellipsis", 3, 4, 5, 6, 7, "ellipsis", 9],
+  },
+  {
+    siblingCount: 2,
+    pages: [6, 7, 8, 9],
+    totalPages: 9,
+    expected: [1, "ellipsis", 3, 4, 5, 6, 7, 8, 9],
+  },
+  // totalPages: 10, totalPageNumbers: 9
+  {
+    siblingCount: 2,
+    pages: [1, 2, 3, 4],
+    totalPages: 10,
+    expected: [1, 2, 3, 4, 5, 6, 7, "ellipsis", 10],
+  },
+  {
+    siblingCount: 2,
+    pages: [5],
+    totalPages: 10,
+    expected: [1, "ellipsis", 3, 4, 5, 6, 7, "ellipsis", 10],
+  },
+  {
+    siblingCount: 2,
+    pages: [6],
+    totalPages: 10,
+    expected: [1, "ellipsis", 4, 5, 6, 7, 8, "ellipsis", 10],
+  },
+  {
+    siblingCount: 2,
+    pages: [7, 8, 9, 10],
+    totalPages: 10,
+    expected: [1, "ellipsis", 4, 5, 6, 7, 8, 9, 10],
+  },
+  // totalPages: 11, totalPageNumbers: 9
+  {
+    siblingCount: 2,
+    pages: [1, 2, 3, 4],
+    totalPages: 11,
+    expected: [1, 2, 3, 4, 5, 6, 7, "ellipsis", 11],
+  },
+  {
+    siblingCount: 2,
+    pages: [5],
+    totalPages: 11,
+    expected: [1, "ellipsis", 3, 4, 5, 6, 7, "ellipsis", 11],
+  },
+  {
+    siblingCount: 2,
+    pages: [6],
+    totalPages: 11,
+    expected: [1, "ellipsis", 4, 5, 6, 7, 8, "ellipsis", 11],
+  },
+  {
+    siblingCount: 2,
+    pages: [7],
+    totalPages: 11,
+    expected: [1, "ellipsis", 5, 6, 7, 8, 9, "ellipsis", 11],
+  },
+  {
+    siblingCount: 2,
+    pages: [8, 9, 10, 11],
+    totalPages: 11,
+    expected: [1, "ellipsis", 5, 6, 7, 8, 9, 10, 11],
+  },
+]
+
+export const getRangeTestCases: GetRangeTestCase[] = [
+  {
+    siblingCount: 1,
+    pages: [0],
+    totalPages: 0,
+    expected: [],
+  },
+  ...siblingCount1Tests,
+  ...siblingCount2Tests,
+]

--- a/packages/machines/pagination/tests/pagination.utils.test.ts
+++ b/packages/machines/pagination/tests/pagination.utils.test.ts
@@ -1,44 +1,48 @@
 import { expect, describe, test } from "vitest"
 import * as utils from "../src/pagination.utils"
+import { getRange } from "../src/pagination.utils"
+import { getRangeTestCases } from "./pagination.utils.test-cases"
 
 describe("@zag-js/pagination utils", () => {
   test("range method", () => {
-    expect(utils.range(1, 5)).toMatchInlineSnapshot(`
-    [
-      1,
-      2,
-      3,
-      4,
-      5,
-    ]
-  `)
+    expect(utils.range(1, 5)).toEqual([1, 2, 3, 4, 5])
   })
 
   test("transform method", () => {
     const items = [1, 2, "ellipsis", 3, 4]
     const transformed = utils.transform(items)
-    expect(transformed).toMatchInlineSnapshot(`
-    [
+    expect(transformed).toEqual([
       {
-        "type": "page",
-        "value": 1,
+        type: "page",
+        value: 1,
       },
       {
-        "type": "page",
-        "value": 2,
+        type: "page",
+        value: 2,
       },
       {
-        "type": "ellipsis",
+        type: "ellipsis",
       },
       {
-        "type": "page",
-        "value": 3,
+        type: "page",
+        value: 3,
       },
       {
-        "type": "page",
-        "value": 4,
+        type: "page",
+        value: 4,
       },
-    ]
-  `)
+    ])
+  })
+
+  describe("getRange method", () => {
+    test.each(getRangeTestCases)(
+      "siblingCount: $siblingCount, totalPages: $totalPages, page: $pages",
+      ({ expected, pages, ...ctx }) => {
+        for (let page of pages) {
+          const range = getRange({ ...ctx, page })
+          expect(range).toEqual(expected)
+        }
+      },
+    )
   })
 })


### PR DESCRIPTION
## 📝 Description

My colleague found a bug so I fixed it.

Apart from that, I add ~50 test cases for pagination and refactor the getRange function.

## ⛳️ Current behavior
1. In some cases, no pagination numbers are returned (in this case, page 4):

https://github.com/chakra-ui/zag/assets/17103865/5b84dede-67d9-46ac-83f9-f738e601e5fc

Data from the video: 
```js
{
      count: 8,
      page: 4,
      pageSize: 1,
      siblingCount: 2,
}
```

## 🚀 New behavior

1. Bug fixed:
 
https://github.com/chakra-ui/zag/assets/17103865/1d5bcd6b-25ff-408c-bd9a-6272648150da


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

