### PR TITLE
fix(date-picker): next and previous aria labels

### DIFF
--- a/.changeset/nice-maps-type.md
+++ b/.changeset/nice-maps-type.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-picker": patch
+---
+
+fix(date-picker): next and previous aria labels

--- a/packages/machines/date-picker/src/date-picker.connect.ts
+++ b/packages/machines/date-picker/src/date-picker.connect.ts
@@ -550,7 +550,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         dir: state.context.dir,
         id: dom.getNextTriggerId(state.context, view),
         type: "button",
-        "aria-label": getPrevTriggerLabel(view),
+        "aria-label": getNextTriggerLabel(view),
         disabled: disabled || !state.context.isNextVisibleRangeValid,
         onClick() {
           send({ type: "GOTO.NEXT", view })
@@ -565,7 +565,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
         dir: state.context.dir,
         id: dom.getPrevTriggerId(state.context, view),
         type: "button",
-        "aria-label": getNextTriggerLabel(view),
+        "aria-label": getPrevTriggerLabel(view),
         disabled: disabled || !state.context.isPrevVisibleRangeValid,
         onClick() {
           send({ type: "GOTO.PREV", view })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Fix the aria labels of the next and previous triggers in the date picker.

![Screenshot 2024-02-29 at 19 37 26](https://github.com/chakra-ui/zag/assets/64312634/77f85bb0-7c93-43d8-acc5-f6084efd655a)

## ⛳️ Current behavior (updates)

> In the date picker, the aria labels of the next and previous triggers are inverted.

## 🚀 New behavior

> Put them in the right order.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information
