### PR TITLE
docs: Add code snippet for color picker (vue-sfc)

### DIFF
--- a/website/data/snippets/vue-sfc/color-picker/usage.mdx
+++ b/website/data/snippets/vue-sfc/color-picker/usage.mdx
@@ -1,2 +1,49 @@
-```jsx
+```html
+<script setup>
+import * as colorPicker from "@zag-js/color-picker";
+import { normalizeProps, useMachine } from "@zag-js/vue";
+import { computed } from "vue";
+
+const [state, send] = useMachine(colorPicker.machine({
+  id: "1",
+  value: colorPicker.parse("hsl(0, 100%, 50%)")
+}))
+
+const api = computed(() => colorPicker.connect(state.value, send, normalizeProps));
+</script>
+
+<template>
+  <div v-bind="api.rootProps">
+    <label v-bind="api.labelProps">Select Color: {{ api.valueAsString }}</label>
+    <input v-bind="api.hiddenInputProps" />
+    <div v-bind="api.controlProps">
+      <button v-bind="api.triggerProps">
+        <div v-bind="api.getTransparencyGridProps({ size: '10px' })" />
+        <div v-bind="api.getSwatchProps({ value: api.value })" />
+      </button>
+      <input v-bind="api.getChannelInputProps({ channel: 'hex' })" />
+      <input v-bind="api.getChannelInputProps({ channel: 'alpha' })" />
+    </div>
+
+    <div v-bind="api.positionerProps">
+      <div v-bind="api.contentProps">
+        <div v-bind="api.getAreaProps()">
+          <div v-bind="api.getAreaBackgroundProps()" />
+          <div v-bind="api.getAreaThumbProps()" />
+        </div>
+
+        <div v-bind="api.getChannelSliderProps({ channel: 'hue' })">
+          <div v-bind="api.getChannelSliderTrackProps({ channel: 'hue' })" />
+          <div v-bind="api.getChannelSliderThumbProps({ channel: 'hue' })" />
+        </div>
+
+        <div v-bind="api.getChannelSliderProps({ channel: 'alpha' })">
+          <div v-bind="api.getTransparencyGridProps({ size: '12px' })" />
+          <div v-bind="api.getChannelSliderTrackProps({ channel: 'alpha' })" />
+          <div v-bind="api.getChannelSliderThumbProps({ channel: 'alpha' })" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
 ```

--- a/website/data/snippets/vue-sfc/color-picker/with-channel-inputs.mdx
+++ b/website/data/snippets/vue-sfc/color-picker/with-channel-inputs.mdx
@@ -1,0 +1,47 @@
+```html
+<script setup>
+import * as colorPicker from "@zag-js/color-picker";
+import { normalizeProps, useMachine } from "@zag-js/vue";
+import { computed } from "vue";
+
+const [state, send] = useMachine(colorPicker.machine({
+  id: "1",
+  value: colorPicker.parse("hsl(0, 100%, 50%)")
+}))
+
+const api = computed(() => colorPicker.connect(state.value, send, normalizeProps));
+</script>
+
+<template>
+  <div v-bind="api.rootProps">
+    // ...
+    <div v-bind="api.positionerProps">
+      <div v-bind="api.contentProps">
+        <template v-if="api.format === 'rgba'">
+          <div>
+            <div>
+              <span>R</span>
+              <input v-bind="api.getChannelInputProps({ channel: 'red' })" />
+            </div>
+
+            <div>
+              <span>G</span>
+              <input v-bind="api.getChannelInputProps({ channel: 'green' })" />
+            </div>
+
+            <div>
+              <span>B</span>
+              <input v-bind="api.getChannelInputProps({ channel: 'blue' })" />
+            </div>
+
+            <div>
+              <span>A</span>
+              <input v-bind="api.getChannelInputProps({ channel: 'alpha' })" />
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+```

--- a/website/data/snippets/vue-sfc/color-picker/with-eye-dropper.mdx
+++ b/website/data/snippets/vue-sfc/color-picker/with-eye-dropper.mdx
@@ -1,0 +1,27 @@
+```html
+<script setup>
+import * as colorPicker from "@zag-js/color-picker";
+import { normalizeProps, useMachine } from "@zag-js/vue";
+import { computed } from "vue";
+
+const [state, send] = useMachine(colorPicker.machine({
+  id: "1",
+  value: colorPicker.parse("hsl(0, 100%, 50%)")
+}))
+
+const api = computed(() => colorPicker.connect(state.value, send, normalizeProps));
+</script>
+
+<template>
+  <div v-bind="api.rootProps">
+    // ...
+    <div v-bind="api.positionerProps">
+      <div v-bind="api.contentProps">
+        <button v-bind="api.eyeDropperTriggerProps">
+          <EyeDropIcon />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+```

--- a/website/data/snippets/vue-sfc/color-picker/with-preview.mdx
+++ b/website/data/snippets/vue-sfc/color-picker/with-preview.mdx
@@ -1,0 +1,24 @@
+```html
+<script setup>
+import * as colorPicker from "@zag-js/color-picker";
+import { normalizeProps, useMachine } from "@zag-js/vue";
+import { computed } from "vue";
+
+const [state, send] = useMachine(colorPicker.machine({
+  id: "1",
+  value: colorPicker.parse("hsl(0, 100%, 50%)")
+}))
+
+const api = computed(() => colorPicker.connect(state.value, send, normalizeProps));
+</script>
+
+<template>
+  <div v-bind="api.rootProps">
+    <div>
+      <div v-bind="api.getTransparencyGridProps({ size: '4px' })" />
+      <div v-bind="api.getSwatchProps({ value: api.value })" />
+    </div>
+    // ...
+  </div>
+</template>
+```

--- a/website/data/snippets/vue-sfc/color-picker/with-swatches.mdx
+++ b/website/data/snippets/vue-sfc/color-picker/with-swatches.mdx
@@ -1,0 +1,34 @@
+```html
+<script setup>
+import * as colorPicker from "@zag-js/color-picker";
+import { normalizeProps, useMachine } from "@zag-js/vue";
+import { computed, ref } from "vue";
+
+const [state, send] = useMachine(colorPicker.machine({
+  id: "1",
+  value: colorPicker.parse("hsl(0, 100%, 50%)")
+}))
+
+const api = computed(() => colorPicker.connect(state.value, send, normalizeProps));
+
+const presets = ref(["#ff0000", "#00ff00", "#0000ff"]);
+</script>
+
+<template>
+  <div v-bind="api.rootProps">
+    // ...
+    <div v-bind="api.positionerProps">
+      <div v-bind="api.contentProps">
+        <div v-bind="api.swatchGroupProps">
+            <template v-for="preset in presets">
+                <button v-bind="api.getSwatchTriggerProps({ value: preset })">
+                    <div v-bind="api.getTransparencyGridProps({ size: '4px' })" />
+                    <div v-bind="api.getSwatchProps({ value: preset })" />
+                </button>
+            </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```


### PR DESCRIPTION
## 📝 Description

Add code snippet for color picker (vue-sfc): https://zagjs.com/components/vue-sfc/color-picker

## ⛳️ Current behavior (updates)

- Color Picker (vue-sfc): `Snippet not found :(`

## 🚀 New behavior

- Color Picker (vue-sfc): Adding snippet for usage, showing color presets, controlling individual color channel, showing a color preview and adding a eyedropper.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
