### PR TITLE
docs: using open instead of isOpen from @zag-js/hover-card

### DIFF
--- a/website/data/snippets/react/hover-card/usage.mdx
+++ b/website/data/snippets/react/hover-card/usage.mdx
@@ -17,7 +17,7 @@ function HoverCard() {
         Twitter
       </a>
 
-      {api.isOpen && (
+      {api.open && (
         <Portal>
           <div {...api.positionerProps}>
             <div {...api.contentProps}>

--- a/website/data/snippets/solid/hover-card/usage.mdx
+++ b/website/data/snippets/solid/hover-card/usage.mdx
@@ -19,7 +19,7 @@ function Checkbox() {
         Twitter
       </a>
 
-      <Show when={api().isOpen}>
+      <Show when={api().open}>
         <Portal>
           <div {...api().positionerProps}>
             <div {...api().contentProps}>

--- a/website/data/snippets/vue-jsx/hover-card/usage.mdx
+++ b/website/data/snippets/vue-jsx/hover-card/usage.mdx
@@ -24,7 +24,7 @@ export default defineComponent({
             Twitter
           </a>
 
-          {api.isOpen && (
+          {api.open && (
             <Teleport to="body">
               <div {...api.positionerProps}>
                 <div {...api.contentProps}>

--- a/website/data/snippets/vue-sfc/hover-card/usage.mdx
+++ b/website/data/snippets/vue-sfc/hover-card/usage.mdx
@@ -17,7 +17,7 @@ const api = computed(() => hoverCard.connect(state.value, send, normalizeProps))
   >
     Twitter
   </a>
-  <Teleport to="body" v-if="api.isOpen">
+  <Teleport to="body" v-if="api.open">
     <div v-bind="api.positionerProps">
       <div v-bind="api.contentProps">
         <div v-bind="api.arrowProps">


### PR DESCRIPTION
## 📝 Description

> Using `api.open` instead of `api.isOpen` from `@zag-js/hover-card`

## ⛳️ Current behavior (updates)

Using `api.isOpen` in code snippets of hover card

## 🚀 New behavior

Using `api.open` in code snippets of hover card

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
