### PR TITLE
docs: checkbox and switch

### DIFF
--- a/website/data/snippets/react/checkbox/usage.mdx
+++ b/website/data/snippets/react/checkbox/usage.mdx
@@ -10,7 +10,7 @@ function Checkbox() {
   return (
     <label {...api.rootProps}>
       <span {...api.labelProps}>
-        Input is {api.isChecked ? "checked" : "unchecked"}
+        Input is {api.checked ? "checked" : "unchecked"}
       </span>
       <div {...api.controlProps} />
       <input {...api.hiddenInputProps} />

--- a/website/data/snippets/react/switch/usage.mdx
+++ b/website/data/snippets/react/switch/usage.mdx
@@ -13,7 +13,7 @@ function Checkbox() {
       <span {...api.controlProps}>
         <span {...api.thumbProps} />
       </span>
-      <span {...api.labelProps}>{api.isChecked ? "On" : "Off"}</span>
+      <span {...api.labelProps}>{api.checked ? "On" : "Off"}</span>
     </label>
   )
 }

--- a/website/data/snippets/solid/switch/usage.mdx
+++ b/website/data/snippets/solid/switch/usage.mdx
@@ -14,7 +14,7 @@ function Checkbox() {
       <span {...api().controlProps}>
         <span {...api().thumbProps} />
       </span>
-      <span {...api().labelProps}>{api.isChecked ? "On" : "Off"}</span>
+      <span {...api().labelProps}>{api.checked ? "On" : "Off"}</span>
     </label>
   )
 }

--- a/website/data/snippets/vue-jsx/checkbox/usage.mdx
+++ b/website/data/snippets/vue-jsx/checkbox/usage.mdx
@@ -17,7 +17,7 @@ export default defineComponent({
       return (
         <label {...api.rootProps}>
           <span {...api.labelProps}>
-            Input is {api.isChecked ? "checked" : "unchecked"}
+            Input is {api.checked ? "checked" : "unchecked"}
           </span>
           <div {...api.controlProps} />
           <input {...api.hiddenInputProps} />

--- a/website/data/snippets/vue-jsx/switch/usage.mdx
+++ b/website/data/snippets/vue-jsx/switch/usage.mdx
@@ -20,7 +20,7 @@ export default defineComponent({
           <span {...api.controlProps}>
             <span {...api.thumbProps} />
           </span>
-          <span {...api.labelProps}>{api.isChecked ? "On" : "Off"}</span>
+          <span {...api.labelProps}>{api.checked ? "On" : "Off"}</span>
         </label>
       )
     }

--- a/website/data/snippets/vue-sfc/avatar/usage.mdx
+++ b/website/data/snippets/vue-sfc/avatar/usage.mdx
@@ -12,7 +12,7 @@
 <template>
   <div v-bind="api.rootProps">
     <span v-bind="api.fallbackProps">PA</span>
-    <img alt="PA" src="{src}" v-bind="api.imageProps" />
+    <img alt="PA" :src="src" v-bind="api.imageProps" />
   </div>
 </template>
 ```

--- a/website/data/snippets/vue-sfc/checkbox/usage.mdx
+++ b/website/data/snippets/vue-sfc/checkbox/usage.mdx
@@ -15,7 +15,7 @@
   <label v-bind="api.rootProps">
     <span v-bind="api.labelProps">
       Input is
-      <span v-if="api.isChecked"> checked</span>
+      <span v-if="api.checked"> checked</span>
       <span v-else> unchecked</span>
     </span>
     <div v-bind="api.controlProps" />

--- a/website/data/snippets/vue-sfc/switch/usage.mdx
+++ b/website/data/snippets/vue-sfc/switch/usage.mdx
@@ -18,7 +18,7 @@
       <span v-bind="api.thumbProps" />
     </span>
     <span v-bind="api.labelProps">
-      <span v-if="api.isChecked">On</span>
+      <span v-if="api.checked">On</span>
       <span v-else>Off</span>
     </span>
   </label>


### PR DESCRIPTION
## 📝 Description

> Fix checked for api of checkbox and switch

## ⛳️ Current behavior (updates)

- Avatar using key is `src="{src}"`
- Checkbox using `api.isChecked`
- Switch using `api.isChecked`


## 🚀 New behavior

- Avatar using key is `:src="src"`
- Checkbox using `api.checked`
- Switch using `api.checked`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
