### PR TITLE
fix: pin input paste behaviour

### DIFF
--- a/.changeset/wet-boats-brush.md
+++ b/.changeset/wet-boats-brush.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/pin-input": patch
+---
+
+Fix an issue where paste in pin input would fill the input with all pasted characters instead of 1 per input

--- a/packages/machines/pin-input/src/pin-input.connect.ts
+++ b/packages/machines/pin-input/src/pin-input.connect.ts
@@ -105,6 +105,12 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
               send({ type: "VALUE.INVALID", value })
               event.preventDefault()
             }
+
+            // select the text so paste always replaces the
+            // current input's value regardless of cursor position
+            if (value.length > 2) {
+              event.currentTarget.setSelectionRange(0, 1, "forward")
+            }
           } catch {
             // noop
           }
@@ -115,6 +121,10 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
 
           if (evt.inputType === "insertFromPaste" || value.length > 2) {
             send({ type: "INPUT.PASTE", value })
+            // prevent multiple characters being pasted
+            // into a single input
+            event.target.value = value[0]
+
             event.preventDefault()
             return
           }

--- a/packages/machines/pin-input/src/pin-input.machine.ts
+++ b/packages/machines/pin-input/src/pin-input.machine.ts
@@ -187,9 +187,14 @@ export function machine(userContext: UserDefinedContext) {
         },
         setPastedValue(ctx, evt) {
           raf(() => {
-            const startIndex = ctx.focusedValue ? 1 : 0
-            const value = evt.value.substring(startIndex, startIndex + ctx.valueLength)
-            set.value(ctx, value)
+            const startIndex = Math.min(ctx.focusedIndex, ctx.filledValueLength)
+            // keep value left of cursor
+            // replace value from curor to end with pasted text
+            const left = startIndex > 0 ? ctx.valueAsString.substring(0, ctx.focusedIndex) : ""
+            const right = evt.value.substring(0, ctx.valueLength - startIndex)
+            const value = left + right
+
+            set.value(ctx, value as any)
           })
         },
         setValueAtIndex(ctx, evt) {


### PR DESCRIPTION
## 📝 Description

When pasting in the pin input after it has been filled, the copied text will sometimes fill a single input, where it should be limited to a single character. This is mostly a visual bug, as the state value is still 'correct' (the first char is used).

Also fixes some inconsistency with pasting a value after being filled. It should now paste the copied text from the current focused input onward, without appending the focused input's value.

https://github.com/chakra-ui/zag/assets/13904763/a2e23a4b-bc25-4a20-a44b-0cc124bf72ce

## ⛳️ Current behavior (updates)

https://github.com/chakra-ui/zag/assets/13904763/a00246f1-b7e5-47a9-b09d-10f97ee4ac30

## 🚀 New behavior

https://github.com/chakra-ui/zag/assets/13904763/608f8bfd-4a98-44a3-908d-d65f1b869aa9


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
