### PR TITLE
chore(.vscode): remove vue ts extension from recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "ms-playwright.playwright",
     "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin",
     "svelte.svelte-vscode"
   ]
 }


### PR DESCRIPTION
Remove the TypeScript Vue Plugin VSCode extension from project recommendations, as this is now deprecated.