### PR TITLE
fix: expose content placement on combobox

### DIFF
--- a/.changeset/early-hairs-do.md
+++ b/.changeset/early-hairs-do.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/combobox": patch
+"@zag-js/docs": patch
+---
+
+Expose data-placement on Content for Combobox

--- a/packages/docs/data/data-attr.json
+++ b/packages/docs/data/data-attr.json
@@ -317,7 +317,8 @@
     "Content": {
       "data-scope": "combobox",
       "data-part": "content",
-      "data-state": "\"open\" | \"closed\""
+      "data-state": "\"open\" | \"closed\"",
+      "data-placement": "The placement of the content"
     },
     "ClearTrigger": {
       "data-scope": "combobox",

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -301,6 +301,7 @@ export function connect<T extends PropTypes, V extends CollectionItem>(
         tabIndex: -1,
         hidden: !open,
         "data-state": open ? "open" : "closed",
+        "data-placement": state.context.currentPlacement,
         "aria-labelledby": dom.getLabelId(state.context),
         "aria-multiselectable": state.context.multiple && composite ? true : undefined,
         onPointerDown(event) {


### PR DESCRIPTION
## 📝 Description

Expose (missing) `data-placement` on Combobox's content.

## 💣 Is this a breaking change (Yes/No):

No.