### PR TITLE
fix: avoid reset scroll position on opening popover

### DIFF
--- a/.changeset/sour-books-act.md
+++ b/.changeset/sour-books-act.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/popover": patch
+---
+
+Fix the issue where page scroll resets on opening popover

--- a/packages/machines/popover/src/popover.machine.ts
+++ b/packages/machines/popover/src/popover.machine.ts
@@ -227,7 +227,7 @@ export function machine(userContext: UserDefinedContext) {
         setInitialFocus(ctx) {
           raf(() => {
             const element = getInitialFocus(dom.getContentEl(ctx), ctx.initialFocusEl)
-            element?.focus()
+            element?.focus({ preventScroll: true })
           })
         },
         setFinalFocus(ctx, evt) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1542

## 📝 Description

As described on #1542, the popover component will reset scroll position when it is opened.
I found `{ preventScroll: true }` parameter of `HTMLElement.focus()` is missing after 0.50.0, which is set before 0.49.0.

### 0.49.0
https://github.com/chakra-ui/zag/blob/%40zag-js/popover%400.49.0/packages/machines/popover/src/popover.machine.ts#L228

### 0.50.0
https://github.com/chakra-ui/zag/blob/%40zag-js/popover%400.50.0/packages/machines/popover/src/popover.machine.ts#L230

The popover content does not look place right position just after opening, `setInitialFocus` will cause this timing, so I think we still need `{ preventScroll: true }` parameter.

## ⛳️ Current behavior (updates)
The popover component will reset scroll position when it is opened.

## 🚀 New behavior
The popover component DOES NOT reset scroll position when it is opened.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
