### PR TITLE
docs: use getButtonProps instead of buttonProps

### DIFF
--- a/website/data/overview/whats-a-machine.mdx
+++ b/website/data/overview/whats-a-machine.mdx
@@ -81,7 +81,7 @@ function connect(state, send) {
   const active = state.matches("active")
   return {
     active,
-    buttonProps: {
+    getButtonProps() {
       type: "button",
       role: "switch",
       "aria-checked": active,


### PR DESCRIPTION
Closes #1749 

## 📝 Description
This pull request changes nothing but a `.mdx` file which is relevant to `whats-a-machine` link.

## 💣 Is this a breaking change (Yes/No): No