### PR TITLE
docs: fix typos and update outdated API usages

### DIFF
--- a/website/data/components/color-picker.mdx
+++ b/website/data/components/color-picker.mdx
@@ -27,17 +27,17 @@ provides a more customizable and consistent user experience.
 
 ## Installation
 
-To use the combobox machine in your project, run the following command in your
+To use the color picker machine in your project, run the following command in your
 command line:
 
 <CodeSnippet id="color-picker/installation.mdx" />
 
-This command will install the framework agnostic combobox logic and the reactive
+This command will install the framework agnostic color picker logic and the reactive
 utilities for your framework of choice.
 
 ## Anatomy
 
-To set up the combobox correctly, you'll need to understand its anatomy and how
+To set up the color picker correctly, you'll need to understand its anatomy and how
 we name its parts.
 
 > Each part includes a `data-part` attribute to help identify them in the DOM.
@@ -46,7 +46,7 @@ we name its parts.
 
 ## Usage
 
-First, import the combobox package into your project
+First, import the color picker package into your project
 
 ```jsx
 import * as colorPicker from "@zag-js/color-picker"
@@ -200,7 +200,7 @@ machine and render the visually hidden input using the `hiddenInputProps`.
 
 ```jsx {3}
 const [state, send] = useMachine(
-  combobox.machine({
+  colorPicker.machine({
     name: "color-preference",
   }),
 )
@@ -232,7 +232,7 @@ the trigger, content, control parts.
 
 ### Focused State
 
-When the combobox is focused, the `data-focus` attribute is added to the control
+When the color picker is focused, the `data-focus` attribute is added to the control
 and label parts.
 
 ```css
@@ -247,7 +247,7 @@ and label parts.
 
 ### Disabled State
 
-When the combobox is disabled, the `data-disabled` attribute is added to the
+When the color picker is disabled, the `data-disabled` attribute is added to the
 label, control, trigger and option parts.
 
 ```css

--- a/website/data/snippets/react/combobox/usage.mdx
+++ b/website/data/snippets/react/combobox/usage.mdx
@@ -24,9 +24,9 @@ export function Combobox() {
       onOpenChange() {
         setOptions(comboboxData)
       },
-      onInputValueChange({ value }) {
+      onInputValueChange({ inputValue }) {
         const filtered = comboboxData.filter((item) =>
-          item.label.toLowerCase().includes(value.toLowerCase()),
+          item.label.toLowerCase().includes(inputValue.toLowerCase()),
         )
         setOptions(filtered.length > 0 ? filtered : comboboxData)
       },

--- a/website/data/snippets/react/dialog/usage.mdx
+++ b/website/data/snippets/react/dialog/usage.mdx
@@ -10,7 +10,7 @@ export function Dialog() {
   return (
     <>
       <button {...api.triggerProps}>Open Dialog</button>
-      {api.isOpen && (
+      {api.open && (
         <Portal>
           <div {...api.backdropProps} />
           <div {...api.positionerProps}>

--- a/website/data/snippets/react/editable/custom-controls.mdx
+++ b/website/data/snippets/react/editable/custom-controls.mdx
@@ -15,8 +15,8 @@ export default function Editable() {
         <span {...api.previewProps} />
       </div>
       <div>
-        {!api.isEditing && <button {...api.editTriggerProps}>Edit</button>}
-        {api.isEditing && (
+        {!api.editing && <button {...api.editTriggerProps}>Edit</button>}
+        {api.editing && (
           <div>
             <button {...api.submitTriggerProps}>Save</button>
             <button {...api.cancelTriggerProps}>Cancel</button>

--- a/website/data/snippets/solid/combobox/usage.mdx
+++ b/website/data/snippets/solid/combobox/usage.mdx
@@ -27,9 +27,9 @@ export function Combobox() {
       onOpenChange() {
         setOptions(comboboxData)
       },
-      onInputValueChange({ value }) {
+      onInputValueChange({ inputValue }) {
         const filtered = comboboxData.filter((item) =>
-          item.label.toLowerCase().includes(value.toLowerCase()),
+          item.label.toLowerCase().includes(inputValue.toLowerCase()),
         )
         setOptions(filtered.length > 0 ? filtered : comboboxData)
       },

--- a/website/data/snippets/solid/dialog/usage.mdx
+++ b/website/data/snippets/solid/dialog/usage.mdx
@@ -12,7 +12,7 @@ export default function Page() {
   return (
     <>
       <button {...api().triggerProps}>Open Dialog</button>
-      <Show when={api().isOpen}>
+      <Show when={api().open}>
         <Portal>
           <div {...api().backdropProps} />
           <div {...api().positionerProps}>

--- a/website/data/snippets/solid/editable/custom-controls.mdx
+++ b/website/data/snippets/solid/editable/custom-controls.mdx
@@ -15,10 +15,10 @@ export default function Editable() {
         <span {...api().previewProps} />
       </div>
       <div>
-        <Show when={!api().isEditing}>
+        <Show when={!api().editing}>
           <button {...api().editTriggerProps}>Edit</button>{" "}
         </Show>
-        <Show when={api().isEditing}>
+        <Show when={api().editing}>
           <div>
             <button {...api().submitTriggerProps}>Save</button>
             <button {...api().cancelTriggerProps}>Cancel</button>

--- a/website/data/snippets/vue-jsx/combobox/usage.mdx
+++ b/website/data/snippets/vue-jsx/combobox/usage.mdx
@@ -29,9 +29,9 @@ export default defineComponent({
         onOpenChange() {
           options.value = comboboxData
         },
-        onInputValueChange({ value }) {
+        onInputValueChange({ inputValue }) {
           const filtered = comboboxData.filter((item) =>
-            item.label.toLowerCase().includes(value.toLowerCase()),
+            item.label.toLowerCase().includes(inputValue.toLowerCase()),
           )
           options.value = filtered.length > 0 ? filtered : comboboxData
         },

--- a/website/data/snippets/vue-jsx/dialog/usage.mdx
+++ b/website/data/snippets/vue-jsx/dialog/usage.mdx
@@ -17,7 +17,7 @@ export default defineComponent({
       return (
         <>
           <button {...api.triggerProps}>Open Dialog</button>
-          {api.isOpen && (
+          {api.open && (
             <Teleport to="body">
               <div {...api.backdropProps} />
               <div {...api.positionerProps}>

--- a/website/data/snippets/vue-jsx/editable/custom-controls.mdx
+++ b/website/data/snippets/vue-jsx/editable/custom-controls.mdx
@@ -22,8 +22,8 @@ export default defineComponent({
             <span {...api.previewProps} />
           </div>
           <div>
-            {!api.isEditing && <button {...api.editTriggerProps}>Edit</button>}
-            {api.isEditing && (
+            {!api.editing && <button {...api.editTriggerProps}>Edit</button>}
+            {api.editing && (
               <div>
                 <button {...api.submitTriggerProps}>Save</button>
                 <button {...api.cancelTriggerProps}>Cancel</button>

--- a/website/data/snippets/vue-sfc/combobox/usage.mdx
+++ b/website/data/snippets/vue-sfc/combobox/usage.mdx
@@ -27,9 +27,9 @@
       onOpenChange() {
         options.value = comboboxData
       },
-      onInputValueChange({ value }) {
+      onInputValueChange({ inputValue }) {
         const filtered = comboboxData.filter((item) =>
-          item.label.toLowerCase().includes(value.toLowerCase()),
+          item.label.toLowerCase().includes(inputValue.toLowerCase()),
         )
         options.value = filtered.length > 0 ? filtered : comboboxData
       },

--- a/website/data/snippets/vue-sfc/dialog/usage.mdx
+++ b/website/data/snippets/vue-sfc/dialog/usage.mdx
@@ -11,7 +11,7 @@ const api = computed(() => dialog.connect(state.value, send, normalizeProps));
 <template>
   <button ref="ref" v-bind="api.triggerProps">Open Dialog</button>
   <Teleport to="body">
-    <div v-if="api.isOpen">
+    <div v-if="api.open">
       <div v-bind="api.backdropProps" />
       <div v-bind="api.positionerProps">
         <div v-bind="api.contentProps">

--- a/website/data/snippets/vue-sfc/editable/custom-controls.mdx
+++ b/website/data/snippets/vue-sfc/editable/custom-controls.mdx
@@ -16,7 +16,7 @@ const api = computed(() => editable.connect(state.value, send, normalizeProps));
       <span v-bind="api.previewProps" />
     </div>
     <div>
-      <div v-if="api.isEditing">
+      <div v-if="api.editing">
         <button v-bind="api.submitTriggerProps">Save</button>
         <button v-bind="api.cancelTriggerProps">Cancel</button>
       </div>


### PR DESCRIPTION
## 📝 Description

Fix typos and update outdated API usages in the documentation. Specifically:

- [ColorPicker](https://zagjs.com/components/react/color-picker): `combobox` -> `colorPicker`
- [Combobox](https://zagjs.com/components/react/combobox): `onInputValueChange({ value })` -> `onInputValueChange({ inputValue })`
- [Dialog](https://zagjs.com/components/react/dialog): `api.isOpen` -> `api.open`
- [Editable](https://zagjs.com/components/react/editable): `api.isEditing` -> `api.editing`