### PR TITLE
fix(combobox): highlight values remain when items changed

### DIFF
--- a/.changeset/spicy-mugs-run.md
+++ b/.changeset/spicy-mugs-run.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/combobox": patch
+---
+
+Fix issue where remaining incorrect highlight values when items changed

--- a/packages/machines/combobox/src/combobox.machine.ts
+++ b/packages/machines/combobox/src/combobox.machine.ts
@@ -792,7 +792,7 @@ export function machine<T extends CollectionItem>(userContext: UserDefinedContex
         highlightFirstItem(ctx) {
           raf(() => {
             const value = ctx.collection.firstValue
-            set.highlightedValue(ctx, value)
+            set.highlightedValue(ctx, value, true)
           })
         },
         highlightFirstItemIfNeeded(ctx) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

In Combobox, when we want to display something like `no option` when filtering by input, an unintended highilghtedValue is kept in the internal state.

This would cause an empty item (like value=‘something’, item=null) to be selected, so this issue has been fixed.

## ⛳️ Current behavior (updates)


https://github.com/user-attachments/assets/50df8bc9-97c7-4a77-83d1-6756b06620bd



## 🚀 New behavior
When items changed (in other word, to change the children node), forced update the highlighted value.
This ensures that the highlight value is not an unintended, 
because the value of `ctx.collection.firstValue` will be null if items is not present and null will be forced set.


https://github.com/user-attachments/assets/6af1a738-4948-49bf-9327-07ee5bd9e8a7



## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information

I thought about preventing value changes when item=null, but I thought that the problem was that the highlight was still remain so I fix like this PR.
