### PR TITLE
feat: add isReadOnly prop and handle read-only state in switch component

### DIFF
--- a/.changeset/brown-birds-explain.md
+++ b/.changeset/brown-birds-explain.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/switch": minor
+---
+
+Updated readOnly props to work as expected

--- a/packages/machines/switch/src/switch.connect.ts
+++ b/packages/machines/switch/src/switch.connect.ts
@@ -7,6 +7,7 @@ import type { MachineApi, Send, State } from "./switch.types"
 
 export function connect<T extends PropTypes>(state: State, send: Send, normalize: NormalizeProps<T>): MachineApi<T> {
   const isDisabled = state.context.isDisabled
+  const isReadOnly = state.context.readOnly
   const isFocused = !isDisabled && state.context.focused
   const isChecked = state.context.checked
 
@@ -17,6 +18,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
     "data-disabled": dataAttr(isDisabled),
     "data-state": state.context.checked ? "checked" : "unchecked",
     "data-invalid": dataAttr(state.context.invalid),
+    "data-readonly": dataAttr(isReadOnly),
   }
 
   return {
@@ -98,6 +100,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       value: state.context.value,
       style: visuallyHiddenStyle,
       onChange(event) {
+        if (isReadOnly) return
         const checked = event.currentTarget.checked
         send({ type: "CHECKED.SET", checked, isTrusted: true })
       },

--- a/packages/machines/switch/src/switch.connect.ts
+++ b/packages/machines/switch/src/switch.connect.ts
@@ -6,6 +6,7 @@ import { dom } from "./switch.dom"
 import type { MachineApi, Send, State } from "./switch.types"
 
 export function connect<T extends PropTypes>(state: State, send: Send, normalize: NormalizeProps<T>): MachineApi<T> {
+  const isInteractive = state.context.isInteractive
   const isDisabled = state.context.isDisabled
   const isReadOnly = state.context.readOnly
   const isFocused = !isDisabled && state.context.focused
@@ -39,22 +40,22 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       id: dom.getRootId(state.context),
       htmlFor: dom.getHiddenInputId(state.context),
       onPointerMove() {
-        if (isDisabled) return
+        if (!isInteractive) return
         send({ type: "CONTEXT.SET", context: { hovered: true } })
       },
       onPointerLeave() {
-        if (isDisabled) return
+        if (!isInteractive) return
         send({ type: "CONTEXT.SET", context: { hovered: false } })
       },
       onPointerDown(event) {
-        if (isDisabled) return
+        if (!isInteractive) return
         // On pointerdown, the input blurs and returns focus to the `body`,
         // we need to prevent this.
-        if (isFocused) event.preventDefault()
+        if (!isInteractive) event.preventDefault()
         send({ type: "CONTEXT.SET", context: { active: true } })
       },
       onPointerUp() {
-        if (isDisabled) return
+        if (!isInteractive) return
         send({ type: "CONTEXT.SET", context: { active: false } })
       },
       onClick(event) {
@@ -100,7 +101,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       value: state.context.value,
       style: visuallyHiddenStyle,
       onChange(event) {
-        if (isReadOnly) return
+        if (!isInteractive) return
         const checked = event.currentTarget.checked
         send({ type: "CHECKED.SET", checked, isTrusted: true })
       },

--- a/packages/machines/switch/src/switch.machine.ts
+++ b/packages/machines/switch/src/switch.machine.ts
@@ -24,7 +24,7 @@ export function machine(userContext: UserDefinedContext) {
 
       computed: {
         isDisabled: (ctx) => ctx.disabled || ctx.fieldsetDisabled,
-        isInteractive: (ctx) => !ctx.readOnly,
+        isInteractive: (ctx) => !(ctx.isDisabled || ctx.readOnly),
       },
 
       watch: {

--- a/packages/machines/switch/src/switch.machine.ts
+++ b/packages/machines/switch/src/switch.machine.ts
@@ -24,6 +24,7 @@ export function machine(userContext: UserDefinedContext) {
 
       computed: {
         isDisabled: (ctx) => ctx.disabled || ctx.fieldsetDisabled,
+        isInteractive: (ctx) => !ctx.readOnly,
       },
 
       watch: {

--- a/packages/machines/switch/src/switch.machine.ts
+++ b/packages/machines/switch/src/switch.machine.ts
@@ -17,6 +17,7 @@ export function machine(userContext: UserDefinedContext) {
         checked: false,
         label: "switch",
         value: "on",
+        readOnly: false,
         disabled: false,
         ...ctx,
         fieldsetDisabled: false,
@@ -24,7 +25,7 @@ export function machine(userContext: UserDefinedContext) {
 
       computed: {
         isDisabled: (ctx) => ctx.disabled || ctx.fieldsetDisabled,
-        isInteractive: (ctx) => !(ctx.isDisabled || ctx.readOnly),
+        isInteractive: (ctx) => !(ctx.disabled || ctx.readOnly),
       },
 
       watch: {
@@ -65,6 +66,7 @@ export function machine(userContext: UserDefinedContext) {
     {
       guards: {
         isTrusted: (_ctx, evt) => !!evt.isTrusted,
+        isInteractive: (ctx) => !(ctx.disabled || ctx.readOnly),
       },
       activities: {
         trackFormControlState(ctx, _evt, { send, initialContext }) {

--- a/packages/machines/switch/src/switch.props.ts
+++ b/packages/machines/switch/src/switch.props.ts
@@ -16,6 +16,7 @@ export const props = createProps<UserDefinedContext>()([
   "onCheckedChange",
   "required",
   "value",
+  "readOnly",
 ])
 
 export const splitProps = createSplitProps<Partial<UserDefinedContext>>(props)

--- a/packages/machines/switch/src/switch.types.ts
+++ b/packages/machines/switch/src/switch.types.ts
@@ -39,6 +39,10 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    */
   invalid?: boolean
   /**
+   * Whether the switch is read-only
+   */
+  readOnly?: boolean
+  /**
    * If `true`, the switch input is marked as required,
    */
   required?: boolean
@@ -73,6 +77,11 @@ type ComputedContext = Readonly<{
    * Whether the switch is disabled
    */
   isDisabled: boolean
+  /**
+   * @computed
+   * Whether the switch is interactive
+   */
+  isInteractive: boolean
 }>
 
 interface PrivateContext {


### PR DESCRIPTION
## 📝 Description

The documentation has a ReadOnly option, but it is not really available.

![screenshot](https://github.com/chakra-ui/zag/assets/45055030/03c33fd6-b889-472d-9e6c-27af429bcfed)
https://zagjs.com/components/react/switch

## 🚀 New behavior

When set to ReadOnly, the value will not change. 
However, unlike disabled, the input element is not "disabled".

## 💣 Is this a breaking change: No

