### PR TITLE
docs: fix typo with listening for changes example for switch component

### DIFF
--- a/website/data/components/switch.mdx
+++ b/website/data/components/switch.mdx
@@ -95,12 +95,12 @@ const [state, send] = useMachine(
 
 ## Listening for changes
 
-When the switch value changes, the `onCheckChange` callback is invoked.
+When the switch value changes, the `onCheckedChange` callback is invoked.
 
 ```jsx {3-5}
 const [state, send] = useMachine(
   zagSwitch.machine({
-    onCheckChange(details) {
+    onCheckedChange(details) {
       // details => { checked: boolean }
       console.log("switch is:", details.checked ? "On" : "Off")
     },


### PR DESCRIPTION
## 📝 Description
Fixed typos for the `onCheckedChange` option on the `listening for changes` example section of the Switch component.

## ⛳️ Current behavior (updates)
The example used `onCheckChange` as the name for the option.

## 🚀 New behavior
This has now been changed to `onCheckedChange`.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
N/A