### PR TITLE
fix(tabbable): correct some returned types

### DIFF
--- a/.changeset/spicy-carpets-tell.md
+++ b/.changeset/spicy-carpets-tell.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/tabbable": patch
+---
+
+Correct some returned types.

--- a/packages/utilities/tabbable/src/focusable.ts
+++ b/packages/utilities/tabbable/src/focusable.ts
@@ -36,7 +36,10 @@ export function isFocusable(element: HTMLElement | null): element is HTMLElement
   return element.matches(focusableSelector) && isVisible(element)
 }
 
-export function getFirstFocusable(container: HTMLElement | null, includeContainer?: IncludeContainerType) {
+export function getFirstFocusable(
+  container: HTMLElement | null,
+  includeContainer?: IncludeContainerType,
+): HTMLElement | null {
   const [first] = getFocusables(container, includeContainer)
   return first || null
 }

--- a/packages/utilities/tabbable/src/tabbable.ts
+++ b/packages/utilities/tabbable/src/tabbable.ts
@@ -39,7 +39,10 @@ export function isTabbable(el: HTMLElement | null): el is HTMLElement {
 /**
  * Returns the first focusable element within the element
  */
-export function getFirstTabbable(container: HTMLElement | null, includeContainer?: IncludeContainerType) {
+export function getFirstTabbable(
+  container: HTMLElement | null,
+  includeContainer?: IncludeContainerType,
+): HTMLElement | null {
   const [first] = getTabbables(container, includeContainer)
   return first || null
 }
@@ -47,7 +50,10 @@ export function getFirstTabbable(container: HTMLElement | null, includeContainer
 /**
  * Returns the last focusable element within the element
  */
-export function getLastTabbable(container: HTMLElement | null, includeContainer?: IncludeContainerType) {
+export function getLastTabbable(
+  container: HTMLElement | null,
+  includeContainer?: IncludeContainerType,
+): HTMLElement | null {
   const elements = getTabbables(container, includeContainer)
   return elements[elements.length - 1] || null
 }
@@ -55,7 +61,10 @@ export function getLastTabbable(container: HTMLElement | null, includeContainer?
 /**
  * Returns the first and last focusable elements within the element
  */
-export function getTabbableEdges(container: HTMLElement | null, includeContainer?: IncludeContainerType) {
+export function getTabbableEdges(
+  container: HTMLElement | null,
+  includeContainer?: IncludeContainerType,
+): [HTMLElement, HTMLElement] | [null, null] {
   const elements = getTabbables(container, includeContainer)
   const first = elements[0] || null
   const last = elements[elements.length - 1] || null
@@ -65,7 +74,7 @@ export function getTabbableEdges(container: HTMLElement | null, includeContainer
 /**
  * Returns the next tabbable element after the current element
  */
-export function getNextTabbable(container: HTMLElement | null, current?: HTMLElement | null) {
+export function getNextTabbable(container: HTMLElement | null, current?: HTMLElement | null): HTMLElement | null {
   const tabbables = getTabbables(container)
   const doc = container?.ownerDocument || document
   const currentElement = current ?? (doc.activeElement as HTMLElement | null)


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

~~Closes #~~

## 📝 Description

This PR simply fixes some TypeScript types from the package `@zag-js/tabbable`, by explicitly adding returned types. 

## ⛳️ Current behavior (updates)

The current `.d.ts` file in [`@zag-js/tabbable@0.41.0`](https://unpkg.com/browse/@zag-js/tabbable@0.41.0/dist/index.d.ts) declares that some API returns `HTMLElement`. 

```ts
/**
 * Returns the first focusable element within the element
 */
declare function getFirstTabbable(...): HTMLElement;
```


## 🚀 New behavior

But they should return `HTMLElement | null`. 

```ts
/**
 * Returns the first focusable element within the element
 */
declare function getFirstTabbable(...): HTMLElement | null;
```
 
## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A
