### PR TITLE
fix: typeerror when clsx str is undefined

### DIFF
--- a/.changeset/wet-plants-flash.md
+++ b/.changeset/wet-plants-flash.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/core": patch
+---
+
+Fix issue where mergeProps throws when className str is undefined

--- a/packages/core/src/merge-props.ts
+++ b/packages/core/src/merge-props.ts
@@ -6,7 +6,7 @@ interface Props {
 
 const clsx = (...args: (string | undefined)[]) =>
   args
-    .map((str) => str?.trim())
+    .map((str) => str?.trim?.())
     .filter(Boolean)
     .join(" ")
 


### PR DESCRIPTION
## 📝 Description
fix a typeerror using the mergeProps function. 

> Add a brief description
<img width="376" alt="image" src="https://github.com/chakra-ui/zag/assets/20296626/3d42c812-2208-4469-b3e1-46320ec1cfd0">

```
merge-props.ts:9 Uncaught TypeError: str.trim is not a function
    at merge-props.ts:9:24
    at Array.map (<anonymous>)
    at clsx (merge-props.ts:9:6)
    at mergeProps (merge-props.ts:30:23)
```

## ⛳️ Current behavior (updates)

The nullish coalescing check is applied to 'str', but 'trim' lacks such protection.

## 🚀 New behavior

nullish coalescing for trim as well

