### PR TITLE
fix(machines): select uses the correct `id` for `aria-activedecesendant` field

### DIFF
--- a/.changeset/wild-drinks-pretend.md
+++ b/.changeset/wild-drinks-pretend.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/select": patch
+---
+
+Fix issue where select uses the incorrect `id` for `aria-activedecesendant` field

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -334,7 +334,9 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
       role: "listbox",
       ...parts.content.attrs,
       "data-state": isOpen ? "open" : "closed",
-      "aria-activedescendant": state.context.highlightedValue || "",
+      "aria-activedescendant": state.context.highlightedValue
+        ? dom.getItemId(state.context, state.context.highlightedValue)
+        : "",
       "aria-multiselectable": state.context.multiple ? "true" : undefined,
       "aria-labelledby": dom.getLabelId(state.context),
       tabIndex: 0,

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -336,7 +336,7 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
       "data-state": isOpen ? "open" : "closed",
       "aria-activedescendant": state.context.highlightedValue
         ? dom.getItemId(state.context, state.context.highlightedValue)
-        : "",
+        : undefined,
       "aria-multiselectable": state.context.multiple ? "true" : undefined,
       "aria-labelledby": dom.getLabelId(state.context),
       tabIndex: 0,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> `aria-activedecesendant` on select machine now correctly references the chosen value by the element id

## ⛳️ Current behavior (updates)

> Just the value of an item is used, which is not accessible since it does not reference the right element

## 🚀 New behavior

> Now uses `dom.getItemId()`, same as the item elements

## 💣 Is this a breaking change (Yes/No):

no
