### PR TITLE
fix(combobox): fix input click when menu is open

### DIFF
--- a/.changeset/green-bananas-ring.md
+++ b/.changeset/green-bananas-ring.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/combobox": patch
+---
+
+Fix an issue that breaks the combobox when clicking on the input while the menu is open

--- a/packages/machines/combobox/src/combobox.machine.ts
+++ b/packages/machines/combobox/src/combobox.machine.ts
@@ -416,7 +416,12 @@ export function machine<T extends CollectionItem>(userContext: UserDefinedContex
           const contentEl = () => dom.getContentEl(ctx)
           return trackDismissableElement(contentEl, {
             defer: true,
-            exclude: () => [dom.getContentEl(ctx), dom.getTriggerEl(ctx), dom.getClearTriggerEl(ctx)],
+            exclude: () => [
+              dom.getInputEl(ctx),
+              dom.getContentEl(ctx),
+              dom.getTriggerEl(ctx),
+              dom.getClearTriggerEl(ctx),
+            ],
             onFocusOutside: ctx.onFocusOutside,
             onPointerDownOutside: ctx.onPointerDownOutside,
             onInteractOutside: ctx.onInteractOutside,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1133 

## 📝 Description

Add the input element to the exclude list of the `trackDismissableElement` function so it won't be considered as an "outside interaction" anymore.

## ⛳️ Current behavior (updates)

When clicking on the input element while the menu is open, it closes the menu and it won't open again until we click outside the component and focus the input again.

Also, if the `openOnclick` property is set to `true`, and when clicking on the input element when the menu is open, it closes the menu before opens it right away.

## 🚀 New behavior

When clicking on the input element while the menu is open does not close it anymore.

## 💣 Is this a breaking change (Yes/No):

No
