### PR TITLE
feat(machines): add `collection` api to Combobox

### DIFF
--- a/.changeset/spicy-experts-wonder.md
+++ b/.changeset/spicy-experts-wonder.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/combobox": patch
+"@zag-js/select": patch
+---
+
+Add collection api to Combobox and fix typos in Select's types.

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -50,6 +50,7 @@ export function connect<T extends PropTypes, V extends CollectionItem>(
     valueAsString: state.context.valueAsString,
     hasSelectedItems: state.context.hasSelectedItems,
     selectedItems: state.context.selectedItems,
+    collection: state.context.collection,
     reposition(options = {}) {
       send({ type: "POSITIONING.SET", options })
     },

--- a/packages/machines/combobox/src/combobox.types.ts
+++ b/packages/machines/combobox/src/combobox.types.ts
@@ -338,6 +338,10 @@ export interface MachineApi<T extends PropTypes = PropTypes, V extends Collectio
    */
   close(): void
   /**
+   * Function to toggle the combobox
+   */
+  collection: Collection<V>
+  /**
    * Function to set the collection of items
    */
   setCollection(collection: Collection<V>): void

--- a/packages/machines/select/src/select.types.ts
+++ b/packages/machines/select/src/select.types.ts
@@ -244,7 +244,7 @@ export interface MachineApi<T extends PropTypes = PropTypes, V extends Collectio
    */
   highlightedItem: V | null
   /**
-   * The value of the combobox input
+   * The value of the select input
    */
   highlightValue(value: string): void
   /**
@@ -268,31 +268,31 @@ export interface MachineApi<T extends PropTypes = PropTypes, V extends Collectio
    */
   selectValue(value: string): void
   /**
-   * Function to set the value of the combobox
+   * Function to set the value of the select
    */
   setValue(value: string[]): void
   /**
-   * Function to clear the value of the combobox
+   * Function to clear the value of the select
    */
   clearValue(value?: string): void
   /**
-   * Function to focus on the combobox input
+   * Function to focus on the select input
    */
   focus(): void
   /**
-   * Returns the state of a combobox item
+   * Returns the state of a select item
    */
   getItemState(props: ItemProps): ItemState
   /**
-   * Function to open the combobox
+   * Function to open the select
    */
   open(): void
   /**
-   * Function to close the combobox
+   * Function to close the select
    */
   close(): void
   /**
-   * Function to toggle the combobox
+   * Function to toggle the select
    */
   collection: Collection<V>
   /**


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1226

## 📝 Description
- Add collection api to Combobox's api. (Like Select: [commit](https://github.com/chakra-ui/zag/commit/3f7ea3936cb86231a105f5d919aff44ddaea60e1#diff-da0ad57d3ce06be4a0bd6f75c2fa4e7eb97a8b0a25feebe0363322f937093ca6))
- Fix typos in Select types (Combobox to Select)

## ⛳️ Current behavior (updates)

`collection` api is not provided by Combobox.

## 🚀 New behavior

`collection` api is provided.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->
No

## 📝 Additional Information
