### PR TITLE
docs(website/mdx-components): create table component for toast page

### DIFF
--- a/website/components/mdx-components.tsx
+++ b/website/components/mdx-components.tsx
@@ -126,6 +126,44 @@ const components: Record<string, FC<any>> = {
   ContextTable(props) {
     return <PropTable type="context" {...props} />
   },
+  DefaultValuesTable: ({
+    tableData,
+  }: {
+    tableData: {
+      headings: string[]
+      data: Array<[string, string]>
+    }
+  }) => {
+    const { data, headings } = tableData
+
+    return (
+      <table>
+        <thead>
+          <tr>
+            {headings.map((heading) => (
+              <th key={heading}>{heading}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map(([prop, value], idx) => (
+            <tr key={idx}>
+              <td>
+                <chakra.code className="prose" layerStyle="inlineCode">
+                  {prop}
+                </chakra.code>
+              </td>
+              <td>
+                <chakra.code fontSize="sm" whiteSpace="pre-wrap">
+                  {value}
+                </chakra.code>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  },
   code(props) {
     if (typeof props.children === "string") {
       return <components.inlineCode {...props} />

--- a/website/data/components/toast.mdx
+++ b/website/data/components/toast.mdx
@@ -103,15 +103,20 @@ The options you can pass in are:
 ## Setting custom duration
 
 Every toast has a default visible duration depending on the `type` set. Here's
-the table showing the toast type and duration.
+the following toast types and matching default durations:
 
-| type      | duration   |
-| --------- | ---------- |
-| `info`    | `5000`     |
-| `error`   | `5000`     |
-| `success` | `2000`     |
-| `custom`  | `5000`     |
-| `loading` | `Infinity` |
+<DefaultValuesTable 
+  tableData={{
+    headings: ['type', 'duration'],
+    data: [
+      ['info', '5000'],
+      ['error', '5000'],
+      ['success', '2000'],
+      ['custom', '5000'],
+      ['loading', 'Infinity'],
+    ]
+  }}
+/>
 
 You can override the duration of the toast by passing the `duration` property to
 the `toast.create(...)` function.


### PR DESCRIPTION
Builds a custom table component for the toast doc page.

The `remark-gfm` plugin is currently not installed, so the table markdown provided in the [Setting Custom Duration](https://zagjs.com/components/react/toast#setting-custom-duration) section does not render correctly.

As this is the only table markdown for the entire site, it is a better choice to create a custom component for this instance than to try and add the plugin (which does not work [for another reason](https://github.com/remarkjs/remark-gfm/issues/57)). 

This custom component is also made to be reusable if needed, as a two-column only table.