### PR TITLE
fix(collection): ensure collection are considered different when disabled change

### DIFF
--- a/.changeset/little-crews-reply.md
+++ b/.changeset/little-crews-reply.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/collection": patch
+---
+
+Ensure collection are considered different when item's disabled property changes

--- a/packages/utilities/collection/src/collection.ts
+++ b/packages/utilities/collection/src/collection.ts
@@ -69,7 +69,7 @@ export class Collection<T extends CollectionItem = CollectionItem> {
       const label = this.itemToString(item)
       const disabled = this.itemToDisabled(item)
 
-      hashSet.add(value)
+      hashSet.add(JSON.stringify({ value, disabled }))
 
       const node: CollectionNode<T> = {
         // freeze item to prevent mutation by frameworks like Solid.js


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Ensure that collection with attributes that changes (e.g. disabled) should be considered as changed.

## ⛳️ Current behavior (updates)

When the items of a collection are updated with only a state change, the collection is considered as equal (as the values are the same).

## 🚀 New behavior

When the items of a collection are updated with only a state change, the collection should be considered as changed, as of now, the disabled attribute changed IS considered as a change for the collection.

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information
