### PR TITLE
fix(time-picker): wrong selected hour on 24 hours format

### DIFF
--- a/.changeset/ninety-geese-repair.md
+++ b/.changeset/ninety-geese-repair.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/time-picker": patch
+---
+
+fix(time-picker): wrong selected hour on 24 hours format

--- a/packages/machines/time-picker/src/time-picker.connect.ts
+++ b/packages/machines/time-picker/src/time-picker.connect.ts
@@ -346,7 +346,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
 
     getPeriodCellProps(props) {
       const isSelected = state.context.period === props.value
-      const currentPeriod = getHourPeriod(currentTime?.hour)
+      const currentPeriod = getHourPeriod(currentTime?.hour, state.context.locale)
       const isCurrent = currentPeriod === props.value
       const isFocused = state.context.focusedColumn === "period" && state.context.focusedValue === props.value
 

--- a/packages/machines/time-picker/src/time-picker.machine.ts
+++ b/packages/machines/time-picker/src/time-picker.machine.ts
@@ -40,7 +40,7 @@ export function machine(userContext: UserDefinedContext) {
       computed: {
         valueAsString: (ctx) => getStringifiedValue(ctx),
         hour12: (ctx) => is12HourFormat(ctx.locale),
-        period: (ctx) => getHourPeriod(ctx.value?.hour),
+        period: (ctx) => getHourPeriod(ctx.value?.hour, ctx.locale),
       },
 
       watch: {

--- a/packages/machines/time-picker/src/time-picker.utils.ts
+++ b/packages/machines/time-picker/src/time-picker.utils.ts
@@ -61,8 +61,8 @@ export function get12HourFormatPeriodHour(hour: number, period: TimePeriod | nul
   return period === "pm" ? hour + 12 : hour
 }
 
-export function getHourPeriod(hour: number | undefined) {
-  if (hour === undefined) return null
+export function getHourPeriod(hour: number | undefined, locale: string) {
+  if (hour === undefined || !is12HourFormat(locale)) return null
   return hour > 11 ? "pm" : "am"
 }
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

If the locale corresponds to a 24 hours format, and the user selects an hour after 11, the cell would not be selected.
Fix by making `getHourPeriod` return `null` if the locale corresponds to a 24 hours format.

## ⛳️ Current behavior (updates)

![image](https://github.com/user-attachments/assets/550eb7e6-da4c-4ed0-901a-57f747f98559)

## 🚀 New behavior

![image](https://github.com/user-attachments/assets/1db752b2-b49f-4716-b278-0087e098af00)

## 💣 Is this a breaking change (Yes/No):

No
