### PR TITLE
fix: ensure clicks outside of dialogs/tours are not passed on to components outside of active focus trap

### DIFF
--- a/.changeset/lovely-hats-wonder.md
+++ b/.changeset/lovely-hats-wonder.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/dialog": patch
+"@zag-js/tour": patch
+---
+
+fix: ensure clicks outside of dialogs are not passed on to components outside of the active focus trap

--- a/packages/machines/dialog/src/dialog.machine.ts
+++ b/packages/machines/dialog/src/dialog.machine.ts
@@ -143,7 +143,6 @@ export function machine(userContext: UserDefinedContext) {
               preventScroll: true,
               fallbackFocus: contentEl,
               returnFocusOnDeactivate: ctx.restoreFocus,
-              allowOutsideClick: true,
               initialFocus: ctx.initialFocusEl?.() ?? undefined,
               setReturnFocus(triggerEl) {
                 return ctx.finalFocusEl?.() ?? triggerEl

--- a/packages/machines/tour/src/tour.machine.ts
+++ b/packages/machines/tour/src/tour.machine.ts
@@ -271,7 +271,6 @@ export function machine(userContext: UserDefinedContext) {
 
             trap = createFocusTrap(contentEl, {
               escapeDeactivates: false,
-              allowOutsideClick: true,
               preventScroll: true,
               returnFocusOnDeactivate: false,
               document: dom.getDoc(ctx),


### PR DESCRIPTION
Fixes https://github.com/chakra-ui/zag/issues/1720

## 📝 Description

Trying my hand at fixing this, as it's currently blocking our migration to ark dialogs.

## ⛳️ Current behavior (updates)

`allowOutsideClick: true` tells focus-trap that clicks on valid elements outside of the focus trap is permitted. If you have a button or link directly underneath a dialog close trigger, both the close trigger and the underlying element would be clicked.

## 🚀 New behavior

Elements outside of the dialog/trigger are no longer triggered if a dialog/tour is open.

## 💣 Is this a breaking change (Yes/No):

I don't think so? I'm not really familiar with focus-trap, nor with the way zag uses it.

## 📝 Additional Information

I tried looking at the git history for both files, but there's not really any information as to why this was set in the first place. 

Also: This option is still set for popovers. I'm not really sure if you'd want popovers to ignore all outside clicks. Maybe the `modal` prop should alter it?
