### PR TITLE
fix(machines): add disabled check in tooltip trigger eventHandler

### DIFF
--- a/.changeset/selfish-masks-sleep.md
+++ b/.changeset/selfish-masks-sleep.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/tooltip": patch
+---
+
+fix disabled tooltip flashing when hovering and clicking the trigger

--- a/packages/machines/tooltip/src/tooltip.connect.ts
+++ b/packages/machines/tooltip/src/tooltip.connect.ts
@@ -42,13 +42,15 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       "data-state": isOpen ? "open" : "closed",
       "aria-describedby": isOpen ? contentId : undefined,
       onClick() {
+        if (isDisabled) return
         send("CLOSE")
       },
       onFocus() {
-        if (state.event.type === "POINTER_DOWN") return
+        if (isDisabled || state.event.type === "POINTER_DOWN") return
         send("OPEN")
       },
       onBlur() {
+        if (isDisabled) return
         if (id === store.id) {
           send("CLOSE")
         }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1247

## 📝 Description
Tooltip that has `disabled` props is unintentionally displayed when hovering and clicking the target.


## ⛳️ Current behavior (updates)
like this (emulate with zag-js React dev)

https://github.com/chakra-ui/zag/assets/38889285/c603b2a3-4898-4553-8871-7a38607db17b




## 🚀 New behavior
like this (emulate with zag-js React dev)

https://github.com/chakra-ui/zag/assets/38889285/70e187e9-39c3-4aab-b8af-96ce575d6324




## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->
No

## 📝 Additional Information
