### PR TITLE
docs(website): remove read only section from switch

### DIFF
--- a/website/components/machines/switch.tsx
+++ b/website/components/machines/switch.tsx
@@ -6,7 +6,6 @@ import { useId } from "react"
 type SwitchProps = {
   controls: {
     disabled: boolean
-    readOnly: boolean
   }
 }
 

--- a/website/components/showcase.tsx
+++ b/website/components/showcase.tsx
@@ -310,7 +310,6 @@ const components = {
       component={Switch}
       defaultProps={{
         disabled: false,
-        readOnly: false,
       }}
     />
   ),

--- a/website/data/components/switch.mdx
+++ b/website/data/components/switch.mdx
@@ -68,18 +68,6 @@ const [state, send] = useMachine(
 )
 ```
 
-## Making the switch readonly
-
-To make a switch readonly, set the context's `readOnly` property to true
-
-```jsx {3}
-const [state, send] = useMachine(
-  zagSwitch.machine({
-    readOnly: true,
-  }),
-)
-```
-
 ## Making it checked by default
 
 To make a switch checked by default, set the context's `checked` property to


### PR DESCRIPTION
## 📝 Description

https://github.com/chakra-ui/zag/pull/1304#issuecomment-1971935771
Based on this comment, I have removed the relevant sections from the document.

## ⛳️ Current behavior (updates)

## 🚀 New behavior

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Ref: https://github.com/chakra-ui/zag/pull/1304