### PR TITLE
docs: fix typo

### DIFF
--- a/website/data/overview/programmatic-control.mdx
+++ b/website/data/overview/programmatic-control.mdx
@@ -7,7 +7,7 @@ description: Controlling the state machines programmatically
 
 In some cases, you may want to control the state or context values of a machine
 programmatically via its `props` or based on certain conditions. This is
-typically know as "controlling" the components.
+typically known as "controlling" the components.
 
 Zag provides a number of ways to control the state of a machine
 programmatically.

--- a/website/data/overview/styling.mdx
+++ b/website/data/overview/styling.mdx
@@ -71,4 +71,4 @@ You can style the accordion's trigger using the CSS attribute selector.
 You'll see this pattern across every components within the library.
 
 > Zag was designed to encapsulate logic, accessibility and interactions, while
-> giving you full control control over styling.
+> giving you full control over styling.


### PR DESCRIPTION
Thanks for creating such a cool project like Zag.js. I found the documentation incredibly engaging and read through it all at once. During my reading, I noticed a typo, which I would like to report. 