### PR TITLE
fix(radio-group): hide indicator when the value is null 

### DIFF
--- a/.changeset/friendly-plums-serve.md
+++ b/.changeset/friendly-plums-serve.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/radio-group": patch
+---
+
+Hide indicator when the value is null

--- a/packages/machines/radio-group/src/radio-group.connect.ts
+++ b/packages/machines/radio-group/src/radio-group.connect.ts
@@ -186,6 +186,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         transitionProperty: "var(--transition-property)",
         transitionDuration: state.context.canIndicatorTransition ? "var(--transition-duration)" : "0ms",
         transitionTimingFunction: "var(--transition-timing-function)",
+        ...(state.context.value === null && { display: "none" }),
         ...state.context.indicatorRect,
       },
     }),


### PR DESCRIPTION
## 📝 Description

This PR changes the indicator when it has a border (in this example `border: "5px solid red"`).

![CleanShot 2023-10-03 at 20 02 54@2x](https://github.com/chakra-ui/zag/assets/17103865/629e75d8-36cd-4f78-aba6-8a031ffc5972)


## ⛳️ Current behavior (updates)

After resetting the state, when the value is `null`, the indicator remains visible. It sets its width/height to zero, but it's not sufficient to fully hide it - the border remains visible.

![CleanShot 2023-10-03 at 20 04 50@2x](https://github.com/chakra-ui/zag/assets/17103865/f6894a52-024a-46ba-81c5-81ad53dbe41a)

## 🚀 New behavior

When the value is `null`, the indicator gets `display: none` in inline CSS and thus disappears.

![CleanShot 2023-10-03 at 20 05 48@2x](https://github.com/chakra-ui/zag/assets/17103865/957d14ff-eaee-4741-b70e-dbd8d52043e9)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Empty string gets treated as a value and does not hide the indicator, since I assume that the only empty value of the radio is null.


Another solution would be to use some custom `data-state="visible/hidden"` on indicator but I think that the solution with `display=none` is sufficient. It still lets the user to use any `display: <value>` since the `display: none;` from inline styles has higher specificity than any user provided `display: <value>` via classNames.