### PR TITLE
fix: add readonly to collection setItems

### DIFF
--- a/packages/utilities/collection/src/collection.ts
+++ b/packages/utilities/collection/src/collection.ts
@@ -104,7 +104,7 @@ export class Collection<T extends CollectionItem = CollectionItem> {
   /**
    * Function to update the collection items
    */
-  setItems = (items: T[]) => {
+  setItems = (items: T[] | readonly T[]) => {
     this.options.items = items
     return this.iterate()
   }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description

Fixed the difference `items` types in  `Collection` constructor and `setItems`

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

In the `Collection` constructor, the `items` type of  `CollectionOptions` is ` T[] | readonly T[]`, but in `setItems` function is `T[]`

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

update `setItem` function type from `(items: T[]) => Collection<T>` to `(items: T[] | readonly T[]) => Collection<T>`

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing users. -->
