### PR TITLE
fix(react): `<Editable />` sync internal value and external value

### DIFF
--- a/.changeset/new-monkeys-watch.md
+++ b/.changeset/new-monkeys-watch.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/editable": patch
+---
+
+Fix issue where the input value doesn't get synced correctly when controlled

--- a/packages/machines/editable/src/editable.machine.ts
+++ b/packages/machines/editable/src/editable.machine.ts
@@ -164,8 +164,7 @@ export function machine(userContext: UserDefinedContext) {
           ctx.onEdit?.()
         },
         syncInputValue(ctx) {
-          const inputEl = dom.getInputEl(ctx)
-          dom.setValue(inputEl, ctx.value)
+          sync.value(ctx)
         },
         setValue(ctx, evt) {
           set.value(ctx, evt.value)
@@ -184,6 +183,13 @@ export function machine(userContext: UserDefinedContext) {
   )
 }
 
+const sync = {
+  value: (ctx: MachineContext) => {
+    const inputEl = dom.getInputEl(ctx)
+    dom.setValue(inputEl, ctx.value)
+  },
+}
+
 const invoke = {
   change(ctx: MachineContext) {
     ctx.onValueChange?.({ value: ctx.value })
@@ -195,5 +201,12 @@ const set = {
     if (isEqual(ctx.value, value)) return
     ctx.value = value
     invoke.change(ctx)
+
+    /**
+     * sync when the value(ctx.value) entered from outside and the internal value(value) are different after invoke.
+     */
+    if (value !== ctx.value) {
+      sync.value(ctx)
+    }
   },
 }


### PR DESCRIPTION
There is currently an issue in `@zag-js/editable` 0.21.0 where passing an object with a state value of `useState` and using the `<Editable />` component in controlled form does not control the value as desired.

You can see a demo below.
(Currently, the logic is set up so that the value is fixed at 10000, but you can see that any value above 10000 will be input).

- [demo](https://stackblitz.com/edit/stackblitz-starters-m4rdhb?file=src%2FApp.tsx,src%2Fstyle.css)

To fix this, modify the code for `zag` and `ark`.

In `zag`, we'll add logic to synchronize if the externally input value is different from the internal value.

In `ark`, we apply `flushSync` to `onChange`.
- [ark PR](https://github.com/chakra-ui/ark/pull/1441)

If there is a better form, please let me know.

cc. @malangcat 