### PR TITLE
Docs | Menu | styling guide | wrong data attribute

### DIFF
--- a/website/data/components/menu.mdx
+++ b/website/data/components/menu.mdx
@@ -185,14 +185,14 @@ When the menu is open or closed, the content and trigger parts will have the
 ### Focused item state
 
 When an item is focused, via keyboard navigation or pointer, it is given a
-`data-focus` attribute.
+`data-highlighted` attribute.
 
 ```css
-[data-part="item"][data-focus] {
+[data-part="item"][data-highlighted] {
   /* styles for focused state */
 }
 
-[data-part="option-item"][data-focus] {
+[data-part="option-item"][data-highlighted] {
   /* styles for focused state */
 }
 ```


### PR DESCRIPTION
## 📝 Description

Wrong data attribute in the documentation, concerning focused states and styling: https://zagjs.com/components/react/menu#focused-item-state

## ⛳️ Current behavior (updates)

current data attribute is `data-focus`

## 🚀 New behavior

current data attribute should be `data-highlighted`
