### PR TITLE
fix(select): keyboard interaction is not acceptable when focus is returned to trigger element

### DIFF
--- a/.changeset/quiet-islands-deliver.md
+++ b/.changeset/quiet-islands-deliver.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/select": patch
+---
+
+Fix issue where keyboard interaction is not acceptable when focus is returned to trigger button

--- a/.xstate/select.js
+++ b/.xstate/select.js
@@ -192,7 +192,7 @@ const fetchMachine = createMachine({
       tags: ["open"],
       entry: ["focusContentEl"],
       exit: ["scrollContentToTop"],
-      activities: ["trackDismissableElement", "computePlacement", "scrollToHighlightedItem", "proxyTabFocus"],
+      activities: ["trackDismissableElement", "trackTriggerFocus", "computePlacement", "scrollToHighlightedItem", "proxyTabFocus"],
       on: {
         "CONTROLLED.CLOSE": [{
           cond: "shouldRestoreFocus",

--- a/e2e/select.e2e.ts
+++ b/e2e/select.e2e.ts
@@ -138,6 +138,13 @@ test.describe("select / keyboard / close", () => {
     await page.keyboard.press("Escape")
     await expect(page.locator(menu)).not.toBeVisible()
   })
+
+  test("should close on shift + tab", async ({ page }) => {
+    await page.click(trigger)
+    await expect(page.locator(menu)).toBeFocused()
+    await page.keyboard.press("Shift+Tab")
+    await expect(page.locator(menu)).not.toBeVisible()
+  })
 })
 
 test.describe("select / keyboard / select", () => {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
In the Select component, if the focus is returned to the trigger button (e.g. shift+tab) when the listbox is open, the listbox cannot be operated with the keyboard. 

## ⛳️ Current behavior (updates)

https://github.com/chakra-ui/zag/assets/38889285/5921d5ee-4ade-4861-89a3-1daee01e07cb

## 🚀 New behavior

https://github.com/chakra-ui/zag/assets/38889285/f5734534-cdc8-4768-8775-8accc22f7df1



## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information

