### PR TITLE
fix(machines): Select itemGroupLabel id props

### DIFF
--- a/.changeset/small-games-greet.md
+++ b/.changeset/small-games-greet.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/select": patch
+---
+
+fix ItemGroupLabel id in Select

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -271,7 +271,7 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
       const { htmlFor } = props
       return normalize.element({
         ...parts.itemGroupLabel.attrs,
-        id: dom.getItemGroupId(state.context, htmlFor),
+        id: dom.getItemGroupLabelId(state.context, htmlFor),
         role: "group",
         dir: state.context.dir,
       })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
`id` props of Select ItemGroupLabel is unintended, so I fixed it.

## ⛳️ Current behavior (updates)
ItemGroupLabel's `id` props is same as ItemGroup's `id` props.
This cause the a11y issue, group is not associated by group label.

## 🚀 New behavior
ItemGroupLabel id props is set as intended.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
