### PR TITLE
refactor: date picker `inputProps` -> `getInputProps`

### DIFF
--- a/.changeset/green-lobsters-hide.md
+++ b/.changeset/green-lobsters-hide.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-picker": minor
+---
+
+[BREAKING] Change date picker to `inputProps` to `getInputProps` to support multiple inputs.

--- a/.xstate/date-picker.js
+++ b/.xstate/date-picker.js
@@ -115,7 +115,8 @@ const fetchMachine = createMachine({
           actions: ["focusFirstSelectedDate", "focusActiveCell"]
         },
         "INPUT.FOCUS": {
-          target: "focused"
+          target: "focused",
+          actions: ["setActiveIndex"]
         },
         "TRIGGER.CLICK": [{
           cond: "isOpenControlled",
@@ -151,7 +152,8 @@ const fetchMachine = createMachine({
           actions: ["focusParsedDate", "selectFocusedDate"]
         },
         "INPUT.BLUR": {
-          target: "idle"
+          target: "idle",
+          actions: ["setActiveIndexToStart"]
         },
         OPEN: [{
           cond: "isOpenControlled",

--- a/examples/next-app/components/date-range-picker.tsx
+++ b/examples/next-app/components/date-range-picker.tsx
@@ -44,7 +44,8 @@ export function DateRangePicker(props: Props) {
       </output>
 
       <div {...api.controlProps}>
-        <input {...api.inputProps} />
+        <input {...api.getInputProps({ index: 0 })} />
+        <input {...api.getInputProps({ index: 1 })} />
         <button {...api.clearTriggerProps}>❌</button>
         <button {...api.triggerProps}>🗓</button>
       </div>

--- a/examples/next-ts/pages/date-picker-multi.tsx
+++ b/examples/next-ts/pages/date-picker-multi.tsx
@@ -36,7 +36,7 @@ export default function Page() {
         </output>
 
         <div {...api.controlProps}>
-          <input {...api.inputProps} />
+          <input {...api.getInputProps()} />
           <button {...api.clearTriggerProps}>❌</button>
           <button {...api.triggerProps}>🗓</button>
         </div>

--- a/examples/next-ts/pages/date-picker-range.tsx
+++ b/examples/next-ts/pages/date-picker-range.tsx
@@ -38,7 +38,8 @@ export default function Page() {
         </output>
 
         <div {...api.controlProps}>
-          <input {...api.inputProps} />
+          <input {...api.getInputProps({ index: 0 })} />
+          <input {...api.getInputProps({ index: 1 })} />
           <button {...api.clearTriggerProps}>❌</button>
           <button {...api.triggerProps}>🗓</button>
         </div>

--- a/examples/next-ts/pages/date-picker.tsx
+++ b/examples/next-ts/pages/date-picker.tsx
@@ -36,7 +36,7 @@ export default function Page() {
         </output>
 
         <div {...api.controlProps}>
-          <input {...api.inputProps} />
+          <input {...api.getInputProps()} />
           <button {...api.clearTriggerProps}>❌</button>
           <button {...api.triggerProps}>🗓</button>
         </div>

--- a/packages/machines/date-picker/src/date-picker.dom.ts
+++ b/packages/machines/date-picker/src/date-picker.dom.ts
@@ -1,4 +1,4 @@
-import { createScope, query } from "@zag-js/dom-query"
+import { createScope, query, queryAll } from "@zag-js/dom-query"
 import type { DateView, MachineContext as Ctx } from "./date-picker.types"
 
 export const dom = createScope({
@@ -14,7 +14,7 @@ export const dom = createScope({
   getViewTriggerId: (ctx: Ctx, view: DateView) => ctx.ids?.viewTrigger?.(view) ?? `datepicker:${ctx.id}:view:${view}`,
   getClearTriggerId: (ctx: Ctx) => ctx.ids?.clearTrigger ?? `datepicker:${ctx.id}:clear`,
   getControlId: (ctx: Ctx) => ctx.ids?.control ?? `datepicker:${ctx.id}:control`,
-  getInputId: (ctx: Ctx) => ctx.ids?.input ?? `datepicker:${ctx.id}:input`,
+  getInputId: (ctx: Ctx, index: number) => ctx.ids?.input?.(index) ?? `datepicker:${ctx.id}:input:${index}`,
   getTriggerId: (ctx: Ctx) => ctx.ids?.trigger ?? `datepicker:${ctx.id}:trigger`,
   getPositionerId: (ctx: Ctx) => ctx.ids?.positioner ?? `datepicker:${ctx.id}:positioner`,
   getMonthSelectId: (ctx: Ctx) => ctx.ids?.monthSelect ?? `datepicker:${ctx.id}:month-select`,
@@ -27,7 +27,7 @@ export const dom = createScope({
     ),
   getTriggerEl: (ctx: Ctx) => dom.getById<HTMLButtonElement>(ctx, dom.getTriggerId(ctx)),
   getContentEl: (ctx: Ctx) => dom.getById(ctx, dom.getContentId(ctx)),
-  getInputEl: (ctx: Ctx) => dom.getById<HTMLInputElement>(ctx, dom.getInputId(ctx)),
+  getInputEls: (ctx: Ctx) => queryAll<HTMLInputElement>(dom.getControlEl(ctx), `[data-part=input]`),
   getYearSelectEl: (ctx: Ctx) => dom.getById<HTMLSelectElement>(ctx, dom.getYearSelectId(ctx)),
   getMonthSelectEl: (ctx: Ctx) => dom.getById<HTMLSelectElement>(ctx, dom.getMonthSelectId(ctx)),
   getClearTriggerEl: (ctx: Ctx) => dom.getById<HTMLButtonElement>(ctx, dom.getClearTriggerId(ctx)),

--- a/packages/machines/date-picker/src/date-picker.types.ts
+++ b/packages/machines/date-picker/src/date-picker.types.ts
@@ -60,7 +60,7 @@ export type ElementIds = Partial<{
   viewTrigger(view: DateView): string
   clearTrigger: string
   control: string
-  input: string
+  input(index: number): string
   trigger: string
   monthSelect: string
   yearSelect: string
@@ -168,11 +168,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The format of the date to display in the input.
    */
-  format?: (date: DateValue[]) => string
+  format?: (date: DateValue) => string
   /**
    * The format of the date to display in the input.
    */
-  parse?: (value: string) => DateValue[]
+  parse?: (value: string) => DateValue
   /**
    * The view of the calendar
    * @default "day"
@@ -217,7 +217,7 @@ type PrivateContext = Context<{
    * @internal
    * The input element's value
    */
-  inputValue: string
+  inputValue: string[]
   /**
    * @internal
    * The current hovered date. Useful for range selection mode.
@@ -358,6 +358,10 @@ export interface TableProps {
 
 export interface ViewProps {
   view?: DateView
+}
+
+export interface InputProps {
+  index?: number
 }
 
 export interface MonthGridProps {
@@ -574,7 +578,7 @@ export interface MachineApi<T extends PropTypes = PropTypes> {
   triggerProps: T["button"]
   getViewTriggerProps(props?: ViewProps): T["button"]
   getViewControlProps(props?: ViewProps): T["element"]
-  inputProps: T["input"]
+  getInputProps(props?: InputProps): T["input"]
   monthSelectProps: T["select"]
   yearSelectProps: T["select"]
 }

--- a/packages/machines/date-picker/src/date-picker.utils.ts
+++ b/packages/machines/date-picker/src/date-picker.utils.ts
@@ -18,7 +18,7 @@ export function sortDates(values: DateValue[]) {
   return values.sort((a, b) => a.compare(b))
 }
 
-export function formatValue(ctx: Pick<MachineContext, "locale" | "timeZone" | "selectionMode" | "value">) {
+export function formatValue(ctx: Pick<MachineContext, "locale" | "timeZone" | "selectionMode" | "value">): string[] {
   const formatter = new DateFormatter(ctx.locale, {
     timeZone: ctx.timeZone,
     day: "2-digit",
@@ -28,17 +28,17 @@ export function formatValue(ctx: Pick<MachineContext, "locale" | "timeZone" | "s
 
   if (ctx.selectionMode === "range") {
     const [startDate, endDate] = ctx.value
-    if (!startDate || !endDate) return ""
-    return `${formatter.format(startDate.toDate(ctx.timeZone))} - ${formatter.format(endDate.toDate(ctx.timeZone))}`
+    if (!startDate || !endDate) return []
+    return [formatter.format(startDate.toDate(ctx.timeZone)), formatter.format(endDate.toDate(ctx.timeZone))]
   }
 
   if (ctx.selectionMode === "single") {
     const [startValue] = ctx.value
-    if (!startValue) return ""
-    return formatter.format(startValue.toDate(ctx.timeZone))
+    if (!startValue) return []
+    return [formatter.format(startValue.toDate(ctx.timeZone))]
   }
 
-  return ctx.value.map((date) => formatter.format(date.toDate(ctx.timeZone))).join(", ")
+  return ctx.value.map((date) => formatter.format(date.toDate(ctx.timeZone)))
 }
 
 export function getNextTriggerLabel(view: DateView) {


### PR DESCRIPTION
## 📝 Description

[BREAKING] Change datepicker from `inputProps` to `getInputProps` to support multiple inputs.


## 💣 Is this a breaking change (Yes/No):

Yes

## 📝 Additional Information
