### PR TITLE
fix(toast): add missing aria attributes on the root element

### DIFF
--- a/.changeset/twenty-dragons-yell.md
+++ b/.changeset/twenty-dragons-yell.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/toast": patch
+---
+
+Add missing `aria-labelledby` and `aria-describedby` attributes on the toast root element

--- a/packages/machines/toast/src/toast.connect.ts
+++ b/packages/machines/toast/src/toast.connect.ts
@@ -58,6 +58,8 @@ export function connect<T extends PropTypes, O>(
 
         role: "status",
         "aria-atomic": "true",
+        "aria-describedby": state.context.description ? dom.getDescriptionId(state.context) : undefined,
+        "aria-labelledby": state.context.title ? dom.getTitleId(state.context) : undefined,
         tabIndex: 0,
         style: getPlacementStyle(state.context, visible),
         onKeyDown(event) {


### PR DESCRIPTION
## 📝 Description

Add missing `aria-labelledby` and `aria-describedby` attributes on the toast root element.

## ⛳️ Current behavior (updates)

Because the `aria-labelledby` and `aria-describedby` attributes are missing, the toast root element (`role="status"`) does not have an _accessible name_.

## 🚀 New behavior

The toast root element (`role="status"`) now have the `aria-labelledby` and `aria-describedby` attributes defined accordingly.

## 💣 Is this a breaking change (Yes/No):

No
