### PR TITLE
fix(collection): fix collection sort function using by copying method

### DIFF
--- a/.changeset/clean-clouds-wink.md
+++ b/.changeset/clean-clouds-wink.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/collection": patch
+---
+
+Fix issue where value is unintentionally sorted when highlighting item in the combobox and the select machine

--- a/packages/utilities/collection/src/collection.ts
+++ b/packages/utilities/collection/src/collection.ts
@@ -146,7 +146,7 @@ export class Collection<T extends CollectionItem = CollectionItem> {
    * Sort the values based on their index
    */
   sort = (values: string[]): string[] => {
-    return values.sort(this.sortFn)
+    return values.toSorted(this.sortFn)
   }
 
   /**


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1433

## 📝 Description

use coping method for sorting in collection util.

## ⛳️ Current behavior (updates)

If implemented like this, original array is also sorted.
```tsx
sort = (values: string[]): string[] => {
	return values.sort(this.sortFn)
}
```

## 🚀 New behavior

use the copying version of the sort() method: [`Array.prototype.toSorted`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted) 

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->

No, values will be not sorted but it is expected behavior

## 📝 Additional Information

This fix affects Select and Combobox machine

- in Select
https://github.com/chakra-ui/zag/blob/67f5faa024ffd9e0ea594508d61faf05ee86a5be/packages/machines/select/src/select.machine.ts#L495-L507

- in Combobox
https://github.com/chakra-ui/zag/blob/67f5faa024ffd9e0ea594508d61faf05ee86a5be/packages/machines/combobox/src/combobox.machine.ts#L598-L601