### PR TITLE
docs: presence and signature pad in vue-sfc

### DIFF
--- a/examples/nuxt-ts/pages/signature-pad.vue
+++ b/examples/nuxt-ts/pages/signature-pad.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import * as signaturePad from "@zag-js/signature-pad"
 import { signaturePadControls } from "@zag-js/shared"
+import * as signaturePad from "@zag-js/signature-pad"
 import { normalizeProps, useMachine } from "@zag-js/vue"
 
 const url = ref("")
@@ -22,7 +22,7 @@ const api = computed(() => signaturePad.connect(state.value, send, normalizeProp
 
       <div v-bind="api.controlProps">
         <svg v-bind="api.segmentProps">
-          <path v-for="path of api.paths" key="{i}" v-bind="api.getSegmentPathProps({ path })" />
+          <path v-for="(path, i) of api.paths" :key="i" v-bind="api.getSegmentPathProps({ path })" />
           <path v-if="api.currentPath" v-bind="api.getSegmentPathProps({ path: api.currentPath })" />
         </svg>
         <div v-bind="api.guideProps" />

--- a/website/data/snippets/vue-sfc/presence/usage.mdx
+++ b/website/data/snippets/vue-sfc/presence/usage.mdx
@@ -4,7 +4,7 @@
   import { useMachine, normalizeProps } from "@zag-js/vue"
   import { computed, watch, ref } from "vue"
 
-  const props = defineProps<{
+  const {present, unmountOnExit } = defineProps<{
     present: boolean
     unmountOnExit?: boolean
   }>()
@@ -24,10 +24,10 @@
   const nodeRef = ref<HTMLElement | null>(null)
 
   watch(nodeRef, () => {
-    apiRef.value.setNode(nodeRef.value)
+    api.value.setNode(nodeRef.value)
   })
 
-  const unmount = computed(() => !api.value.present && props.unmountOnExit)
+  const unmount = computed(() => !api.value.present && unmountOnExit)
 </script>
 
 <template>

--- a/website/data/snippets/vue-sfc/signature-pad/usage.mdx
+++ b/website/data/snippets/vue-sfc/signature-pad/usage.mdx
@@ -18,8 +18,8 @@
     <div v-bind="api.controlProps">
       <svg v-bind="api.segmentProps">
         <path
-          v-for="path of api.paths"
-          key="{i}"
+          v-for="(path, i) of api.paths"
+          :key="i"
           v-bind="api.getSegmentPathProps({ path })"
         />
         <path


### PR DESCRIPTION
## 📝 Description

> Update variable for presence and key for signature pad in vue-sfc

## ⛳️ Current behavior (updates)

-  `present`, `apiRef` is not defined in presence code snippet of vue-sfc
- `<path v-for="path of api.paths" key="{i}" v-bind="api.getSegmentPathProps({ path })" />"` is not valid in signature code snippet of vue-sfc

## 🚀 New behavior

- Presence: update variable in defineProps

```js
const {present, unmountOnExit } = defineProps<{
    present: boolean
    unmountOnExit?: boolean
  }>()
```

- Signature: update key by index

```js
<path v-for="(path, i) of api.paths" :key="i" v-bind="api.getSegmentPathProps({ path })" />
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
