### PR TITLE
fix: improve is* checkers compatibility

### DIFF
--- a/.changeset/silver-ducks-brush.md
+++ b/.changeset/silver-ducks-brush.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/dom-query": patch
+---
+
+Fix an issue where `isHTMLElement` throws an error in Node.js environments.
+
+Fix an issue where `isNode` throws an error for `null` or `undefined` values.

--- a/packages/utilities/dom-query/src/is.ts
+++ b/packages/utilities/dom-query/src/is.ts
@@ -1,18 +1,12 @@
-const ELEMENT_NODE: typeof Node.ELEMENT_NODE = 1
-const DOCUMENT_NODE: typeof Node.DOCUMENT_NODE = 9
-const DOCUMENT_FRAGMENT_NODE: typeof Node.DOCUMENT_FRAGMENT_NODE = 11
+export const isHTMLElement = (v: any): v is HTMLElement =>
+  typeof v === "object" && v?.nodeType === Node.ELEMENT_NODE && typeof v?.nodeName === "string"
 
-const isObject = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null
+export const isDocument = (el: any): el is Document => el.nodeType === Node.DOCUMENT_NODE
 
-export const isHTMLElement = (el: any): el is HTMLElement =>
-  typeof isObject(el) && el.nodeType === ELEMENT_NODE && typeof el.nodeName === "string"
-
-export const isDocument = (el: any): el is Document => isObject(el) && el.nodeType === DOCUMENT_NODE
-
-export const isWindow = (el: any): el is Window => isObject(el) && el === el.window
+export const isWindow = (el: any): el is Window => el != null && el === el.window
 
 export const isVisualViewport = (el: any): el is VisualViewport =>
-  isObject(el) && el.constructor.name === "VisualViewport"
+  el != null && el.constructor.name === "VisualViewport"
 
 export const getNodeName = (node: Node | Window): string => {
   if (isHTMLElement(node)) return node.localName || ""
@@ -23,7 +17,7 @@ export function isRootElement(node: Node): boolean {
   return ["html", "body", "#document"].includes(getNodeName(node))
 }
 
-export const isNode = (el: any): el is Node => isObject(el) && el.nodeType !== undefined
+export const isNode = (el: any): el is Node => el.nodeType !== undefined
 
 export const isShadowRoot = (el: any): el is ShadowRoot =>
- isNode(el) && el.nodeType === DOCUMENT_FRAGMENT_NODE && "host" in el
+  el && isNode(el) && el.nodeType === Node.DOCUMENT_FRAGMENT_NODE && "host" in el

--- a/packages/utilities/dom-query/src/is.ts
+++ b/packages/utilities/dom-query/src/is.ts
@@ -1,12 +1,18 @@
-export const isHTMLElement = (v: any): v is HTMLElement =>
-  typeof v === "object" && v?.nodeType === Node.ELEMENT_NODE && typeof v?.nodeName === "string"
+const ELEMENT_NODE: typeof Node.ELEMENT_NODE = 1
+const DOCUMENT_NODE: typeof Node.DOCUMENT_NODE = 9
+const DOCUMENT_FRAGMENT_NODE: typeof Node.DOCUMENT_FRAGMENT_NODE = 11
 
-export const isDocument = (el: any): el is Document => el.nodeType === Node.DOCUMENT_NODE
+const isObject = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null
 
-export const isWindow = (el: any): el is Window => el != null && el === el.window
+export const isHTMLElement = (el: any): el is HTMLElement =>
+  isObject(el) && el.nodeType === ELEMENT_NODE && typeof el.nodeName === "string"
+
+export const isDocument = (el: any): el is Document => isObject(el) && el.nodeType === DOCUMENT_NODE
+
+export const isWindow = (el: any): el is Window => isObject(el) && el === el.window
 
 export const isVisualViewport = (el: any): el is VisualViewport =>
-  el != null && el.constructor.name === "VisualViewport"
+  isObject(el) && el.constructor.name === "VisualViewport"
 
 export const getNodeName = (node: Node | Window): string => {
   if (isHTMLElement(node)) return node.localName || ""
@@ -17,7 +23,7 @@ export function isRootElement(node: Node): boolean {
   return ["html", "body", "#document"].includes(getNodeName(node))
 }
 
-export const isNode = (el: any): el is Node => el.nodeType !== undefined
+export const isNode = (el: any): el is Node => isObject(el) && el.nodeType !== undefined
 
 export const isShadowRoot = (el: any): el is ShadowRoot =>
-  el && isNode(el) && el.nodeType === Node.DOCUMENT_FRAGMENT_NODE && "host" in el
+  isNode(el) && el.nodeType === DOCUMENT_FRAGMENT_NODE && "host" in el

--- a/packages/utilities/dom-query/src/is.ts
+++ b/packages/utilities/dom-query/src/is.ts
@@ -1,12 +1,18 @@
-export const isHTMLElement = (v: any): v is HTMLElement =>
-  typeof v === "object" && v?.nodeType === Node.ELEMENT_NODE && typeof v?.nodeName === "string"
+const ELEMENT_NODE: typeof Node.ELEMENT_NODE = 1
+const DOCUMENT_NODE: typeof Node.DOCUMENT_NODE = 9
+const DOCUMENT_FRAGMENT_NODE: typeof Node.DOCUMENT_FRAGMENT_NODE = 11
 
-export const isDocument = (el: any): el is Document => el.nodeType === Node.DOCUMENT_NODE
+const isObject = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null
 
-export const isWindow = (el: any): el is Window => el != null && el === el.window
+export const isHTMLElement = (el: any): el is HTMLElement =>
+  typeof isObject(el) && el.nodeType === ELEMENT_NODE && typeof el.nodeName === "string"
+
+export const isDocument = (el: any): el is Document => isObject(el) && el.nodeType === DOCUMENT_NODE
+
+export const isWindow = (el: any): el is Window => isObject(el) && el === el.window
 
 export const isVisualViewport = (el: any): el is VisualViewport =>
-  el != null && el.constructor.name === "VisualViewport"
+  isObject(el) && el.constructor.name === "VisualViewport"
 
 export const getNodeName = (node: Node | Window): string => {
   if (isHTMLElement(node)) return node.localName || ""
@@ -17,7 +23,7 @@ export function isRootElement(node: Node): boolean {
   return ["html", "body", "#document"].includes(getNodeName(node))
 }
 
-export const isNode = (el: any): el is Node => el.nodeType !== undefined
+export const isNode = (el: any): el is Node => isObject(el) && el.nodeType !== undefined
 
 export const isShadowRoot = (el: any): el is ShadowRoot =>
-  el && isNode(el) && el.nodeType === Node.DOCUMENT_FRAGMENT_NODE && "host" in el
+ isNode(el) && el.nodeType === DOCUMENT_FRAGMENT_NODE && "host" in el


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

~~Closes #~~ <!-- Github issue # here -->

## 📝 Description

> Add a brief description

This PR includes two improvements for `isHTMLElement()` functions etc.
 
1. Ensure they work on Node.js, where global `Node` is not available. 
2. Check whether the past argument is a valid object. This ensures that passing a `null` or `undefined` won't throw errors. The typescript signature for past `ev` is `any` so it's better to support `null` and `undefined` etc.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

```
$ echo "require('@zag-js/dom-query').isHTMLElement({});" | node

var isHTMLElement = (v) => typeof v === "object" && v?.nodeType === Node.ELEMENT_NODE && typeof v?.nodeName === "string";
                                                                    ^
ReferenceError: Node is not defined
```

```
$ echo "require('@zag-js/dom-query').isNode(null);" | node

var isNode = (el) => el.nodeType !== void 0;
                        ^
TypeError: Cannot read properties of null (reading 'nodeType')
```


## 🚀 New behavior

No error for both two examples above.

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information

N/A
