### PR TITLE
fix(clipboard): correct condition to use clipboard API

### DIFF
--- a/packages/machines/clipboard/src/clipboard.dom.ts
+++ b/packages/machines/clipboard/src/clipboard.dom.ts
@@ -1,5 +1,4 @@
 import { createScope, getWindow } from "@zag-js/dom-query"
-import { hasProp } from "@zag-js/utils"
 import type { MachineContext as Ctx } from "./clipboard.types"
 
 export const dom = createScope({
@@ -48,7 +47,7 @@ function copyNode(node: HTMLElement): Promise<void> {
 function copyText(doc: Document, text: string): Promise<void> {
   const win = doc.defaultView || window
 
-  if (hasProp(win.navigator, "clipboard")) {
+  if (win.navigator.clipboard?.writeText !== undefined) {
     return win.navigator.clipboard.writeText(text)
   }
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
Clipboard API is never used because the condition is wrong.

## ⛳️ Current behavior (updates)
See above

## 🚀 New behavior
Browser support is correctly checked so `writeText` of Clipboard API is called if supported

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information
You can reproduce this here
https://codesandbox.io/p/sandbox/determined-neco-9ktp4x?file=%2Fsrc%2FApp.tsx