### PR TITLE
docs: tabs

### DIFF
--- a/website/data/snippets/vue-sfc/tabs/usage.mdx
+++ b/website/data/snippets/vue-sfc/tabs/usage.mdx
@@ -28,7 +28,7 @@ const api = computed(() => tabs.connect(state.value, send, normalizeProps));
     <div
       v-for="item in data"
       v-bind="api.getContentProps({ value: item.value })"
-      key="{item.value}"
+      :key="item.value"
     >
       <p>{{ item.content }}</p>
     </div>

--- a/website/data/snippets/vue-sfc/tabs/with-indicator.mdx
+++ b/website/data/snippets/vue-sfc/tabs/with-indicator.mdx
@@ -15,7 +15,7 @@
   <div
     v-for="item in data"
     v-bind="api.getContentProps({ value: item.value })"
-    key="{item.value}"
+    :key="item.value"
   >
     <p>{{ item.content }}</p>
   </div>


### PR DESCRIPTION
## 📝 Description

> Fix key in code snippet of vue-sfc tabs

## ⛳️ Current behavior (updates)

`key="{item.value}"`

## 🚀 New behavior

`:key="item.value"`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
