### PR TITLE
fix: file upload setFiles and clearFiles methods

### DIFF
--- a/.xstate/file-upload.js
+++ b/.xstate/file-upload.js
@@ -22,6 +22,9 @@ const fetchMachine = createMachine({
     },
     "FILE.DELETE": {
       actions: ["removeFile"]
+    },
+    "FILES.CLEAR": {
+      actions: ["clearFiles"]
     }
   },
   on: {

--- a/packages/machines/file-upload/src/file-upload.connect.ts
+++ b/packages/machines/file-upload/src/file-upload.connect.ts
@@ -26,10 +26,10 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     files: state.context.files,
     setFiles(files) {
       const count = files.length
-      send({ type: "VALUE.SET", files, count })
+      send({ type: "FILES.SET", files, count })
     },
     clearFiles() {
-      send({ type: "VALUE.SET", files: [] })
+      send({ type: "FILES.CLEAR" })
     },
     getFileSize(file) {
       return formatFileSize(file.size, { locale: state.context.locale })

--- a/packages/machines/file-upload/src/file-upload.machine.ts
+++ b/packages/machines/file-upload/src/file-upload.machine.ts
@@ -35,6 +35,9 @@ export function machine(userContext: UserDefinedContext) {
         "FILE.DELETE": {
           actions: ["removeFile"],
         },
+        "FILES.CLEAR": {
+          actions: ["clearFiles"],
+        },
       },
       states: {
         idle: {
@@ -123,6 +126,9 @@ export function machine(userContext: UserDefinedContext) {
         removeFile(ctx, evt) {
           const nextFiles = ctx.files.filter((file) => file !== evt.file)
           set.files(ctx, nextFiles)
+        },
+        clearFiles(ctx) {
+          set.files(ctx, [])
         },
       },
       compareFns: {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This fixes the setFiles and clearFiles API's of the file upload machine.

## ⛳️ Current behavior (updates)

Nothing happens when called

## 🚀 New behavior

Files can be modified using setFiles(files) and all files can be cleared using clearFiles()

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
