### PR TITLE
[React] docs: fix combobox `items` in the instantiation of collections (#1145)

### DIFF
--- a/website/data/snippets/react/combobox/usage.mdx
+++ b/website/data/snippets/react/combobox/usage.mdx
@@ -12,7 +12,7 @@ export function Combobox() {
   const [options, setOptions] = useState(comboboxData)
 
   const collection = combobox.collection({
-    items: comboboxData,
+    items: options,
     itemToValue: (item) => item.code,
     itemToString: (item) => item.label,
   })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1145 

## 📝 Description

Solves issue #1145 

## ⛳️ Current behavior (updates)

When the snippet is used, the arrow down or up does not work when the combobox list is filtered.

## 🚀 New behavior

When the snippet is used, the arrow down/up hightlight the first item of the filtered list.

💣 Is this a breaking change (No)
