### PR TITLE
chore: better examples

### DIFF
--- a/.changeset/polite-laws-study.md
+++ b/.changeset/polite-laws-study.md
@@ -1,0 +1,9 @@
+---
+"@zag-js/shared": patch
+"next-ts": patch
+"nuxt-ts": patch
+"solid-ts": patch
+"vue-ts": patch
+---
+
+chore: better examples

--- a/examples/next-ts/pages/accordion.tsx
+++ b/examples/next-ts/pages/accordion.tsx
@@ -29,6 +29,7 @@ export default function Page() {
               <h3>
                 <button data-testid={`${item.id}:trigger`} {...api.getItemTriggerProps({ value: item.id })}>
                   {item.label}
+                  <div {...api.getItemIndicatorProps({ value: item.id })}>{">"}</div>
                 </button>
               </h3>
               <div data-testid={`${item.id}:content`} {...api.getItemContentProps({ value: item.id })}>

--- a/examples/next-ts/pages/checkbox.tsx
+++ b/examples/next-ts/pages/checkbox.tsx
@@ -36,6 +36,7 @@ export default function Page() {
               <div {...api.controlProps} />
               <span {...api.labelProps}>Input {api.isChecked ? "Checked" : "Unchecked"}</span>
               <input {...api.hiddenInputProps} data-testid="hidden-input" />
+              <div {...api.indicatorProps}>Indicator</div>
             </label>
 
             <button type="button" disabled={api.isChecked} onClick={() => api.setChecked(true)}>
@@ -48,6 +49,7 @@ export default function Page() {
           </fieldset>
         </form>
       </main>
+
       <Toolbar controls={controls.ui}>
         <StateVisualizer state={state} />
       </Toolbar>

--- a/examples/next-ts/pages/menu-options.tsx
+++ b/examples/next-ts/pages/menu-options.tsx
@@ -25,7 +25,7 @@ export default function Page() {
       <main>
         <div>
           <button data-testid="trigger" {...api.triggerProps}>
-            Actions <span aria-hidden>▾</span>
+            Actions <span {...api.indicatorProps}>▾</span>
           </button>
 
           <Portal>

--- a/examples/next-ts/pages/menu.tsx
+++ b/examples/next-ts/pages/menu.tsx
@@ -19,7 +19,7 @@ export default function Page() {
       <main>
         <div>
           <button {...api.triggerProps}>
-            Actions <span aria-hidden>▾</span>
+            Actions <span {...api.indicatorProps}>▾</span>
           </button>
           <Portal>
             <div {...api.positionerProps}>

--- a/examples/next-ts/pages/popover.tsx
+++ b/examples/next-ts/pages/popover.tsx
@@ -30,6 +30,7 @@ export default function Page() {
 
           <button data-testid="popover-trigger" {...api.triggerProps}>
             Click me
+            <div {...api.indicatorProps}>{">"}</div>
           </button>
 
           <div {...api.anchorProps}>anchor</div>

--- a/examples/next-ts/pages/radio-group.tsx
+++ b/examples/next-ts/pages/radio-group.tsx
@@ -28,6 +28,7 @@ export default function Page() {
           <fieldset disabled={false}>
             <div {...api.rootProps}>
               <h3 {...api.labelProps}>Fruits</h3>
+              <div {...api.indicatorProps} />
               {radioData.map((opt) => (
                 <label key={opt.id} data-testid={`radio-${opt.id}`} {...api.getItemProps({ value: opt.id })}>
                   <div data-testid={`control-${opt.id}`} {...api.getItemControlProps({ value: opt.id })} />

--- a/examples/next-ts/pages/select.tsx
+++ b/examples/next-ts/pages/select.tsx
@@ -41,7 +41,7 @@ export default function Page() {
           <div {...api.controlProps}>
             <button {...api.triggerProps}>
               <span>{api.valueAsString || "Select option"}</span>
-              <span>▼</span>
+              <span {...api.indicatorProps}>▼</span>
             </button>
             <button {...api.clearTriggerProps}>X</button>
           </div>

--- a/examples/next-ts/pages/tags-input.tsx
+++ b/examples/next-ts/pages/tags-input.tsx
@@ -34,7 +34,9 @@ export default function Page() {
             {api.value.map((value, index) => (
               <span key={`${toDashCase(value)}-tag-${index}`}>
                 <div data-testid={`${toDashCase(value)}-tag`} {...api.getItemProps({ index, value })}>
-                  <span data-testid={`${toDashCase(value)}-valuetext`}>{value} </span>
+                  <span data-testid={`${toDashCase(value)}-valuetext`} {...api.getItemTextProps({ index, value })}>
+                    {value}{" "}
+                  </span>
                   <button
                     data-testid={`${toDashCase(value)}-close-button`}
                     {...api.getItemDeleteTriggerProps({ index, value })}

--- a/examples/nuxt-ts/pages/accordion.vue
+++ b/examples/nuxt-ts/pages/accordion.vue
@@ -19,6 +19,7 @@ const api = computed(() => accordion.connect(state.value, send, normalizeProps))
         <h3>
           <button :data-testid="`${item.id}:trigger`" v-bind="api.getItemTriggerProps({ value: item.id })">
             {{ item.label }}
+            <div v-bind="api.getItemIndicatorProps({ value: item.id })">{{ ">" }}</div>
           </button>
         </h3>
         <div :data-testid="`${item.id}:content`" v-bind="api.getItemContentProps({ value: item.id })">

--- a/examples/nuxt-ts/pages/checkbox.vue
+++ b/examples/nuxt-ts/pages/checkbox.vue
@@ -32,6 +32,7 @@ const api = computed(() => checkbox.connect(state.value, send, normalizeProps))
           <div v-bind="api.controlProps" />
           <span v-bind="api.labelProps">Input {{ api.isChecked ? "Checked" : "Unchecked" }}</span>
           <input v-bind="api.hiddenInputProps" data-testid="hidden-input" />
+          <div v-bind="api.indicatorProps">Indicator</div>
         </label>
 
         <button type="button" :disabled="api.isChecked" @click="() => api.setChecked(true)">Check</button>

--- a/examples/nuxt-ts/pages/menu-options.vue
+++ b/examples/nuxt-ts/pages/menu-options.vue
@@ -32,7 +32,7 @@ const checkboxes = data.type.map((item) => ({
 <template>
   <main>
     <div>
-      <button v-bind="api.triggerProps">Actions <span aria-hidden>▾</span></button>
+      <button v-bind="api.triggerProps">Actions <span v-bind="api.indicatorProps">▾</span></button>
       <Teleport to="body">
         <div v-bind="api.positionerProps">
           <div v-bind="api.contentProps">

--- a/examples/nuxt-ts/pages/menu.vue
+++ b/examples/nuxt-ts/pages/menu.vue
@@ -13,7 +13,7 @@ const api = computed(() => menu.connect(state.value, send, normalizeProps))
 <template>
   <main>
     <div>
-      <button v-bind="api.triggerProps">Actions <span aria-hidden>▾</span></button>
+      <button v-bind="api.triggerProps">Actions <span v-bind="api.indicatorProps">▾</span></button>
       <Teleport to="body">
         <div v-bind="api.positionerProps">
           <ul v-bind="api.contentProps">

--- a/examples/nuxt-ts/pages/popover.vue
+++ b/examples/nuxt-ts/pages/popover.vue
@@ -16,7 +16,10 @@ const api = computed(() => popover.connect(state.value, send, normalizeProps))
   <main>
     <div data-part="root">
       <button data-testid="button-before">Button :before</button>
-      <button data-testid="popover-trigger" v-bind="api.triggerProps">Click me</button>
+      <button data-testid="popover-trigger" v-bind="api.triggerProps">
+        Click me
+        <div v-bind="api.indicatorProps">{{ ">" }}</div>
+      </button>
       <Teleport to="body" :disabled="!api.portalled">
         <div v-bind="api.positionerProps">
           <div data-testid="popover-content" class="popover-content" v-bind="api.contentProps">

--- a/examples/nuxt-ts/pages/radio-group.vue
+++ b/examples/nuxt-ts/pages/radio-group.vue
@@ -26,6 +26,7 @@ const api = computed(() => radio.connect(state.value, send, normalizeProps))
       <fieldset>
         <div v-bind="api.rootProps">
           <h3 v-bind="api.labelProps">Fruits</h3>
+          <div v-bind="api.indicatorProps" />
 
           <label
             v-for="opt in radioData"

--- a/examples/nuxt-ts/pages/select.vue
+++ b/examples/nuxt-ts/pages/select.vue
@@ -26,7 +26,7 @@ const api = computed(() => select.connect(state.value, send, normalizeProps))
         <label v-bind="api.labelProps">Label</label>
         <button v-bind="api.triggerProps">
           <span>{{ api.valueAsString || "Select option" }}</span>
-          <span>▼</span>
+          <span v-bind="api.indicatorProps">▼</span>
         </button>
       </div>
       <form

--- a/examples/nuxt-ts/pages/tags-input.vue
+++ b/examples/nuxt-ts/pages/tags-input.vue
@@ -27,7 +27,9 @@ const api = computed(() => tagsInput.connect(state.value, send, normalizeProps))
       <div v-bind="api.controlProps">
         <span v-for="(value, index) in api.value" :key="`${toDashCase(value)}-tag-${index}`">
           <div :data-testid="`${toDashCase(value)}-tag`" v-bind="api.getItemProps({ index, value })">
-            <span>{{ value }} &nbsp;</span>
+            <span :data-testid="`${toDashCase(value)}-valuetext`" v-bind="api.getItemTextProps({ index, value })"
+              >{{ value }} &nbsp;</span
+            >
             <button
               :data-testid="`${toDashCase(value)}-close-button`"
               v-bind="api.getItemDeleteTriggerProps({ index, value })"

--- a/examples/shadow-dom/src/Menu.tsx
+++ b/examples/shadow-dom/src/Menu.tsx
@@ -19,7 +19,7 @@ export const Menu: React.FC<{ id: string }> = ({ id }) => {
   return (
     <div ref={ref}>
       <button {...api.triggerProps}>
-        Actions <span aria-hidden>▾</span>
+        Actions <span {...api.indicatorProps}>▾</span>
       </button>
       <div {...api.positionerProps}>
         <ul {...api.contentProps} style={{ backgroundColor: "white", color: "black" }}>

--- a/examples/solid-ts/src/pages/accordion.tsx
+++ b/examples/solid-ts/src/pages/accordion.tsx
@@ -25,6 +25,7 @@ export default function Page() {
                 <h3>
                   <button data-testid={`${item.id}:trigger`} {...api().getItemTriggerProps({ value: item.id })}>
                     {item.label}
+                    <div {...api().getItemIndicatorProps({ value: item.id })}>{">"}</div>
                   </button>
                 </h3>
                 <div data-testid={`${item.id}:content`} {...api().getItemContentProps({ value: item.id })}>

--- a/examples/solid-ts/src/pages/checkbox.tsx
+++ b/examples/solid-ts/src/pages/checkbox.tsx
@@ -37,6 +37,7 @@ export default function Page() {
                 <div {...api().controlProps} />
                 <span {...api().labelProps}>Input {api().isChecked ? "Checked" : "Unchecked"}</span>
                 <input {...api().hiddenInputProps} data-testid="hidden-input" />
+                <div {...api().indicatorProps}>Indicator</div>
               </label>
             </fieldset>
 

--- a/examples/solid-ts/src/pages/menu-options.tsx
+++ b/examples/solid-ts/src/pages/menu-options.tsx
@@ -28,7 +28,7 @@ export default function Page() {
       <main>
         <div>
           <button data-testid="trigger" {...api().triggerProps}>
-            Actions <span aria-hidden>▾</span>
+            Actions <span {...api().indicatorProps}>▾</span>
           </button>
 
           <Portal>

--- a/examples/solid-ts/src/pages/menu.tsx
+++ b/examples/solid-ts/src/pages/menu.tsx
@@ -20,7 +20,7 @@ export default function Page() {
       <main>
         <div>
           <button {...api().triggerProps}>
-            Actions <span aria-hidden>▾</span>
+            Actions <span {...api().indicatorProps}>▾</span>
           </button>
 
           <Portal>

--- a/examples/solid-ts/src/pages/popover.tsx
+++ b/examples/solid-ts/src/pages/popover.tsx
@@ -27,6 +27,7 @@ export default function Page() {
           <button data-testid="button-before">Button :before</button>
           <button data-testid="popover-trigger" {...api().triggerProps}>
             Click me
+            <div {...api().indicatorProps}>{">"}</div>
           </button>
           <Wrapper guard={api().portalled}>
             <div {...api().positionerProps}>

--- a/examples/solid-ts/src/pages/radio-group.tsx
+++ b/examples/solid-ts/src/pages/radio-group.tsx
@@ -34,6 +34,7 @@ export default function Page() {
           <fieldset disabled={false}>
             <div {...api().rootProps}>
               <h3 {...api().labelProps}>Fruits</h3>
+              <div {...api().indicatorProps} />
               {radioData.map((opt) => (
                 <label data-testid={`radio-${opt.id}`} {...api().getItemProps({ value: opt.id })}>
                   <div data-testid={`control-${opt.id}`} {...api().getItemControlProps({ value: opt.id })} />

--- a/examples/solid-ts/src/pages/select.tsx
+++ b/examples/solid-ts/src/pages/select.tsx
@@ -32,7 +32,7 @@ export default function Page() {
             <label {...api().labelProps}>Label</label>
             <button {...api().triggerProps}>
               {api().valueAsString || "Select option"}
-              <span>▼</span>
+              <span {...api().indicatorProps}>▼</span>
             </button>
           </div>
 

--- a/examples/solid-ts/src/pages/tags-input.tsx
+++ b/examples/solid-ts/src/pages/tags-input.tsx
@@ -33,7 +33,12 @@ export default function Page() {
               {(value, index) => (
                 <span>
                   <div data-testid={`${toDashCase(value)}-tag`} {...api().getItemProps({ index: index(), value })}>
-                    <span data-testid={`${toDashCase(value)}-valuetext`}>{value} </span>
+                    <span
+                      data-testid={`${toDashCase(value)}-valuetext`}
+                      {...api().getItemTextProps({ index: index(), value })}
+                    >
+                      {value}{" "}
+                    </span>
                     <button
                       data-testid={`${toDashCase(value)}-close-button`}
                       {...api().getItemDeleteTriggerProps({ index: index(), value })}

--- a/examples/vue-ts/src/pages/accordion.tsx
+++ b/examples/vue-ts/src/pages/accordion.tsx
@@ -29,6 +29,7 @@ export default defineComponent({
                   <h3>
                     <button data-testid={`${item.id}:trigger`} {...api.getItemTriggerProps({ value: item.id })}>
                       {item.label}
+                      <div {...api.getItemIndicatorProps({ value: item.id })}>{">"}</div>
                     </button>
                   </h3>
                   <div data-testid={`${item.id}:content`} {...api.getItemContentProps({ value: item.id })}>

--- a/examples/vue-ts/src/pages/checkbox.tsx
+++ b/examples/vue-ts/src/pages/checkbox.tsx
@@ -41,6 +41,7 @@ export default defineComponent({
                   <div {...api.controlProps} />
                   <span {...api.labelProps}>Input {api.isChecked ? "Checked" : "Unchecked"}</span>
                   <input {...api.hiddenInputProps} data-testid="hidden-input" />
+                  <div {...api.indicatorProps}>Indicator</div>
                 </label>
 
                 <button type="button" disabled={api.isChecked} onClick={() => api.setChecked(true)}>

--- a/examples/vue-ts/src/pages/menu-options.tsx
+++ b/examples/vue-ts/src/pages/menu-options.tsx
@@ -28,7 +28,7 @@ export default defineComponent({
           <main>
             <div>
               <button data-testid="trigger" {...api.triggerProps}>
-                Actions <span aria-hidden>▾</span>
+                Actions <span {...api.indicatorProps}>▾</span>
               </button>
               <Teleport to="body">
                 <div {...api.positionerProps}>

--- a/examples/vue-ts/src/pages/menu.tsx
+++ b/examples/vue-ts/src/pages/menu.tsx
@@ -23,7 +23,7 @@ export default defineComponent({
           <main>
             <div>
               <button {...api.triggerProps}>
-                Actions <span aria-hidden>▾</span>
+                Actions <span {...api.indicatorProps}>▾</span>
               </button>
               <Teleport to="body">
                 <div {...api.positionerProps}>

--- a/examples/vue-ts/src/pages/popover.tsx
+++ b/examples/vue-ts/src/pages/popover.tsx
@@ -28,6 +28,7 @@ export default defineComponent({
               <button data-testid="button-before">Button :before</button>
               <button data-testid="popover-trigger" {...api.triggerProps}>
                 Click me
+                <div {...api.indicatorProps}>{">"}</div>
               </button>
               <Teleport to="body" disabled={!api.portalled}>
                 <div {...api.positionerProps}>

--- a/examples/vue-ts/src/pages/radio-group.tsx
+++ b/examples/vue-ts/src/pages/radio-group.tsx
@@ -33,6 +33,7 @@ export default defineComponent({
               <fieldset disabled={false}>
                 <div {...api.rootProps}>
                   <h3 {...api.labelProps}>Fruits</h3>
+                  <div {...api.indicatorProps} />
                   {radioData.map((opt) => (
                     <label key={opt.id} data-testid={`radio-${opt.id}`} {...api.getItemProps({ value: opt.id })}>
                       <div data-testid={`control-${opt.id}`} {...api.getItemControlProps({ value: opt.id })} />

--- a/examples/vue-ts/src/pages/select.tsx
+++ b/examples/vue-ts/src/pages/select.tsx
@@ -36,7 +36,7 @@ export default defineComponent({
                 <label {...api.labelProps}>Label</label>
                 <button {...api.triggerProps}>
                   {api.valueAsString || "Select option"}
-                  <span>▼</span>
+                  <span {...api.indicatorProps}>▼</span>
                 </button>
               </div>
 

--- a/examples/vue-ts/src/pages/tags-input.tsx
+++ b/examples/vue-ts/src/pages/tags-input.tsx
@@ -40,7 +40,9 @@ export default defineComponent({
                 {api.value.map((value, index) => (
                   <span key={`${toDashCase(value)}-tag-${index}`}>
                     <div data-testid={`${toDashCase(value)}-tag`} {...api.getItemProps({ index, value })}>
-                      <span>{value} </span>
+                      <span data-testid={`${toDashCase(value)}-valuetext`} {...api.getItemTextProps({ index, value })}>
+                        {value}{" "}
+                      </span>
                       <button
                         data-testid={`${toDashCase(value)}-close-button`}
                         {...api.getItemDeleteTriggerProps({ index, value })}

--- a/shared/src/style.css
+++ b/shared/src/style.css
@@ -158,6 +158,14 @@ a[aria-current="page"] {
 * Avatar
 * -----------------------------------------------------------------------------*/
 
+[data-scope="accordion"][data-part="item-indicator"][data-state="open"] {
+  rotate: 90deg;
+}
+
+/* -----------------------------------------------------------------------------
+* Avatar
+* -----------------------------------------------------------------------------*/
+
 [data-scope="avatar"][data-part="root"] {
   width: 80px;
   height: 80px;
@@ -456,6 +464,10 @@ main [data-testid="scrubber"] {
   --arrow-background: white;
   --arrow-shadow-color: #ebebeb;
   box-shadow: var(--box-shadow);
+}
+
+[data-scope="popover"][data-part="indicator"][data-state="open"] {
+  rotate: 90deg;
 }
 
 /* -----------------------------------------------------------------------------

--- a/website/components/machines/menu.tsx
+++ b/website/components/machines/menu.tsx
@@ -25,7 +25,7 @@ export function Menu(props: MenuProps) {
     <div>
       <Button size="sm" variant="green" {...api.triggerProps}>
         Actions{" "}
-        <chakra.span ml="2" aria-hidden>
+        <chakra.span ml="2" {...api.indicatorProps}>
           ▾
         </chakra.span>
       </Button>

--- a/website/components/machines/nested-menu.tsx
+++ b/website/components/machines/nested-menu.tsx
@@ -47,7 +47,7 @@ export function NestedMenu() {
     <div>
       <Button size="sm" variant="green" {...fileMenu.triggerProps}>
         Click me
-        <chakra.span ml="2" aria-hidden>
+        <chakra.span ml="2" {...fileMenu.indicatorProps}>
           ▾
         </chakra.span>
       </Button>
@@ -90,7 +90,7 @@ export function NestedMenu() {
               {...shareMenuTriggerProps}
             >
               Share
-              <chakra.span ml="2" aria-hidden>
+              <chakra.span ml="2" {...shareMenu.indicatorProps}>
                 »
               </chakra.span>
             </chakra.li>

--- a/website/data/snippets/react/menu/usage.mdx
+++ b/website/data/snippets/react/menu/usage.mdx
@@ -10,7 +10,7 @@ export function Menu() {
   return (
     <div>
       <button {...api.triggerProps}>
-        Actions <span aria-hidden>▾</span>
+        Actions <span {...api.indicatorProps}>▾</span>
       </button>
       <div {...api.positionerProps}>
         <ul {...api.contentProps}>

--- a/website/data/snippets/solid/menu/usage.mdx
+++ b/website/data/snippets/solid/menu/usage.mdx
@@ -13,7 +13,7 @@ export function Menu() {
   return (
     <div>
       <button {...api().triggerProps}>
-        Actions <span aria-hidden>▾</span>
+        Actions <span {...api().indicatorProps}>▾</span>
       </button>
       <div {...api().positionerProps}>
         <ul {...api().contentProps}>

--- a/website/data/snippets/vue-jsx/menu/usage.mdx
+++ b/website/data/snippets/vue-jsx/menu/usage.mdx
@@ -18,7 +18,7 @@ export default defineComponent({
       return (
         <div>
           <button {...api.triggerProps}>
-            Actions <span aria-hidden>▾</span>
+            Actions <span {...api.indicatorProps}>▾</span>
           </button>
           <div {...api.positionerProps}>
             <ul {...api.contentProps}>

--- a/website/data/snippets/vue-sfc/menu/usage.mdx
+++ b/website/data/snippets/vue-sfc/menu/usage.mdx
@@ -11,7 +11,7 @@ const api = computed(() => menu.connect(state.value, send, normalizeProps));
 <template>
   <div ref="ref">
     <button v-bind="api.triggerProps">
-      Actions <span aria-hidden>▾</span>
+        Actions <span v-bind="api.indicatorProps">▾</span>
     </button>
     <div v-bind="api.positionerProps">
       <ul v-bind="api.contentProps">


### PR DESCRIPTION
## 📝 Description

#882 introduced a new `Indicator` part for some components. It'll be nice to provide full examples.

For example, the menu component uses this:

![image](https://github.com/chakra-ui/zag/assets/6079265/994e3c5f-e4f9-472b-bc44-7037690157ad)

It's time to use something better:
![image](https://github.com/chakra-ui/zag/assets/6079265/de17193a-f898-4db9-b98a-ce21ece406d1)

## ⛳️ Current behavior (updates)

Missing `Indicator` components

## 🚀 New behavior

Changed examples

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Related to chakra-ui/ark#1695