### PR TITLE
fix: focus-visible

### DIFF
--- a/.changeset/heavy-jars-enjoy.md
+++ b/.changeset/heavy-jars-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/focus-visible": patch
+---
+
+Fix focus handling when clicked inside element with tabindex attribute

--- a/packages/utilities/focus-visible/src/index.ts
+++ b/packages/utilities/focus-visible/src/index.ts
@@ -75,6 +75,12 @@ function onWindowFocus(event: FocusEvent) {
     return
   }
 
+  // An extra event is fired when the user first clicks inside an element with tabindex attribute.
+  // We ignore these events so they don't cause keyboard focus ring to appear.
+  if (event.target instanceof Element && event.target.hasAttribute("tabindex")) {
+    return
+  }
+
   // If a focus event occurs without a preceding keyboard or pointer event, switch to keyboard modality.
   // This occurs, for example, when navigating a form with the next/previous buttons on iOS.
   if (!hasEventBeforeFocus && !hasBlurredWindowRecently) {


### PR DESCRIPTION
Closes [#8000](https://github.com/chakra-ui/chakra-ui/issues/8000)

## 📝 Description

Fix for inconsistent checkbox focus ring behaviour when a checkbox is descendant of an element with `tabindex` attribute. The problem is that the browser fires an extra window `focus` event when the user clicks inside an element which has `tabindex` property. This event needs to be ignored in order to ensure consistent focus ring behaviour.

## ⛳️ Current behavior (updates)

Focus-visible ring appears on mouse click if checkbox is descendant of an element with `tabindex` attribute.

## 🚀 New behavior

Focus-visible ring does not appear on mouse click if checkbox is descendant of an element with `tabindex` attribute.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
