### PR TITLE
fix(presence): missing invoke on exit complete

### DIFF
--- a/.changeset/chilled-bees-switch.md
+++ b/.changeset/chilled-bees-switch.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/presence": patch
+---
+
+fix(presence): missing invoke on exit complete

--- a/.xstate/presence.js
+++ b/.xstate/presence.js
@@ -50,7 +50,7 @@ const fetchMachine = createMachine({
       }
     },
     unmounted: {
-      entry: ["clearPrevAnimationName"],
+      entry: ["clearPrevAnimationName", "invokeOnExitComplete"],
       on: {
         MOUNT: "mounted"
       }

--- a/packages/machines/presence/src/presence.machine.ts
+++ b/packages/machines/presence/src/presence.machine.ts
@@ -71,7 +71,6 @@ export function machine(ctx: Partial<UserDefinedContext>) {
       },
       actions: {
         invokeOnExitComplete(ctx) {
-          console.log("invokeOnExitComplete")
           ctx.onExitComplete?.()
         },
         setNode(ctx, evt) {

--- a/packages/machines/presence/src/presence.machine.ts
+++ b/packages/machines/presence/src/presence.machine.ts
@@ -54,7 +54,7 @@ export function machine(ctx: Partial<UserDefinedContext>) {
           },
         },
         unmounted: {
-          entry: ["clearPrevAnimationName"],
+          entry: ["clearPrevAnimationName", "invokeOnExitComplete"],
           on: {
             MOUNT: "mounted",
           },
@@ -71,6 +71,7 @@ export function machine(ctx: Partial<UserDefinedContext>) {
       },
       actions: {
         invokeOnExitComplete(ctx) {
+          console.log("invokeOnExitComplete")
           ctx.onExitComplete?.()
         },
         setNode(ctx, evt) {


### PR DESCRIPTION

Fixes chakra-ui/ark#1627 

## 📝 Description

There is a missing invoke for `onExitComplete`

## ⛳️ Current behavior (updates)



## 🚀 New behavior

Fires `onExitComplete` invoke properly

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
