### PR TITLE
feat: add data-disabled, data-invalid, aria-invalid, data-readonly to indicatorProps for Select

### DIFF
--- a/.changeset/famous-lobsters-yawn.md
+++ b/.changeset/famous-lobsters-yawn.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/select": patch
+---
+
+Add data-disabled, data-invalid, aria-invalid, data-readonly to indicatorProps for Select

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -205,6 +205,10 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
       dir: state.context.dir,
       "aria-hidden": true,
       "data-state": isOpen ? "open" : "closed",
+      "data-disabled": dataAttr(isDisabled),
+      "data-invalid": dataAttr(isInvalid),
+      "aria-invalid": isInvalid,
+      "data-readonly": dataAttr(isReadOnly),
     }),
 
     getItemProps(props) {

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -207,8 +207,7 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
       "data-state": isOpen ? "open" : "closed",
       "data-disabled": dataAttr(isDisabled),
       "data-invalid": dataAttr(isInvalid),
-      "aria-invalid": isInvalid,
-      "data-readonly": dataAttr(isReadOnly),
+      "data-readonly": dataAttr(isReadOnly), 
     }),
 
     getItemProps(props) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> this will enable styling of indicator when building custom select component with chakra-ui and applying visual styles trough theme via: _disabled, _readOnly, _invalid props

## ⛳️ Current behavior (updates)

> data and aria attributes are currently not visible on indicator atom

## 🚀 New behavior

> now those props are applied as compared to triggerProps

## 💣 Is this a breaking change (Yes/No): 
No

## 📝 Additional Information

indicatorProps are not shown in documentation, i saw that ark-ui uses it in its select implementation.
