### PR TITLE
fix(combobox): autocomplete not working in vue version

### DIFF
--- a/.changeset/ten-candles-pretend.md
+++ b/.changeset/ten-candles-pretend.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/combobox": patch
+---
+
+Fix autocomplete input behavior not working in Vue version

--- a/packages/machines/combobox/src/combobox.machine.ts
+++ b/packages/machines/combobox/src/combobox.machine.ts
@@ -573,7 +573,9 @@ export function machine<T extends CollectionItem>(userContext: UserDefinedContex
           const inputEl = dom.getInputEl(ctx)
           if (!ctx.autoComplete || !inputEl || !KEYDOWN_EVENT_REGEX.test(evt.type)) return
           const valueText = ctx.collection.valueToString(ctx.highlightedValue)
-          inputEl.value = valueText || ctx.inputValue
+          raf(() => {
+            inputEl.value = valueText || ctx.inputValue
+          })
         },
         setCollection(ctx, evt) {
           ctx.collection = evt.value


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When setting `inputBehavior` to `autocomplete` oninVue version, nothing happens to input value when you move through items. Same behavior works for React and Solid versions.

I’ve wrappend DOM mutation inside `requestAnimationFrame` call, but I don’t know if that’s correct way to approach these issues.

## ⛳️ Current behavior (updates)

Setting `inputBehavior` to `autocomplete` should update input value to highlighted item. Works for React and Solid, but not for Vue.

## 🚀 New behavior

Setting `inputBehavior` to `autocomplete` should update input value to highlighted item on all frameworks.

This also makes Playwright test pass, and that was the only one not passing for combobox.

## 💣 Is this a breaking change (Yes/No):

Not breaking change.

## 📝 Additional Information

N/A