### PR TITLE
docs: Update missing selectData and collection property in select (vue-sfc)

### DIFF
--- a/website/data/snippets/vue-sfc/select/usage.mdx
+++ b/website/data/snippets/vue-sfc/select/usage.mdx
@@ -4,7 +4,20 @@
   import { normalizeProps, useMachine } from "@zag-js/vue"
   import { computed, defineComponent, Teleport } from "vue"
 
-  const [state, send] = useMachine(select.machine({ id: "1" }))
+  const selectData = [
+    { label: "Nigeria", value: "NG" },
+    { label: "Japan", value: "JP" },
+    //...
+  ]
+
+  const [state, send] = useMachine(
+    select.machine({ 
+      id: "1",
+      collection: select.collection({
+        items: selectData,
+      }),
+    })
+  )
 
   const api = computed(() => select.connect(state.value, send, normalizeProps))
 </script>


### PR DESCRIPTION
## 📝 Description

Missing `selectData` and `collection` property in select: https://zagjs.com/components/react/select

## ⛳️ Current behavior (updates)

In usage of select, missing `selectData` and `collection` property

## 🚀 New behavior

Adding `selectData` and `collection` property for select

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
