### PR TITLE
fix: splitter machine onSizeChange

### DIFF
--- a/packages/machines/splitter/src/splitter.machine.ts
+++ b/packages/machines/splitter/src/splitter.machine.ts
@@ -126,7 +126,7 @@ export function machine(userContext: UserDefinedContext) {
           activities: ["trackPointerMove"],
           on: {
             POINTER_MOVE: {
-              actions: ["setPointerValue", "setGlobalCursor"],
+              actions: ["invokeOnResize", "setPointerValue", "setGlobalCursor"],
             },
             POINTER_UP: {
               target: "focused",


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description

> Fix splitter machine onSizeChange doesn't work.

## ⛳️ Current behavior (updates)

> Fix splitter machine onSizeChange doesn't work.

## 🚀 New behavior

> Fix splitter machine onSizeChange doesn't work.

## 💣 Is this a breaking change (Yes/No):
> No
## 📝 Additional Information
