### PR TITLE
fix(machine/combobox): use `value` context with `clearTriggerProps` hidden check

### DIFF
--- a/.changeset/stale-waves-kiss.md
+++ b/.changeset/stale-waves-kiss.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/combobox": patch
+---
+
+Fixes issue where on load -- if the user set initial `value` to context -- `value` should be used to check whether a
+trigger button using `clearTriggerProps` should be visible on the page.

--- a/examples/next-ts/pages/combobox.tsx
+++ b/examples/next-ts/pages/combobox.tsx
@@ -47,6 +47,7 @@ export default function Page() {
           <button data-testid="clear-value-button" onClick={() => api.clearValue()}>
             Clear Value
           </button>
+          <button {...api.clearTriggerProps}>Clear Trigger</button>
           <br />
           <div {...api.rootProps}>
             <label {...api.labelProps}>Select country</label>

--- a/examples/nuxt-ts/pages/combobox.vue
+++ b/examples/nuxt-ts/pages/combobox.vue
@@ -42,7 +42,7 @@ const api = computed(() => combobox.connect(state.value, send, normalizeProps))
     <div>
       <button @click="() => api.setValue(['TG'])">Set to Togo</button>
       <button data-testid="clear-value-button" @click="api.clearValue">Clear Value</button>
-
+      <button v-bind="api.clearTriggerProps">Clear Trigger</button>
       <br />
 
       <div v-bind="api.rootProps">

--- a/examples/solid-ts/src/pages/combobox.tsx
+++ b/examples/solid-ts/src/pages/combobox.tsx
@@ -49,6 +49,7 @@ export default function Page() {
           <button data-testid="clear-value-button" onClick={() => api().clearValue()}>
             Clear Value
           </button>
+          <button {...api().clearTriggerProps}>Clear Trigger</button>
           <br />
 
           <div {...api().rootProps}>

--- a/examples/vue-ts/src/pages/combobox.tsx
+++ b/examples/vue-ts/src/pages/combobox.tsx
@@ -52,6 +52,7 @@ export default defineComponent({
               <button data-testid="clear-value-button" onClick={() => api.clearValue()}>
                 Clear Value
               </button>
+              <button {...api.clearTriggerProps}>Clear Trigger</button>
 
               <br />
 

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -276,7 +276,7 @@ export function connect<T extends PropTypes, V extends CollectionItem>(
       tabIndex: -1,
       disabled: isDisabled,
       "aria-label": translations.clearTriggerLabel,
-      hidden: state.context.isInputValueEmpty,
+      hidden: !state.context.value.length,
       onPointerDown(event) {
         const evt = getNativeEvent(event)
         if (!isInteractive || !isLeftClick(evt)) return

--- a/packages/machines/combobox/src/combobox.machine.ts
+++ b/packages/machines/combobox/src/combobox.machine.ts
@@ -45,7 +45,6 @@ export function machine<T extends CollectionItem>(userContext: UserDefinedContex
           ...ctx.translations,
         },
       },
-
       computed: {
         isInputValueEmpty: (ctx) => ctx.inputValue.length === 0,
         isInteractive: (ctx) => !(ctx.readOnly || ctx.disabled),
@@ -632,7 +631,6 @@ const set = {
       invoke.selectionChange(ctx)
       return
     }
-
     ctx.value = ctx.multiple ? addOrRemove(ctx.value, value!) : [value!]
     invoke.selectionChange(ctx)
   },


### PR DESCRIPTION


<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1320

## 📝 Description

Updates the rendering on page load of a "clear" button that uses `clearTriggerProps` where the combobox is provide a default value.

## ⛳️ Current behavior (updates)

When a user provides an initial `value` to the machine's context, it does not cause the button using `clearTriggerProps` to be visible on the page.


## 🚀 New behavior

In `clearTriggerProps`, have the `hidden` attribute be checked with the `value` context instead of `inputValue`


## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing users. -->
