### PR TITLE
fix(avatar): check removed avatar node type

### DIFF
--- a/.changeset/many-papayas-clap.md
+++ b/.changeset/many-papayas-clap.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/avatar": patch
+---
+
+Fix issues where avatar could throw when the fallback inner text changes.

--- a/examples/next-ts/pages/avatar.tsx
+++ b/examples/next-ts/pages/avatar.tsx
@@ -12,7 +12,6 @@ export default function Page() {
   const [state, send] = useMachine(avatar.machine({ id: useId() }))
   const [src, setSrc] = useState(images[0])
   const [showImage, setShowImage] = useState(true)
-  const [name, setName] = useState("PA")
 
   const api = avatar.connect(state, send, normalizeProps)
 
@@ -20,7 +19,7 @@ export default function Page() {
     <>
       <main className="avatar">
         <div {...api.getRootProps()}>
-          <span {...api.getFallbackProps()}>{name}</span>
+          <span {...api.getFallbackProps()}>PA</span>
           {showImage && <img alt="" referrerPolicy="no-referrer" src={src} {...api.getImageProps()} />}
         </div>
 
@@ -28,7 +27,6 @@ export default function Page() {
           <button onClick={() => setSrc(getRandomImage())}>Change Image</button>
           <button onClick={() => setSrc(avatarData.broken)}>Broken Image</button>
           <button onClick={() => setShowImage((c) => !c)}>Toggle Image</button>
-          <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
         </div>
       </main>
 

--- a/examples/next-ts/pages/avatar.tsx
+++ b/examples/next-ts/pages/avatar.tsx
@@ -12,6 +12,7 @@ export default function Page() {
   const [state, send] = useMachine(avatar.machine({ id: useId() }))
   const [src, setSrc] = useState(images[0])
   const [showImage, setShowImage] = useState(true)
+  const [name, setName] = useState("PA")
 
   const api = avatar.connect(state, send, normalizeProps)
 
@@ -19,7 +20,7 @@ export default function Page() {
     <>
       <main className="avatar">
         <div {...api.getRootProps()}>
-          <span {...api.getFallbackProps()}>PA</span>
+          <span {...api.getFallbackProps()}>{name}</span>
           {showImage && <img alt="" referrerPolicy="no-referrer" src={src} {...api.getImageProps()} />}
         </div>
 
@@ -27,6 +28,7 @@ export default function Page() {
           <button onClick={() => setSrc(getRandomImage())}>Change Image</button>
           <button onClick={() => setSrc(avatarData.broken)}>Broken Image</button>
           <button onClick={() => setShowImage((c) => !c)}>Toggle Image</button>
+          <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
         </div>
       </main>
 

--- a/packages/machines/avatar/src/avatar.machine.ts
+++ b/packages/machines/avatar/src/avatar.machine.ts
@@ -74,7 +74,9 @@ export function machine(userContext: UserDefinedContext) {
           return observeChildren(rootEl, {
             callback(records) {
               const removedNodes = Array.from(records[0].removedNodes) as HTMLElement[]
-              const removed = removedNodes.find((node) => node.matches("[data-scope=avatar][data-part=image]"))
+              const removed = removedNodes.find(
+                (node) => node.nodeType === Node.ELEMENT_NODE && node.matches("[data-scope=avatar][data-part=image]"),
+              )
               if (removed) {
                 send({ type: "IMG.UNMOUNT" })
               }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Checking the NodeType for errors caused by having a TextNode instead of an HTMLElement in removedNodes.

## ⛳️ Current behavior (updates)

If the name of the Avatar is an empty string, this type error occurs.

![스크린샷 2024-09-06 오전 2 34 36](https://github.com/user-attachments/assets/ac9a3307-134a-427e-815a-14ec18ab4c13)

## 🚀 New behavior

No error

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information
