### PR TITLE
fix(dialog): do not close Dialog on outside focus

### DIFF
--- a/packages/machines/dialog/src/dialog.machine.ts
+++ b/packages/machines/dialog/src/dialog.machine.ts
@@ -82,6 +82,9 @@ export function machine(userContext: UserDefinedContext) {
               }
               ctx.onEsc?.()
             },
+            onFocusOutside(event) {
+              event.preventDefault()
+            },
             onPointerDownOutside(event) {
               if (!ctx.closeOnOutsideClick) {
                 event.preventDefault()


### PR DESCRIPTION
improvement for #885

## 📝 Description

Do not close Dialog on outside focus.

At first I thought I would solve this like so:
```ts
onFocusOutside(event) {
  if (!ctx.closeOnOutsideClick) event.preventDefault()
},
```

But then I thought that there is no case of user wanting to close the Dialog by focusing anything else. So I left it like this:
```ts
onFocusOutside(event) {
  event.preventDefault()
},
```

This is an incomplete fix, since I think that clicking on Alerts shouldn't close Dialogs at all, no matter whether the closeOnOutsideClick flag is set to true or false. With closeOnOutsideClick equal to true, Dialogs should get closed only when one clicks on the overlay, not other top-level components.

## ⛳️ Current behavior (updates)

Dialog **is** closed when anything outside of Dialog is getting focused. 
When closeOnOutsideClick is set to false, the Dialog gets closed when Alert's button gets focused by clicking it. 

## 🚀 New behavior

Dialog **is not** closed when anything outside of Dialog is getting focused. 
When closeOnOutsideClick is set to false, the Dialog does not get closed when Alert's button gets focused by clicking it. 

## 💣 Is this a breaking change (Yes/No):

No

