### PR TITLE
docs:  Add code snippet for color picker (vue-jsx)

### DIFF
--- a/website/data/snippets/vue-jsx/color-picker/usage.mdx
+++ b/website/data/snippets/vue-jsx/color-picker/usage.mdx
@@ -1,2 +1,56 @@
-```jsx
+```tsx
+import * as colorPicker from "@zag-js/color-picker"
+import { normalizeProps, useMachine } from "@zag-js/vue"
+import { computed } from "vue"
+
+export default defineComponent({
+  name: "ColorPicker",
+  setup() {
+    const [state, send] = useMachine(colorPicker.machine({
+      id: "1",
+      value: colorPicker.parse("hsl(0, 100%, 50%)")
+    }))
+
+    const apiRef = computed(() => colorPicker.connect(state.value, send, normalizeProps))
+
+    return () => {
+      const api = apiRef.value
+
+      return (
+        <div {...api.rootProps}>
+          <label {...api.labelProps}>Select Color: { api.valueAsString }</label>
+          <input {...api.hiddenInputProps} />
+          <div {...api.controlProps}>
+            <button {...api.triggerProps}>
+              <div {...api.getTransparencyGridProps({ size: '10px' })} />
+              <div {...api.getSwatchProps({ value: api.value })} />
+            </button>
+            <input {...api.getChannelInputProps({ channel: 'hex' })} />
+            <input {...api.getChannelInputProps({ channel: 'alpha' })} />
+          </div>
+      
+          <div {...api.positionerProps}>
+            <div {...api.contentProps}>
+              <div {...api.getAreaProps()}>
+                <div {...api.getAreaBackgroundProps()} />
+                <div {...api.getAreaThumbProps()} />
+              </div>
+      
+              <div {...api.getChannelSliderProps({ channel: 'hue' })}>
+                <div {...api.getChannelSliderTrackProps({ channel: 'hue' })} />
+                <div {...api.getChannelSliderThumbProps({ channel: 'hue' })} />
+              </div>
+      
+              <div {...api.getChannelSliderProps({ channel: 'alpha' })}>
+                <div {...api.getTransparencyGridProps({ size: '12px' })} />
+                <div {...api.getChannelSliderTrackProps({ channel: 'alpha' })} />
+                <div {...api.getChannelSliderThumbProps({ channel: 'alpha' })} />
+              </div>
+            </div>
+          </div>
+        </div>
+      )
+    }
+  }
+})
 ```

--- a/website/data/snippets/vue-jsx/color-picker/with-channel-inputs.mdx
+++ b/website/data/snippets/vue-jsx/color-picker/with-channel-inputs.mdx
@@ -1,0 +1,54 @@
+```tsx
+import * as colorPicker from "@zag-js/color-picker"
+import { normalizeProps, useMachine } from "@zag-js/vue"
+import { computed } from "vue"
+
+export default defineComponent({
+  name: "ColorPicker",
+  setup() {
+    const [state, send] = useMachine(colorPicker.machine({
+      id: "1",
+      value: colorPicker.parse("hsl(0, 100%, 50%)")
+    }))
+
+    const apiRef = computed(() => colorPicker.connect(state.value, send, normalizeProps))
+
+    return () => {
+      const api = apiRef.value
+
+      return (
+        <div {...api.rootProps}>
+          {/* ... */}
+          <div {...api.positionerProps}>
+            <div {...api.contentProps}>
+              {api.format === 'rgba' && (
+                <div>
+                  <div>
+                    <span>R</span>
+                    <input {...api.getChannelInputProps({ channel: 'red' })} />
+                  </div>
+
+                  <div>
+                    <span>G</span>
+                    <input {...api.getChannelInputProps({ channel: 'green' })} />
+                  </div>
+
+                  <div>
+                    <span>B</span>
+                    <input {...api.getChannelInputProps({ channel: 'blue' })} />
+                  </div>
+
+                  <div>
+                    <span>A</span>
+                    <input {...api.getChannelInputProps({ channel: 'alpha' })} />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )
+    }
+  }
+})
+```

--- a/website/data/snippets/vue-jsx/color-picker/with-eye-dropper.mdx
+++ b/website/data/snippets/vue-jsx/color-picker/with-eye-dropper.mdx
@@ -1,0 +1,34 @@
+```tsx
+import * as colorPicker from "@zag-js/color-picker"
+import { normalizeProps, useMachine } from "@zag-js/vue"
+import { computed } from "vue"
+
+export default defineComponent({
+  name: "ColorPicker",
+  setup() {
+    const [state, send] = useMachine(colorPicker.machine({
+      id: "1",
+      value: colorPicker.parse("hsl(0, 100%, 50%)")
+    }))
+
+    const apiRef = computed(() => colorPicker.connect(state.value, send, normalizeProps))
+
+    return () => {
+      const api = apiRef.value
+
+      return (
+        <div {...api.rootProps}>
+          {/* ... */}
+          <div {...api.positionerProps}>
+            <div {...api.contentProps}>
+              <button {...api.eyeDropperTriggerProps}>
+                <EyeDropIcon />
+              </button>
+            </div>
+          </div>
+        </div>
+      )
+    }
+  }
+})
+```

--- a/website/data/snippets/vue-jsx/color-picker/with-preview.mdx
+++ b/website/data/snippets/vue-jsx/color-picker/with-preview.mdx
@@ -1,0 +1,31 @@
+```tsx
+import * as colorPicker from "@zag-js/color-picker"
+import { normalizeProps, useMachine } from "@zag-js/vue"
+import { computed } from "vue"
+
+export default defineComponent({
+  name: "ColorPicker",
+  setup() {
+    const [state, send] = useMachine(colorPicker.machine({
+      id: "1",
+      value: colorPicker.parse("hsl(0, 100%, 50%)")
+    }))
+
+    const apiRef = computed(() => colorPicker.connect(state.value, send, normalizeProps))
+
+    return () => {
+      const api = apiRef.value
+
+      return (
+        <div {...api.rootProps}>
+          <div>
+            <div {...api.getTransparencyGridProps({ size: '4px' })} />
+            <div {...api.getSwatchProps({ value: api.value })} />
+          </div>
+          {/* ... */}
+        </div>
+      )
+    }
+  }
+})
+```

--- a/website/data/snippets/vue-jsx/color-picker/with-swatches.mdx
+++ b/website/data/snippets/vue-jsx/color-picker/with-swatches.mdx
@@ -1,0 +1,41 @@
+```tsx
+import * as colorPicker from "@zag-js/color-picker"
+import { normalizeProps, useMachine } from "@zag-js/vue"
+import { computed, ref } from "vue"
+
+export default defineComponent({
+  name: "ColorPicker",
+  setup() {
+    const [state, send] = useMachine(colorPicker.machine({
+      id: "1",
+      value: colorPicker.parse("hsl(0, 100%, 50%)")
+    }))
+
+    const apiRef = computed(() => colorPicker.connect(state.value, send, normalizeProps))
+
+    const presets = ref(["#ff0000", "#00ff00", "#0000ff"])
+
+    return () => {
+      const api = apiRef.value
+
+      return (
+        <div {...api.rootProps}>
+          {/* ... */}
+          <div {...api.positionerProps}>
+            <div {...api.contentProps}>
+              <div {...api.swatchGroupProps}>
+                {presets.value.map((preset) => (
+                  <button {...api.getSwatchTriggerProps({ value: preset })}>
+                    <div {...api.getTransparencyGridProps({ size: '4px' })} />
+                    <div {...api.getSwatchProps({ value: preset })} />
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )
+    }
+  }
+})
+```


### PR DESCRIPTION
## 📝 Description

Add code snippet for color picker (vue-jsx): https://zagjs.com/components/vue-sfc/color-picker

## ⛳️ Current behavior (updates)

- Color picker of Vue 3 (JSX): `Snippet not found :(`

## 🚀 New behavior

- Color picker of Vue 3 (JSX): Adding snippet for usage, showing color presets, controlling individual color channel, showing a color preview and adding a eyedropper.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
