### PR TITLE
fix: circular progress circle diameter

### DIFF
--- a/.changeset/lemon-insects-remember.md
+++ b/.changeset/lemon-insects-remember.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/progress": patch
+---
+
+Fix issue where circular progress circle diameter doesn't get calculated correctly

--- a/packages/machines/progress/src/progress.connect.ts
+++ b/packages/machines/progress/src/progress.connect.ts
@@ -142,8 +142,7 @@ function getCircleProps(ctx: MachineContext) {
     range: {
       style: {
         ...circleProps.style,
-
-        "--circumference": `calc(${2 * Math.PI} * var(--radius))`,
+        "--circumference": `calc(2 * 3.14159 * var(--radius))`,
         "--offset": `calc(var(--circumference) * (100 - ${ctx.percent}) / 100}))`,
         strokeDashoffset: `calc(var(--circumference) * ((100 - ${ctx.percent}) / 100))`,
         strokeDasharray: ctx.isIndeterminate ? undefined : `var(--circumference)`,

--- a/packages/machines/progress/src/progress.connect.ts
+++ b/packages/machines/progress/src/progress.connect.ts
@@ -120,19 +120,19 @@ function getProgressState(value: number | null, maxValue: number): ProgressState
 }
 
 function getCircleProps(ctx: MachineContext) {
-  const determinant = ctx.isIndeterminate ? undefined : ctx.percent * 2.64
   const circleProps = {
     style: {
-      cx: "50px",
-      cy: "50px",
-      r: "42px",
+      "--radius": "calc(var(--size) / 2 - var(--thickness) / 2)",
+      cx: "calc(var(--size) / 2)",
+      cy: "calc(var(--size) / 2)",
+      r: "var(--radius)",
       fill: "transparent",
       strokeWidth: "var(--thickness)",
     },
   }
   return {
     root: {
-      viewBox: "0 0 100 100",
+      viewBox: "0 0 var(--size) var(--size)",
       style: {
         width: "var(--size)",
         height: "var(--size)",
@@ -142,8 +142,13 @@ function getCircleProps(ctx: MachineContext) {
     range: {
       style: {
         ...circleProps.style,
-        strokeDashoffset: "66px",
-        strokeDasharray: determinant != null ? `${determinant} ${264 - determinant}` : undefined,
+
+        "--circumference": `calc(${2 * Math.PI} * var(--radius))`,
+        "--offset": `calc(var(--circumference) * (100 - ${ctx.percent}) / 100}))`,
+        strokeDashoffset: `calc(var(--circumference) * ((100 - ${ctx.percent}) / 100))`,
+        strokeDasharray: ctx.isIndeterminate ? undefined : `var(--circumference)`,
+        transformOrigin: "center",
+        transform: ctx.isIndeterminate ? undefined : `rotate(-90deg)`,
       },
     },
   }

--- a/packages/machines/progress/src/progress.connect.ts
+++ b/packages/machines/progress/src/progress.connect.ts
@@ -142,9 +142,10 @@ function getCircleProps(ctx: MachineContext) {
     range: {
       style: {
         ...circleProps.style,
+        "--percent": ctx.percent,
         "--circumference": `calc(2 * 3.14159 * var(--radius))`,
-        "--offset": `calc(var(--circumference) * (100 - ${ctx.percent}) / 100}))`,
-        strokeDashoffset: `calc(var(--circumference) * ((100 - ${ctx.percent}) / 100))`,
+        "--offset": `calc(var(--circumference) * (100 - var(--percent)) / 100}))`,
+        strokeDashoffset: `calc(var(--circumference) * ((100 - var(--percent)) / 100))`,
         strokeDasharray: ctx.isIndeterminate ? undefined : `var(--circumference)`,
         transformOrigin: "center",
         transform: ctx.isIndeterminate ? undefined : `rotate(-90deg)`,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/zag/issues/1361

## 📝 Description

My solution on Issue was not 100% correct since the progress didnt start at 12 o' clock.

i used this blogpost as an idea: [Blog](https://nikitahl.com/svg-circle-progress#:~:text=We%20need%20to%20set%20stroke%2Ddasharray%20property%20value%20to%20be%20equal%20to%20the%20circumference%20of%20our%20circle%2C%20this%20way%20it%20will%20fill%20up%20the%20whole%20circle%20and%20be%20equal%20to%20100%25.%20Next%2C%20we%20need%20to%20set%20stroke%2Ddashoffset%20to%20move%20the%20progress%20back%20(offset)%20as%20if%20we%E2%80%99re%20subtracting%20from%20our%20progress)

Thanks @isBatak

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information
