### PR TITLE
docs: tooltip

### DIFF
--- a/website/data/overview/installation.mdx
+++ b/website/data/overview/installation.mdx
@@ -45,7 +45,7 @@ export function Tooltip() {
   return (
     <>
       <button {...api.triggerProps}>Hover me</button>
-      {api.isOpen && (
+      {api.open && (
         <div {...api.positionerProps}>
           <div {...api.contentProps}>Tooltip</div>
         </div>
@@ -84,7 +84,7 @@ export default defineComponent({
         <>
           <div>
             <button {...api.triggerProps}>Hover me</button>
-            {api.isOpen && (
+            {api.open && (
               <div {...api.positionerProps}>
                 <div {...api.contentProps}>Tooltip</div>
               </div>
@@ -122,7 +122,7 @@ export function Tooltip() {
   return (
     <div>
       <button {...api().triggerProps}>Hover me</button>
-      <Show when={api().isOpen}>
+      <Show when={api().open}>
         <div {...api().positionerProps}>
           <div {...api().contentProps}>Tooltip</div>
         </div>

--- a/website/data/snippets/react/tooltip/usage.mdx
+++ b/website/data/snippets/react/tooltip/usage.mdx
@@ -10,7 +10,7 @@ export function Tooltip() {
   return (
     <>
       <button {...api.triggerProps}>Hover me</button>
-      {api.isOpen && (
+      {api.open && (
         <div {...api.positionerProps}>
           <div {...api.contentProps}>Tooltip</div>
         </div>

--- a/website/data/snippets/solid/tooltip/usage.mdx
+++ b/website/data/snippets/solid/tooltip/usage.mdx
@@ -11,7 +11,7 @@ export function Tooltip() {
   return (
     <div>
       <button {...api().triggerProps}>Hover me</button>
-      <Show when={api().isOpen}>
+      <Show when={api().open}>
         <div {...api().positionerProps}>
           <div {...api().contentProps}>Tooltip</div>
         </div>

--- a/website/data/snippets/vue-jsx/tooltip/usage.mdx
+++ b/website/data/snippets/vue-jsx/tooltip/usage.mdx
@@ -17,7 +17,7 @@ export default defineComponent({
         <>
           <div>
             <button {...api.triggerProps}>Hover me</button>
-            {api.isOpen && (
+            {api.open && (
               <div {...api.positionerProps}>
                 <div {...api.contentProps}>Tooltip</div>
               </div>

--- a/website/data/snippets/vue-sfc/tooltip/usage.mdx
+++ b/website/data/snippets/vue-sfc/tooltip/usage.mdx
@@ -11,7 +11,7 @@ const api = computed(() => tooltip.connect(state.value, send, normalizeProps));
 <template>
   <div>
     <button ref="ref" v-bind="api.triggerProps">Hover me</button>
-    <div v-if="isOpen" v-bind="api.positionerProps">
+    <div v-if="api.open" v-bind="api.positionerProps">
       <div v-bind="api.contentProps">Tooltip</div>
     </div>
   </div>


### PR DESCRIPTION
## 📝 Description

> Using `api.open` instead of `api.isOpen` from `@zag-js/tooltip`

## ⛳️ Current behavior (updates)

Using `api.isOpen` in code snippets of tooltip

## 🚀 New behavior

Using `api.open` in code snippets of tooltip

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
