### PR TITLE
docs(combobox): add combobox properties to docs and examples

### DIFF
--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -18,9 +18,18 @@ export const switchControls = defineControls({
 })
 
 export const comboboxControls = defineControls({
+  disabled: { type: "boolean", defaultValue: false },
+  readOnly: { type: "boolean", defaultValue: false },
+  multiple: { type: "boolean", defaultValue: false },
+  allowCustomValue: { type: "boolean", defaultValue: false },
+  loop: { type: "boolean", defaultValue: true },
+  openOnClick: { type: "boolean", defaultValue: false },
+  closeOnSelect: { type: "boolean", defaultValue: true },
+  selectOnBlur: { type: "boolean", defaultValue: true },
+  placeholder: { type: "string", defaultValue: "Type or select a country" },
   inputBehavior: {
     type: "select",
-    defaultValue: "autohighlight",
+    defaultValue: "none",
     options: ["autohighlight", "autocomplete", "none"] as const,
   },
   selectionBehavior: {
@@ -28,11 +37,6 @@ export const comboboxControls = defineControls({
     defaultValue: "replace",
     options: ["replace", "clear", "preserve"] as const,
   },
-  disabled: { type: "boolean", defaultValue: false },
-  multiple: { type: "boolean", defaultValue: false },
-  loop: { type: "boolean", defaultValue: true },
-  openOnClick: { type: "boolean", defaultValue: false },
-  selectOnBlur: { type: "boolean", defaultValue: true },
 })
 
 export const editableControls = defineControls({

--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -29,7 +29,7 @@ export const comboboxControls = defineControls({
   placeholder: { type: "string", defaultValue: "Type or select a country" },
   inputBehavior: {
     type: "select",
-    defaultValue: "none",
+    defaultValue: "autohighlight",
     options: ["autohighlight", "autocomplete", "none"] as const,
   },
   selectionBehavior: {

--- a/website/components/machines/combobox.tsx
+++ b/website/components/machines/combobox.tsx
@@ -86,7 +86,6 @@ export function Combobox(props: ComboboxProps) {
         )
         setOptions(filtered.length > 0 ? filtered : comboboxData)
       },
-      placeholder: "Type or select country",
     }),
     { context: { ...props.controls, collection } },
   )

--- a/website/components/showcase.tsx
+++ b/website/components/showcase.tsx
@@ -54,10 +54,20 @@ const components = {
       defaultProps={{
         disabled: false,
         readOnly: false,
-        loop: false,
+        multiple: false,
+        allowCustomValue: false,
+        loop: true,
+        openOnClick: false,
+        closeOnSelect: true,
+        selectOnBlur: true,
+        placeholder: "Type or select a country",
         inputBehavior: {
-          default: "autohighlight",
+          default: "none",
           options: ["autohighlight", "autocomplete", "none"],
+        },
+        selectionBehavior: {
+          default: "replace",
+          options: ["replace", "clear", "preserve"],
         },
       }}
     />

--- a/website/data/components/combobox.mdx
+++ b/website/data/components/combobox.mdx
@@ -119,9 +119,9 @@ const [state, send] = useMachine(
 
 ## Rendering the selected values outside the combobox
 
-By default, the selected values of a combobox is displayed in the input element,
-when selecting multiple items, it is a better UX to render the selected value
-outside the combobox.
+By default, the selected values of a combobox are displayed in the input
+element, when selecting multiple items, it is a better UX to render the selected
+value outside the combobox.
 
 To achieve this you need to:
 


### PR DESCRIPTION
## 📝 Description

Add misssing Combobox properties on website and in examples.

![CleanShot 2023-10-05 at 20 21 36](https://github.com/chakra-ui/zag/assets/17103865/02f9ab66-0ea5-49b7-ab1f-c917d6d887da)


## 💣 Is this a breaking change (Yes/No):

No