### PR TITLE
docs: Update code snippets (vue sfc) tags and tags input components

### DIFF
--- a/website/data/snippets/vue-sfc/tabs/usage.mdx
+++ b/website/data/snippets/vue-sfc/tabs/usage.mdx
@@ -22,7 +22,7 @@ const api = computed(() => tabs.connect(state.value, send, normalizeProps));
         v-bind="api.getTriggerProps({ value: item.value })"
         :key="item.value"
       >
-        {item.label}
+        {{ item.label }}
       </button>
     </div>
     <div
@@ -30,7 +30,7 @@ const api = computed(() => tabs.connect(state.value, send, normalizeProps));
       v-bind="api.getContentProps({ value: item.value })"
       key="{item.value}"
     >
-      <p>{item.content}</p>
+      <p>{{ item.content }}</p>
     </div>
   </div>
 </template>

--- a/website/data/snippets/vue-sfc/tags-input/usage.mdx
+++ b/website/data/snippets/vue-sfc/tags-input/usage.mdx
@@ -19,7 +19,7 @@ const api = computed(() =>
   <div ref="ref" v-bind="api.rootProps">
     <span v-for="(value, index) in api.value" :key="index">
       <div v-bind="api.getItemProps({ index, value })">
-        <span>{value} </span>
+        <span>{{ value }} </span>
         <button v-bind="api.getItemDeleteTriggerProps({ index, value })">
           &#x2715;
         </button>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

<!-- Github issue # here -->

## 📝 Description

Wrong data binding of Tabs and Tags Input Components in Vue (SFC)

- https://zagjs.com/components/react/tabs
- https://zagjs.com/components/react/tags-input

## ⛳️ Current behavior (updates)

- Tabs have data binding is `{item.label}` and `{item.content}`
- Tags Input have data binding is `{value}`

## 🚀 New behavior

- Tabs have data binding is `{{ item.label }}` and `{{ item.content }}`
- Tags Input have data binding is `{{ value }}`


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
