### PR TITLE
fix (dom-query): trim text to ensure finding an item by text

### DIFF
--- a/packages/utilities/dom-query/src/get-by-text.ts
+++ b/packages/utilities/dom-query/src/get-by-text.ts
@@ -2,7 +2,7 @@ import { indexOfId } from "./get-by-id"
 
 const getValueText = <T extends HTMLElement>(item: T) => item.dataset.valuetext ?? item.textContent ?? ""
 
-const match = (valueText: string, query: string) => valueText.toLowerCase().startsWith(query.toLowerCase())
+const match = (valueText: string, query: string) => valueText.trim().toLowerCase().startsWith(query.toLowerCase())
 
 const wrap = <T>(v: T[], idx: number) => {
   return v.map((_, index) => v[(Math.max(idx, 0) + index) % v.length])


### PR DESCRIPTION
Following this PR that I submitted for Ark: https://github.com/chakra-ui/ark/pull/1795

I suggest to trim the text in the get-by-text utility of the dom-query, allowing to find an item, event if it contains extra spaces in its text.