### PR TITLE
chore: add start-website as an npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ ensure that the component works the same way regardless of the framework.
 - `test` : Run the tests for all packages
 - `lint` : Lint all packages
 
+### Website
+
+- `start-website`: Starts the website
+
 ---
 
 ## Inspirations

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start-vue": "pnpm vue dev",
     "start-vue-sfc": "pnpm vue-sfc dev",
     "start-solid": "pnpm solid dev",
+    "start-website": "pnpm website dev",
     "pw-report": "playwright show-report e2e/report",
     "pw-test": "playwright test",
     "pw-test-debug": "playwright test --debug",


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR provides contributors with an intuitive way to run the website in local environments.

## ⛳️ Current behavior (updates)

zag has the `pnpm website` script, but we have to add the `dev` command to run the website.

```
pnpm website dev
```

If we run the run the npm script (`website`) without the command (`dev`), we would see the following error.

```
> pnpm --filter=./website

 ERROR  Unknown option: 'recursive'
For help, run: pnpm help recursive
 ELIFECYCLE  Command failed with exit code 1.
```

## 🚀 New behavior

I'd like to add the `start-website` script, which is a command to run the website, as an explicit way to run the website.
There are already ' start-***` commends to run examples, so I've followed the convention.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
