### PR TITLE
fix(select): use optional chaining operator for safe access to ctx's highlightedItem

### DIFF
--- a/e2e/select.e2e.ts
+++ b/e2e/select.e2e.ts
@@ -254,3 +254,17 @@ test.describe("select / focused / select option", () => {
     await expectToBeChecked(page.locator(getOption("KE")))
   })
 })
+
+test.describe("select / loop / keyboard", () => {
+  test("should loop through the options when loop is enabled", async ({ page }) => {
+    await controls(page).bool("loop")
+    await page.focus(trigger)
+    await page.keyboard.press("Enter")
+
+    await page.keyboard.press("ArrowUp")
+    await expectToBeHighlighted(page.locator(options).last())
+
+    await page.keyboard.press("ArrowDown")
+    await expectToBeHighlighted(page.locator(options).first())
+  })
+})

--- a/packages/machines/select/src/select.machine.ts
+++ b/packages/machines/select/src/select.machine.ts
@@ -288,8 +288,8 @@ export function machine<T extends CollectionItem>(userContext: UserDefinedContex
         multiple: (ctx) => !!ctx.multiple,
         hasSelectedItems: (ctx) => ctx.hasSelectedItems,
         hasHighlightedItem: (ctx) => ctx.highlightedValue != null,
-        isFirstItemHighlighted: (ctx) => ctx.highlightedItem["value"] === ctx.collection.first(),
-        isLastItemHighlighted: (ctx) => ctx.highlightedItem["value"] === ctx.collection.last(),
+        isFirstItemHighlighted: (ctx) => ctx.highlightedItem?.["value"] === ctx.collection.first(),
+        isLastItemHighlighted: (ctx) => ctx.highlightedItem?.["value"] === ctx.collection.last(),
         selectOnBlur: (ctx) => !!ctx.selectOnBlur,
         closeOnSelect: (ctx, evt) => {
           if (ctx.multiple) return false


### PR DESCRIPTION
## 📝 Description

On my previous PR (#954), I've introduced a bug, sorry about that 🙇
I didn't check if `highlightedItem` from the context was defined before trying to access its value.

When defining the guards for `CONTENT.ARROW_UP` (or `CONTENT.ARROW_DOWN`), I put `isFirstItemHighlighted` (or `isLastItemHighlighted`) at the end, thinking they would be called after the `hasHighlightedItem` guard, which checks if `highlightedItem` is indeed defined.
I wrongly assumed that if one guard fails, there would be an early return and the subsequent guards wouldn't be called, but that's not the case it seems.

```tsx
{
  guard: and("hasHighlightedItem", "isLoopEnabled", "isFirstItemHighlighted"),
  actions: ["highlightLastItem"],
},
```
This PR fixes that by using the optional chaining operator to safely access the `highlightedItem` value

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
