### PR TITLE
fix(presence): set initial context

### DIFF
--- a/.xstate/presence.js
+++ b/.xstate/presence.js
@@ -11,6 +11,11 @@ const {
 } = actions;
 const fetchMachine = createMachine({
   initial: initialState,
+  context: {
+    "isPresent": false,
+    "isAnimationNone || isDisplayNone": false,
+    "wasPresent && isAnimating": false
+  },
   on: {
     "NODE.SET": {
       actions: ["setNode", "setStyles"]
@@ -27,7 +32,9 @@ const fetchMachine = createMachine({
       target: "unmountSuspended"
     }, {
       target: "unmounted"
-    }],
+    }]
+  },
+  on: {
     UPDATE_CONTEXT: {
       actions: "updateContext"
     }

--- a/packages/machines/presence/src/presence.machine.ts
+++ b/packages/machines/presence/src/presence.machine.ts
@@ -15,6 +15,13 @@ export function machine(ctx: Partial<UserDefinedContext>) {
       watch: {
         present: ["raisePresenceChange", "setPrevPresent"],
       },
+      context: {
+        node: null,
+        styles: null,
+        prevAnimationName: "",
+        present: false,
+        ...ctx,
+      },
       on: {
         "NODE.SET": {
           actions: ["setNode", "setStyles"],


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

fixed not set initial context for presence

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

the usecase: 

```ts
  const [state, send] = useMachine(
    presence.machine({
      ...context.value,
      onExitComplete: () => {
        emit('exit-complete')
      },
    }),
    // the below context don't include onExitComplete anymore
    { context },
  )
```

if i passed `onExitComplete` as initial context to useMachine, the onExitComplete won't call correctly

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

set initial context for presence

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information
