### PR TITLE
Fix typo in composition.mdx

### DIFF
--- a/website/data/overview/composition.mdx
+++ b/website/data/overview/composition.mdx
@@ -38,7 +38,7 @@ export function Toggle() {
 
   return (
     // 4. spread the new props
-    <a href="https://twitter.com/zag_js" target="_blank" {...api.getTriggerProps()}>
+    <a href="https://twitter.com/zag_js" target="_blank" {...triggerProps}>
       {api.open ? "Open" : "Close"}
     </a>
   )


### PR DESCRIPTION
## 📝 Description

The `triggerProps` variable was created but not used.

## 💣 Is this a breaking change (Yes/No):

No.
