### PR TITLE
fix(types): add undefined to all machine optional types

### DIFF
--- a/packages/machines/accordion/src/accordion.types.ts
+++ b/packages/machines/accordion/src/accordion.types.ts
@@ -28,17 +28,17 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the accordion. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Whether multple accordion items can be expanded at the same time.
    * @default false
    */
-  multiple?: boolean
+  multiple?: boolean | undefined
   /**
    * Whether an accordion item can be closed after it has been expanded.
    * @default false
    */
-  collapsible?: boolean
+  collapsible?: boolean | undefined
   /**
    * The `value` of the accordion items that are currently being expanded.
    */
@@ -46,7 +46,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the accordion items are disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * The callback fired when the state of expanded/collapsed accordion items changes.
    */
@@ -59,7 +59,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    *  The orientation of the accordion items.
    *  @default "vertical"
    */
-  orientation?: "horizontal" | "vertical"
+  orientation?: "horizontal" | "vertical" | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
@@ -104,7 +104,7 @@ export interface ItemProps {
   /**
    * Whether the accordion item is disabled.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export interface ItemState {

--- a/packages/machines/avatar/src/avatar.types.ts
+++ b/packages/machines/avatar/src/avatar.types.ts
@@ -25,11 +25,11 @@ interface PublicContext extends CommonProperties, DirectionProperty {
   /**
    * Functional called when the image loading status changes.
    */
-  onStatusChange?: (details: StatusChangeDetails) => void
+  onStatusChange?: ((details: StatusChangeDetails) => void) | undefined
   /**
    * The ids of the elements in the avatar. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
 }
 
 interface PrivateContext {}

--- a/packages/machines/carousel/src/carousel.types.ts
+++ b/packages/machines/carousel/src/carousel.types.ts
@@ -59,16 +59,16 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Function called when the slide changes.
    */
-  onIndexChange?: (details: SlideChangeDetails) => void
+  onIndexChange?: ((details: SlideChangeDetails) => void) | undefined
   /**
    * The ids of the elements in the carousel. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
 }
 
 interface PrivateContext {
   slideRects: DOMRect[]
-  containerRect?: DOMRect
+  containerRect?: DOMRect | undefined
   containerSize: number
   scrollSnaps: number[]
   scrollProgress: number
@@ -135,7 +135,7 @@ export interface ItemState {
 
 export interface IndicatorProps {
   index: number
-  readOnly?: boolean
+  readOnly?: boolean | undefined
 }
 
 export interface MachineApi<T extends PropTypes = PropTypes> {

--- a/packages/machines/checkbox/src/checkbox.types.ts
+++ b/packages/machines/checkbox/src/checkbox.types.ts
@@ -26,19 +26,19 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the checkbox. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Whether the checkbox is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the checkbox is invalid
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * Whether the checkbox is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * The checked state of the checkbox
    */
@@ -46,7 +46,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the checkbox is read-only
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * The callback invoked when the checked state changes.
    */
@@ -55,11 +55,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    * The name of the input field in a checkbox.
    * Useful for form submission.
    */
-  name?: string
+  name?: string | undefined
   /**
    * The id of the form that the checkbox belongs to.
    */
-  form?: string
+  form?: string | undefined
   /**
    * The value of checkbox input. Useful for form submission.
    * @default "on"
@@ -89,22 +89,22 @@ interface PrivateContext {
    * @internal
    * Whether the checkbox is pressed
    */
-  active?: boolean
+  active?: boolean | undefined
   /**
    * @internal
    * Whether the checkbox has focus
    */
-  focused?: boolean
+  focused?: boolean | undefined
   /**
    * @internal
    * Whether the checkbox is focus visible
    */
-  focusVisible?: boolean
+  focusVisible?: boolean | undefined
   /**
    * @internal
    * Whether the checkbox is hovered
    */
-  hovered?: boolean
+  hovered?: boolean | undefined
   /**
    * @internal
    * Whether the checkbox's fieldset is disabled

--- a/packages/machines/clipboard/src/clipboard.types.ts
+++ b/packages/machines/clipboard/src/clipboard.types.ts
@@ -15,7 +15,7 @@ interface PublicContext extends CommonProperties {
   /**
    * The ids of the elements in the clipboard. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The value to be copied to the clipboard
    */
@@ -23,7 +23,7 @@ interface PublicContext extends CommonProperties {
   /**
    * The function to be called when the value is copied to the clipboard
    */
-  onStatusChange?: (details: CopyStatusDetails) => void
+  onStatusChange?: ((details: CopyStatusDetails) => void) | undefined
   /**
    * The timeout for the copy operation
    * @default 3000

--- a/packages/machines/collapsible/src/collapsible.types.ts
+++ b/packages/machines/collapsible/src/collapsible.types.ts
@@ -23,27 +23,27 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the collapsible. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Function called when the animation ends in the closed state.
    */
-  onExitComplete?: () => void
+  onExitComplete?: (() => void) | undefined
   /**
    * Function called when the popup is opened
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * Whether the collapsible is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the collapsible is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    *  Whether the collapsible open state is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
 }
 
 type ComputedContext = Readonly<{}>
@@ -73,7 +73,7 @@ interface PrivateContext {
    * @internal
    * The requestAnimationFrame id
    */
-  _rafCleanup?: VoidFunction
+  _rafCleanup?: VoidFunction | undefined
   /**
    * @internal
    * The unmount animation name

--- a/packages/machines/color-picker/src/color-picker.types.ts
+++ b/packages/machines/color-picker/src/color-picker.types.ts
@@ -61,7 +61,7 @@ interface PublicContext extends CommonProperties, DirectionProperty, InteractOut
   /**
    * The ids of the elements in the color picker. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The current color value
    * @default #000000
@@ -70,31 +70,31 @@ interface PublicContext extends CommonProperties, DirectionProperty, InteractOut
   /**
    * Whether the color picker is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the color picker is read-only
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Whether the color picker is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Handler that is called when the value changes, as the user drags.
    */
-  onValueChange?: (details: ValueChangeDetails) => void
+  onValueChange?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Handler that is called when the user stops dragging.
    */
-  onValueChangeEnd?: (details: ValueChangeDetails) => void
+  onValueChangeEnd?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Handler that is called when the user opens or closes the color picker.
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * The name for the form input
    */
-  name?: string
+  name?: string | undefined
   /**
    * The positioning options for the color picker
    */
@@ -102,15 +102,15 @@ interface PublicContext extends CommonProperties, DirectionProperty, InteractOut
   /**
    * The initial focus element when the color picker is opened.
    */
-  initialFocusEl?: () => HTMLElement | null
+  initialFocusEl?: (() => HTMLElement | null) | undefined
   /**
    * Whether the color picker is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the color picker open state is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
   /**
    * The color format to use
    * @default "rgba"
@@ -119,12 +119,12 @@ interface PublicContext extends CommonProperties, DirectionProperty, InteractOut
   /**
    * Function called when the color format changes
    */
-  onFormatChange?: (details: FormatChangeDetails) => void
+  onFormatChange?: ((details: FormatChangeDetails) => void) | undefined
   /**
    * Whether to close the color picker when a swatch is selected
    * @default false
    */
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean | undefined
 }
 
 interface PrivateContext {
@@ -152,12 +152,12 @@ interface PrivateContext {
    * @internal
    * The current placement of the color picker
    */
-  currentPlacement?: PositioningOptions["placement"]
+  currentPlacement?: PositioningOptions["placement"] | undefined
   /**
    *  @internal
    * Whether the color picker should return focus to the trigger when closed
    */
-  restoreFocus?: boolean
+  restoreFocus?: boolean | undefined
 }
 
 type ComputedContext = Readonly<{
@@ -209,21 +209,21 @@ export type Service = Machine<MachineContext, MachineState, S.AnyEventObject>
 
 export interface ChannelProps {
   channel: ColorChannel
-  orientation?: Orientation
+  orientation?: Orientation | undefined
 }
 
 export interface ChannelSliderProps extends ChannelProps {
-  format?: ColorFormat
+  format?: ColorFormat | undefined
 }
 
 export interface ChannelInputProps {
   channel: ExtendedColorChannel
-  orientation?: Orientation
+  orientation?: Orientation | undefined
 }
 
 export interface AreaProps {
-  xChannel?: ColorChannel
-  yChannel?: ColorChannel
+  xChannel?: ColorChannel | undefined
+  yChannel?: ColorChannel | undefined
 }
 
 export interface SwatchTriggerProps {
@@ -234,7 +234,7 @@ export interface SwatchTriggerProps {
   /**
    * Whether the swatch trigger is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export interface SwatchTriggerState {
@@ -252,11 +252,11 @@ export interface SwatchProps {
   /**
    * Whether to include the alpha channel in the color
    */
-  respectAlpha?: boolean
+  respectAlpha?: boolean | undefined
 }
 
 export interface TransparencyGridProps {
-  size?: string
+  size?: string | undefined
 }
 
 export interface MachineApi<T extends PropTypes = PropTypes> {

--- a/packages/machines/combobox/src/combobox.types.ts
+++ b/packages/machines/combobox/src/combobox.types.ts
@@ -34,7 +34,7 @@ export interface SelectionValueDetails<T extends CollectionItem = CollectionItem
 
 export interface ScrollToIndexDetails {
   index: number
-  immediate?: boolean
+  immediate?: boolean | undefined
 }
 
 /* -----------------------------------------------------------------------------
@@ -42,8 +42,8 @@ export interface ScrollToIndexDetails {
  * -----------------------------------------------------------------------------*/
 
 export interface IntlTranslations {
-  triggerLabel?: string
-  clearTriggerLabel?: string
+  triggerLabel?: string | undefined
+  clearTriggerLabel?: string | undefined
 }
 
 export type ElementIds = Partial<{
@@ -67,15 +67,15 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
   /**
    * Whether the combobox is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the combobox open state is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
   /**
    * The ids of the elements in the combobox. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The current value of the combobox's input
    */
@@ -83,32 +83,32 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
   /**
    * The `name` attribute of the combobox's input. Useful for form submission
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the combobox.
    */
-  form?: string
+  form?: string | undefined
   /**
    * Whether the combobox is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the combobox is readonly. This puts the combobox in a "non-editable" mode
    * but the user can still interact with it
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Whether the combobox is invalid
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * Whether the combobox is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * The placeholder text of the combobox's input
    */
-  placeholder?: string
+  placeholder?: string | undefined
   /**
    * The active item's id. Used to set the `aria-activedescendant` attribute
    */
@@ -139,26 +139,26 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
   /**
    * Whether to autofocus the input on mount
    */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /**
    * Whether to open the combobox popup on initial click on the input
    * @default false
    */
-  openOnClick?: boolean
+  openOnClick?: boolean | undefined
   /**
    * Whether to show the combobox when the input value changes
    * @default true
    */
-  openOnChange?: boolean | ((details: InputValueChangeDetails) => boolean)
+  openOnChange?: boolean | ((details: InputValueChangeDetails) => boolean) | undefined
   /**
    * Whether to allow typing custom values in the input
    */
-  allowCustomValue?: boolean
+  allowCustomValue?: boolean | undefined
   /**
    * Whether to loop the keyboard navigation through the items
    * @default true
    */
-  loopFocus?: boolean
+  loopFocus?: boolean | undefined
   /**
    * The positioning options to dynamically position the menu
    */
@@ -166,20 +166,20 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
   /**
    * Function called when the input's value changes
    */
-  onInputValueChange?: (details: InputValueChangeDetails) => void
+  onInputValueChange?: ((details: InputValueChangeDetails) => void) | undefined
   /**
    * Function called when a new item is selected
    */
-  onValueChange?: (details: ValueChangeDetails<T>) => void
+  onValueChange?: ((details: ValueChangeDetails<T>) => void) | undefined
   /**
    * Function called when an item is highlighted using the pointer
    * or keyboard navigation.
    */
-  onHighlightChange?: (details: HighlightChangeDetails<T>) => void
+  onHighlightChange?: ((details: HighlightChangeDetails<T>) => void) | undefined
   /**
    * Function called when the popup is opened
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * Specifies the localized strings that identifies the accessibility elements and their states
    */
@@ -194,15 +194,15 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
    * **Good to know:** When `multiple` is `true`, the `selectionBehavior` is automatically set to `clear`.
    * It is recommended to render the selected items in a separate container.
    */
-  multiple?: boolean
+  multiple?: boolean | undefined
   /**
    * Whether to close the combobox when an item is selected.
    */
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean | undefined
   /**
    * Function to get the display value of the selected item
    */
-  getSelectionValue?: (details: SelectionValueDetails<T>) => string
+  getSelectionValue?: ((details: SelectionValueDetails<T>) => string) | undefined
   /**
    * Whether to open the combobox on arrow key press
    * @default true
@@ -211,7 +211,7 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
   /**
    * Function to scroll to a specific index
    */
-  scrollToIndexFn?: (details: ScrollToIndexDetails) => void
+  scrollToIndexFn?: ((details: ScrollToIndexDetails) => void) | undefined
   /**
    * Whether the combobox is a composed with other composite widgets like tabs
    * @default true
@@ -220,7 +220,7 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
   /**
    * Whether to disable registering this a dismissable layer
    */
-  disableLayer?: boolean
+  disableLayer?: boolean | undefined
 }
 
 export type UserDefinedContext<T extends CollectionItem = CollectionItem> = RequiredBy<
@@ -259,7 +259,7 @@ interface PrivateContext<T extends CollectionItem = CollectionItem> {
    * @internal
    * The placement of the combobox popover.
    */
-  currentPlacement?: Placement
+  currentPlacement?: Placement | undefined
   /**
    * The highlighted item
    */
@@ -297,14 +297,14 @@ export interface TriggerProps {
   /**
    * Whether the trigger is focusable
    */
-  focusable?: boolean
+  focusable?: boolean | undefined
 }
 
 export interface ItemProps {
   /**
    * Whether hovering outside should clear the highlighted state
    */
-  persistFocus?: boolean
+  persistFocus?: boolean | undefined
   /**
    * The item to render
    */

--- a/packages/machines/date-picker/src/date-picker.types.ts
+++ b/packages/machines/date-picker/src/date-picker.types.ts
@@ -88,15 +88,15 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The localized messages to use.
    */
-  translations?: IntlTranslations
+  translations?: IntlTranslations | undefined
   /**
    * The ids of the elements in the date picker. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The `name` attribute of the input element.
    */
-  name?: string
+  name?: string | undefined
   /**
    * The time zone to use
    * @default "UTC"
@@ -105,25 +105,25 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the calendar is disabled.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the calendar is read-only.
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * The minimum date that can be selected.
    */
-  min?: DateValue
+  min?: DateValue | undefined
   /**
    * The maximum date that can be selected.
    */
-  max?: DateValue
+  max?: DateValue | undefined
   /**
    * Whether the calendar should close after the date selection is complete.
    * This is ignored when the selection mode is `multiple`.
    * @default true
    */
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean | undefined
   /**
    * The selected date(s).
    */
@@ -146,32 +146,32 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    *  `5` - Friday
    *  `6` - Saturday
    */
-  startOfWeek?: number
+  startOfWeek?: number | undefined
   /**
    * Whether the calendar should have a fixed number of weeks.
    * This renders the calendar with 6 weeks instead of 5 or 6.
    */
-  fixedWeeks?: boolean
+  fixedWeeks?: boolean | undefined
   /**
    * Function called when the value changes.
    */
-  onValueChange?: (details: ValueChangeDetails) => void
+  onValueChange?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Function called when the focused date changes.
    */
-  onFocusChange?: (details: FocusChangeDetails) => void
+  onFocusChange?: ((details: FocusChangeDetails) => void) | undefined
   /**
    * Function called when the view changes.
    */
-  onViewChange?: (details: ViewChangeDetails) => void
+  onViewChange?: ((details: ViewChangeDetails) => void) | undefined
   /**
    * Function called when the calendar opens or closes.
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * Returns whether a date of the calendar is available.
    */
-  isDateUnavailable?: (date: DateValue, locale: string) => boolean
+  isDateUnavailable?: ((date: DateValue, locale: string) => boolean) | undefined
   /**
    * The selection mode of the calendar.
    * - `single` - only one date can be selected
@@ -184,7 +184,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The format of the date to display in the input.
    */
-  format?: (date: DateValue) => string
+  format?: ((date: DateValue) => string) | undefined
   /**
    * The view of the calendar
    * @default "day"
@@ -194,7 +194,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    * Whether the calendar should be modal. This means that the calendar will
    * block interaction with the rest of the page, and trap focus within it.
    */
-  modal?: boolean
+  modal?: boolean | undefined
   /**
    * The user provided options used to position the date picker content
    */
@@ -202,11 +202,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the datepicker is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the datepicker open state is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
 }
 
 interface PrivateContext {
@@ -224,12 +224,12 @@ interface PrivateContext {
    * @internal
    * Whether the calendar has focus
    */
-  hasFocus?: boolean
+  hasFocus?: boolean | undefined
   /**
    * @internal
    * The live region to announce changes
    */
-  announcer?: LiveRegion
+  announcer?: LiveRegion | undefined
   /**
    * @internal
    * The current hovered date. Useful for range selection mode.
@@ -245,12 +245,12 @@ interface PrivateContext {
    * @internal
    * The computed placement (maybe different from initial placement)
    */
-  currentPlacement?: Placement
+  currentPlacement?: Placement | undefined
   /**
    * @internal
    * Whether the calendar should restore focus to the input when it closes.
    */
-  restoreFocus?: boolean
+  restoreFocus?: boolean | undefined
 }
 
 type ComputedContext = Readonly<{
@@ -333,9 +333,9 @@ export interface DateValueOffset {
 }
 
 export interface TableCellProps {
-  disabled?: boolean
+  disabled?: boolean | undefined
   value: number
-  columns?: number
+  columns?: number | undefined
 }
 
 export interface TableCellState {
@@ -348,8 +348,8 @@ export interface TableCellState {
 
 export interface DayTableCellProps {
   value: DateValue
-  disabled?: boolean
-  visibleRange?: VisibleRange
+  disabled?: boolean | undefined
+  visibleRange?: VisibleRange | undefined
 }
 
 export interface DayTableCellState {
@@ -370,9 +370,9 @@ export interface DayTableCellState {
 }
 
 export interface TableProps {
-  view?: DateView
-  columns?: number
-  id?: string
+  view?: DateView | undefined
+  columns?: number | undefined
+  id?: string | undefined
 }
 
 export type PresetTriggerValue = DateValue[] | DateRangePreset
@@ -382,20 +382,20 @@ export interface PresetTriggerProps {
 }
 
 export interface ViewProps {
-  view?: DateView
+  view?: DateView | undefined
 }
 
 export interface InputProps {
-  index?: number
+  index?: number | undefined
 }
 
 export interface LabelProps {
-  index?: number
+  index?: number | undefined
 }
 
 export interface MonthGridProps {
-  columns?: number
-  format?: "short" | "long"
+  columns?: number | undefined
+  format?: "short" | "long" | undefined
 }
 
 export interface Cell {
@@ -406,7 +406,7 @@ export interface Cell {
 export type MonthGridValue = Cell[][]
 
 export interface YearGridProps {
-  columns?: number
+  columns?: number | undefined
 }
 
 export type YearGridValue = Cell[][]
@@ -419,7 +419,7 @@ export interface WeekDay {
 }
 
 export interface MonthFormatOptions {
-  format?: "short" | "long"
+  format?: "short" | "long" | undefined
 }
 
 export interface VisibleRangeText extends Range<string> {

--- a/packages/machines/dialog/src/dialog.types.ts
+++ b/packages/machines/dialog/src/dialog.types.ts
@@ -32,7 +32,7 @@ interface PublicContext
   /**
    * The ids of the elements in the dialog. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Whether to trap focus inside the dialog when it's opened
    * @default true
@@ -47,23 +47,23 @@ interface PublicContext
    * Whether to prevent pointer interaction outside the element and hide all content below it
    * @default true
    */
-  modal?: boolean
+  modal?: boolean | undefined
   /**
    * Element to receive focus when the dialog is opened
    */
-  initialFocusEl?: () => HTMLElement | null
+  initialFocusEl?: (() => HTMLElement | null) | undefined
   /**
    * Element to receive focus when the dialog is closed
    */
-  finalFocusEl?: () => HTMLElement | null
+  finalFocusEl?: (() => HTMLElement | null) | undefined
   /**
    * Whether to restore focus to the element that had focus before the dialog was opened
    */
-  restoreFocus?: boolean
+  restoreFocus?: boolean | undefined
   /**
    * Callback to be invoked when the dialog is opened or closed
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * Whether to close the dialog when the outside is clicked
    * @default true
@@ -77,7 +77,7 @@ interface PublicContext
   /**
    * Human readable label for the dialog, in event the dialog title is not rendered
    */
-  "aria-label"?: string
+  "aria-label"?: string | undefined
   /**
    * The dialog's role
    * @default "dialog"
@@ -86,11 +86,11 @@ interface PublicContext
   /**
    * Whether the dialog is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the dialog is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">

--- a/packages/machines/editable/src/editable.types.ts
+++ b/packages/machines/editable/src/editable.types.ts
@@ -45,23 +45,23 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
   /**
    * The ids of the elements in the editable. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Whether the input's value is invalid.
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * The name attribute of the editable component. Used for form submission.
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the underlying input.
    */
-  form?: string
+  form?: string | undefined
   /**
    * Whether the editable should auto-resize to fit the content.
    */
-  autoResize?: boolean
+  autoResize?: boolean | undefined
   /**
    * The activation mode for the preview element.
    *
@@ -86,16 +86,16 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
   /**
    * Whether the editable is in edit mode.
    */
-  edit?: boolean
+  edit?: boolean | undefined
   /**
    * Whether the editable is controlled
    */
-  "edit.controlled"?: boolean
+  "edit.controlled"?: boolean | undefined
   /**
    * Whether to select the text in the input when it is focused.
    * @default true
    */
-  selectOnFocus?: boolean
+  selectOnFocus?: boolean | undefined
   /**
    * The value of the editable in both edit and preview mode
    */
@@ -103,39 +103,39 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
   /**
    * The maximum number of characters allowed in the editable
    */
-  maxLength?: number
+  maxLength?: number | undefined
   /**
    * Whether the editable is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the editable is readonly
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Whether the editable is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * The callback that is called when the editable's value is changed
    */
-  onValueChange?: (details: ValueChangeDetails) => void
+  onValueChange?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * The callback that is called when the esc key is pressed or the cancel button is clicked
    */
-  onValueRevert?: (details: ValueChangeDetails) => void
+  onValueRevert?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * The callback that is called when the editable's value is submitted.
    */
-  onValueCommit?: (details: ValueChangeDetails) => void
+  onValueCommit?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * The callback that is called when the edit mode is changed
    */
-  onEditChange?: (details: EditChangeDetails) => void
+  onEditChange?: ((details: EditChangeDetails) => void) | undefined
   /**
    * The placeholder value to show when the `value` is empty
    */
-  placeholder?: string | { edit: string; preview: string }
+  placeholder?: string | { edit: string; preview: string } | undefined
   /**
    * Specifies the localized strings that identifies the accessibility elements and their states
    */
@@ -144,7 +144,7 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
    * The element that should receive focus when the editable is closed.
    * By default, it will focus on the trigger element.
    */
-  finalFocusEl?: () => HTMLElement | null
+  finalFocusEl?: (() => HTMLElement | null) | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">

--- a/packages/machines/file-upload/src/file-upload.types.ts
+++ b/packages/machines/file-upload/src/file-upload.types.ts
@@ -43,7 +43,7 @@ export type ElementIds = Partial<{
 }>
 
 export interface IntlTranslations {
-  dropzone?: string
+  dropzone?: string | undefined
   itemPreview?(file: File): string
   deleteFile?(file: File): string
 }
@@ -52,11 +52,11 @@ interface PublicContext extends LocaleProperties, CommonProperties {
   /**
    * The name of the underlying file input
    */
-  name?: string
+  name?: string | undefined
   /**
    * The ids of the elements. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The localized messages to use.
    */
@@ -64,20 +64,20 @@ interface PublicContext extends LocaleProperties, CommonProperties {
   /**
    * The accept file types
    */
-  accept?: Record<string, string[]> | FileMimeType | FileMimeType[]
+  accept?: Record<string, string[]> | FileMimeType | FileMimeType[] | undefined
   /**
    * Whether the file input is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the file input is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Whether to allow drag and drop in the dropzone element
    * @default true
    */
-  allowDrop?: boolean
+  allowDrop?: boolean | undefined
   /**
    * The maximum file size in bytes
    *
@@ -98,31 +98,31 @@ interface PublicContext extends LocaleProperties, CommonProperties {
   /**
    * Function to validate a file
    */
-  validate?: (file: File) => FileError[] | null
+  validate?: ((file: File) => FileError[] | null) | undefined
   /**
    * Function called when the value changes, whether accepted or rejected
    */
-  onFileChange?: (details: FileChangeDetails) => void
+  onFileChange?: ((details: FileChangeDetails) => void) | undefined
   /**
    * Function called when the file is accepted
    */
-  onFileAccept?: (details: FileAcceptDetails) => void
+  onFileAccept?: ((details: FileAcceptDetails) => void) | undefined
   /**
    * Function called when the file is rejected
    */
-  onFileReject?: (details: FileRejectDetails) => void
+  onFileReject?: ((details: FileRejectDetails) => void) | undefined
   /**
    * The default camera to use when capturing media
    */
-  capture?: "user" | "environment"
+  capture?: "user" | "environment" | undefined
   /**
    * Whether to accept directories, only works in webkit browsers
    */
-  directory?: boolean
+  directory?: boolean | undefined
   /**
    * Whether the file input is invalid
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
 }
 
 interface PrivateContext {

--- a/packages/machines/floating-panel/src/floating-panel.types.ts
+++ b/packages/machines/floating-panel/src/floating-panel.types.ts
@@ -45,7 +45,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the floating panel. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The strategy to use for positioning
    * @default "absolute"
@@ -59,17 +59,17 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the panel is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the panel is draggable
    * @default true
    */
-  draggable?: boolean
+  draggable?: boolean | undefined
   /**
    * Whether the panel is resizable
    * @default true
    */
-  resizable?: boolean
+  resizable?: boolean | undefined
   /**
    * The size of the panel
    */
@@ -77,11 +77,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The minimum size of the panel
    */
-  minSize?: Size
+  minSize?: Size | undefined
   /**
    * The maximum size of the panel
    */
-  maxSize?: Size
+  maxSize?: Size | undefined
   /**
    * The position of the panel
    */
@@ -94,11 +94,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the panel is locked to its aspect ratio
    */
-  lockAspectRatio?: boolean
+  lockAspectRatio?: boolean | undefined
   /**
    * Whether the panel should close when the escape key is pressed
    */
-  closeOnEscape?: boolean
+  closeOnEscape?: boolean | undefined
   /**
    * The boundary of the panel. Useful for recalculating the boundary rect when
    * the it is resized.
@@ -107,7 +107,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    *  Whether the panel is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Function called when the position of the panel changes via dragging
    */
@@ -131,7 +131,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the panel size and position should be preserved when it is closed
    */
-  persistRect?: boolean
+  persistRect?: boolean | undefined
   /**
    * The snap grid for the panel
    * @default 1
@@ -159,11 +159,11 @@ interface PrivateContext {
   /**
    * The stage of the panel
    */
-  stage?: Stage
+  stage?: Stage | undefined
   /**
    * Whether the panel is topmost in the panel stack
    */
-  isTopmost?: boolean
+  isTopmost?: boolean | undefined
 }
 
 type ComputedContext = Readonly<{

--- a/packages/machines/hover-card/src/hover-card.types.ts
+++ b/packages/machines/hover-card/src/hover-card.types.ts
@@ -25,11 +25,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the popover. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Function called when the hover card opens or closes.
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * The duration from when the mouse enters the trigger until the hover card opens.
    * @default 700
@@ -43,11 +43,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the hover card is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the hover card is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
   /**
    * The user provided options used to position the popover content
    */
@@ -59,12 +59,12 @@ interface PrivateContext {
    * @internal
    * The computed placement of the tooltip.
    */
-  currentPlacement?: Placement
+  currentPlacement?: Placement | undefined
   /**
    * @internal
    * Whether the hover card is open by pointer
    */
-  isPointer?: boolean
+  isPointer?: boolean | undefined
 }
 
 type ComputedContext = Readonly<{}>

--- a/packages/machines/menu/src/menu.types.ts
+++ b/packages/machines/menu/src/menu.types.ts
@@ -48,7 +48,7 @@ interface PublicContext extends DirectionProperty, CommonProperties, Dismissable
   /**
    * The ids of the elements in the menu. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The value of the highlighted menu item.
    */
@@ -56,11 +56,11 @@ interface PublicContext extends DirectionProperty, CommonProperties, Dismissable
   /**
    * Function called when the highlighted menu item changes.
    */
-  onHighlightChange?: (details: HighlightChangeDetails) => void
+  onHighlightChange?: ((details: HighlightChangeDetails) => void) | undefined
   /**
    * Function called when a menu item is selected.
    */
-  onSelect?: (details: SelectionDetails) => void
+  onSelect?: ((details: SelectionDetails) => void) | undefined
   /**
    * The positioning point for the menu. Can be set by the context menu trigger or the button trigger.
    */
@@ -82,19 +82,19 @@ interface PublicContext extends DirectionProperty, CommonProperties, Dismissable
   /**
    * The accessibility label for the menu
    */
-  "aria-label"?: string
+  "aria-label"?: string | undefined
   /**
    * Whether the menu is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Function called when the menu opens or closes
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    *  Whether the menu's open state is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
   /**
    * Whether the pressing printable characters should trigger typeahead navigation
    * @default true
@@ -158,7 +158,7 @@ interface PrivateContext {
    * @internal
    * The computed placement (maybe different from initial placement)
    */
-  currentPlacement?: Placement
+  currentPlacement?: Placement | undefined
   /**
    * @internal
    * The typeahead state for faster keyboard navigation
@@ -168,7 +168,7 @@ interface PrivateContext {
    * @internal
    * Whether to return focus to the trigger when the menu is closed
    */
-  restoreFocus?: boolean
+  restoreFocus?: boolean | undefined
 }
 
 export interface MachineContext extends PublicContext, PrivateContext, ComputedContext {}
@@ -201,16 +201,16 @@ export interface ItemProps {
   /**
    * Whether the menu item is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * The textual value of the option. Used in typeahead navigation of the menu.
    * If not provided, the text content of the menu item will be used.
    */
-  valueText?: string
+  valueText?: string | undefined
   /**
    * Whether the menu should be closed when the option is selected.
    */
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean | undefined
 }
 
 export interface OptionItemProps extends Partial<ItemProps> {

--- a/packages/machines/number-input/src/cursor.ts
+++ b/packages/machines/number-input/src/cursor.ts
@@ -3,11 +3,11 @@
  */
 
 interface Selection {
-  start?: number
-  end?: number
-  value?: string
-  beforeTxt?: string
-  afterTxt?: string
+  start?: number | undefined
+  end?: number | undefined
+  value?: string | undefined
+  beforeTxt?: string | undefined
+  afterTxt?: string | undefined
 }
 
 export function recordCursor(inputEl: HTMLInputElement): Selection | undefined {

--- a/packages/machines/number-input/src/number-input.types.ts
+++ b/packages/machines/number-input/src/number-input.types.ts
@@ -56,31 +56,31 @@ interface PublicContext extends LocaleProperties, CommonProperties {
   /**
    * The ids of the elements in the number input. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The name attribute of the number input. Useful for form submission.
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the input element.
    */
-  form?: string
+  form?: string | undefined
   /**
    * Whether the number input is disabled.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the number input is readonly
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Whether the number input value is invalid.
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * Whether the number input is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * The pattern used to check the <input> element's value against
    *
@@ -109,7 +109,7 @@ interface PublicContext extends LocaleProperties, CommonProperties {
   /**
    * Whether to allow mouse wheel to change the value
    */
-  allowMouseWheel?: boolean
+  allowMouseWheel?: boolean | undefined
   /**
    * Whether to allow the value overflow the min/max range
    * @default true
@@ -132,7 +132,7 @@ interface PublicContext extends LocaleProperties, CommonProperties {
   /**
    * The options to pass to the `Intl.NumberFormat` constructor
    */
-  formatOptions?: Intl.NumberFormatOptions
+  formatOptions?: Intl.NumberFormatOptions | undefined
   /**
    * Hints at the type of data that might be entered by the user. It also determines
    * the type of keyboard shown to the user on mobile devices
@@ -142,20 +142,20 @@ interface PublicContext extends LocaleProperties, CommonProperties {
   /**
    * Function invoked when the value changes
    */
-  onValueChange?: (details: ValueChangeDetails) => void
+  onValueChange?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Function invoked when the value overflows or underflows the min/max range
    */
-  onValueInvalid?: (details: ValueInvalidDetails) => void
+  onValueInvalid?: ((details: ValueInvalidDetails) => void) | undefined
   /**
    * Function invoked when the number input is focused
    */
-  onFocusChange?: (details: FocusChangeDetails) => void
+  onFocusChange?: ((details: FocusChangeDetails) => void) | undefined
   /**
    * Whether to spin the value when the increment/decrement button is pressed
    * @default true
    */
-  spinOnPress?: boolean
+  spinOnPress?: boolean | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">

--- a/packages/machines/pagination/src/pagination.types.ts
+++ b/packages/machines/pagination/src/pagination.types.ts
@@ -24,9 +24,9 @@ export interface ItemLabelDetails {
 }
 
 export interface IntlTranslations {
-  rootLabel?: string
-  prevTriggerLabel?: string
-  nextTriggerLabel?: string
+  rootLabel?: string | undefined
+  prevTriggerLabel?: string | undefined
+  nextTriggerLabel?: string | undefined
   itemLabel?(details: ItemLabelDetails): string
 }
 
@@ -42,7 +42,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the accordion. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Specifies the localized strings that identifies the accessibility elements and their states
    */
@@ -69,11 +69,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Called when the page number is changed
    */
-  onPageChange?: (details: PageChangeDetails) => void
+  onPageChange?: ((details: PageChangeDetails) => void) | undefined
   /**
    * Called when the page size is changed
    */
-  onPageSizeChange?: (details: PageSizeChangeDetails) => void
+  onPageSizeChange?: ((details: PageSizeChangeDetails) => void) | undefined
   /**
    * The type of the trigger element
    * @default "button"

--- a/packages/machines/pin-input/src/pin-input.types.ts
+++ b/packages/machines/pin-input/src/pin-input.types.ts
@@ -35,49 +35,49 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The name of the input element. Useful for form submission.
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the underlying input element.
    */
-  form?: string
+  form?: string | undefined
   /**
    * The regular expression that the user-entered input value is checked against.
    */
-  pattern?: string
+  pattern?: string | undefined
   /**
    * The ids of the elements in the pin input. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Whether the inputs are disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * The placeholder text for the input
    * @default "○"
    */
-  placeholder?: string
+  placeholder?: string | undefined
   /**
    * Whether to auto-focus the first input.
    */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /**
    * Whether the pin input is in the invalid state
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * Whether the pin input is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Whether the pin input is in the valid state
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * If `true`, the pin input component signals to its fields that they should
    * use `autocomplete="one-time-code"`.
    */
-  otp?: boolean
+  otp?: boolean | undefined
   /**
    * The value of the the pin input.
    */
@@ -86,31 +86,31 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    * The type of value the pin-input should allow
    * @default "numeric"
    */
-  type?: "alphanumeric" | "numeric" | "alphabetic"
+  type?: "alphanumeric" | "numeric" | "alphabetic" | undefined
   /**
    * Function called when all inputs have valid values
    */
-  onValueComplete?: (details: ValueChangeDetails) => void
+  onValueComplete?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Function called on input change
    */
-  onValueChange?: (details: ValueChangeDetails) => void
+  onValueChange?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Function called when an invalid value is entered
    */
-  onValueInvalid?: (details: ValueInvalidDetails) => void
+  onValueInvalid?: ((details: ValueInvalidDetails) => void) | undefined
   /**
    * If `true`, the input's value will be masked just like `type=password`
    */
-  mask?: boolean
+  mask?: boolean | undefined
   /**
    * Whether to blur the input when the value is complete
    */
-  blurOnComplete?: boolean
+  blurOnComplete?: boolean | undefined
   /**
    * Whether to select input value when input is focused
    */
-  selectOnFocus?: boolean
+  selectOnFocus?: boolean | undefined
   /**
    * Specifies the localized strings that identifies the accessibility elements and their states
    */

--- a/packages/machines/popover/src/popover.types.ts
+++ b/packages/machines/popover/src/popover.types.ts
@@ -34,7 +34,7 @@ interface PublicContext
   /**
    * The ids of the elements in the popover. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Whether the popover should be modal. When set to `true`:
    * - interaction with outside elements will be disabled
@@ -44,39 +44,39 @@ interface PublicContext
    *
    * @default false
    */
-  modal?: boolean
+  modal?: boolean | undefined
   /**
    * Whether the popover is portalled. This will proxy the tabbing behavior regardless of the DOM position
    * of the popover content.
    *
    * @default true
    */
-  portalled?: boolean
+  portalled?: boolean | undefined
   /**
    * Whether to automatically set focus on the first focusable
    * content within the popover when opened.
    *
    * @default true
    */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /**
    * The element to focus on when the popover is opened.
    */
-  initialFocusEl?: () => HTMLElement | null
+  initialFocusEl?: (() => HTMLElement | null) | undefined
   /**
    * Whether to close the popover when the user clicks outside of the popover.
    * @default true
    */
-  closeOnInteractOutside?: boolean
+  closeOnInteractOutside?: boolean | undefined
   /**
    * Whether to close the popover when the escape key is pressed.
    * @default true
    */
-  closeOnEscape?: boolean
+  closeOnEscape?: boolean | undefined
   /**
    * Function invoked when the popover opens or closes
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * The user provided options used to position the popover content
    */
@@ -84,11 +84,11 @@ interface PublicContext
   /**
    * Whether the popover is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the popover is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
@@ -114,7 +114,7 @@ interface PrivateContext {
    * @internal
    * The computed placement (maybe different from initial placement)
    */
-  currentPlacement?: Placement
+  currentPlacement?: Placement | undefined
 }
 
 export interface MachineContext extends PublicContext, ComputedContext, PrivateContext {}

--- a/packages/machines/presence/src/presence.types.ts
+++ b/packages/machines/presence/src/presence.types.ts
@@ -16,7 +16,7 @@ interface PublicContext {
   /**
    * Whether to synchronize the present change immediately or defer it to the next frame
    */
-  immediate?: boolean
+  immediate?: boolean | undefined
 }
 
 interface PrivateContext {
@@ -25,7 +25,7 @@ interface PrivateContext {
   styles: CSSStyleDeclaration | null
   unmountAnimationName: string | null
   prevAnimationName: string | null
-  rafId?: number
+  rafId?: number | undefined
 }
 
 export interface UserDefinedContext extends PublicContext {}

--- a/packages/machines/progress/src/progress.types.ts
+++ b/packages/machines/progress/src/progress.types.ts
@@ -40,7 +40,7 @@ interface PublicContext extends DirectionProperty, CommonProperties, Orientation
   /**
    * The ids of the elements in the progress bar. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    *  The current value of the progress bar.
    * @default 50

--- a/packages/machines/qr-code/src/qr-code.types.ts
+++ b/packages/machines/qr-code/src/qr-code.types.ts
@@ -16,11 +16,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The element ids.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The qr code encoding options.
    */
-  encoding?: QrCodeGenerateOptions
+  encoding?: QrCodeGenerateOptions | undefined
 }
 
 interface PrivateContext {

--- a/packages/machines/radio-group/src/radio-group.types.ts
+++ b/packages/machines/radio-group/src/radio-group.types.ts
@@ -23,7 +23,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the radio. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The value of the checked radio
    */
@@ -32,19 +32,19 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    * The name of the input fields in the radio
    * (Useful for form submission).
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the underlying input.
    */
-  form?: string
+  form?: string | undefined
   /**
    * If `true`, the radio group will be disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the checkbox is read-only
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Function called once a radio is checked
    * @param value the value of the checked radio
@@ -53,7 +53,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Orientation of the radio group
    */
-  orientation?: "horizontal" | "vertical"
+  orientation?: "horizontal" | "vertical" | undefined
 }
 
 interface PrivateContext {
@@ -81,12 +81,12 @@ interface PrivateContext {
    * @internal
    * Whether the active tab indicator's rect can transition
    */
-  canIndicatorTransition?: boolean
+  canIndicatorTransition?: boolean | undefined
   /**
    * @internal
    * Function to clean up the observer for the active tab's rect
    */
-  indicatorCleanup?: VoidFunction | null
+  indicatorCleanup?: VoidFunction | null | undefined
   /**
    * @internal
    * Whether the radio group's fieldset is disabled
@@ -132,8 +132,8 @@ export type Service = Machine<MachineContext, MachineState, S.AnyEventObject>
 
 export interface ItemProps {
   value: string
-  disabled?: boolean
-  invalid?: boolean
+  disabled?: boolean | undefined
+  invalid?: boolean | undefined
 }
 
 export interface ItemState {

--- a/packages/machines/rating-group/src/rating-group.types.ts
+++ b/packages/machines/rating-group/src/rating-group.types.ts
@@ -33,7 +33,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the rating. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Specifies the localized strings that identifies the accessibility elements and their states
    */
@@ -46,11 +46,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The name attribute of the rating element (used in forms).
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the underlying input element.
    */
-  form?: string
+  form?: string | undefined
   /**
    * The current rating value.
    */
@@ -58,31 +58,31 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the rating is readonly.
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Whether the rating is disabled.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the rating is required.
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Whether to allow half stars.
    */
-  allowHalf?: boolean
+  allowHalf?: boolean | undefined
   /**
    * Whether to autofocus the rating.
    */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /**
    * Function to be called when the rating value changes.
    */
-  onValueChange?: (details: ValueChangeDetails) => void
+  onValueChange?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Function to be called when the rating value is hovered.
    */
-  onHoverChange?: (details: HoverChangeDetails) => void
+  onHoverChange?: ((details: HoverChangeDetails) => void) | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">

--- a/packages/machines/select/src/select.types.ts
+++ b/packages/machines/select/src/select.types.ts
@@ -26,7 +26,7 @@ export interface OpenChangeDetails {
 
 export interface ScrollToIndexDetails {
   index: number
-  immediate?: boolean
+  immediate?: boolean | undefined
 }
 
 /* -----------------------------------------------------------------------------
@@ -58,48 +58,48 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
   /**
    * The ids of the elements in the select. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The `name` attribute of the underlying select.
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the underlying select.
    */
-  form?: string
+  form?: string | undefined
   /**
    * Whether the select is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the select is invalid
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * Whether the select is read-only
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Whether the select is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Whether the select should close after an item is selected
    * @default true
    */
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean | undefined
   /**
    * The callback fired when the highlighted item changes.
    */
-  onHighlightChange?: (details: HighlightChangeDetails<T>) => void
+  onHighlightChange?: ((details: HighlightChangeDetails<T>) => void) | undefined
   /**
    * The callback fired when the selected item changes.
    */
-  onValueChange?: (details: ValueChangeDetails<T>) => void
+  onValueChange?: ((details: ValueChangeDetails<T>) => void) | undefined
   /**
    * Function called when the popup is opened
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * The positioning options of the menu.
    */
@@ -116,23 +116,23 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
    * Whether to loop the keyboard navigation through the options
    * @default false
    */
-  loopFocus?: boolean
+  loopFocus?: boolean | undefined
   /**
    * Whether to allow multiple selection
    */
-  multiple?: boolean
+  multiple?: boolean | undefined
   /**
    * Whether the select menu is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the select's open state is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
   /**
    * Function to scroll to a specific index
    */
-  scrollToIndexFn?: (details: ScrollToIndexDetails) => void
+  scrollToIndexFn?: ((details: ScrollToIndexDetails) => void) | undefined
   /**
    * Whether the select is a composed with other composite widgets like tabs or combobox
    * @default true
@@ -143,7 +143,7 @@ interface PublicContext<T extends CollectionItem = CollectionItem>
    *
    * **Note:** this is only applicable for single selection
    */
-  deselectable?: boolean
+  deselectable?: boolean | undefined
 }
 
 interface PrivateContext<T extends CollectionItem = CollectionItem> {
@@ -156,7 +156,7 @@ interface PrivateContext<T extends CollectionItem = CollectionItem> {
    * @internal
    * The current placement of the menu
    */
-  currentPlacement?: Placement
+  currentPlacement?: Placement | undefined
   /**
    * @internal
    * Whether the fieldset is disabled
@@ -230,7 +230,7 @@ export interface ItemProps<T extends CollectionItem = CollectionItem> {
   /**
    * Whether hovering outside should clear the highlighted state
    */
-  persistFocus?: boolean
+  persistFocus?: boolean | undefined
 }
 
 export interface ItemState {

--- a/packages/machines/signature-pad/src/signature-pad.types.ts
+++ b/packages/machines/signature-pad/src/signature-pad.types.ts
@@ -21,7 +21,7 @@ export interface DrawingOptions extends StrokeOptions {
    * The color of the stroke.
    * Note: Must be a valid CSS color string, not a css variable.
    */
-  fill?: string
+  fill?: string | undefined
 }
 
 export type DataUrlType = "image/png" | "image/jpeg" | "image/svg+xml"
@@ -33,7 +33,7 @@ export interface DrawEndDetails {
 
 export interface DataUrlOptions {
   type: DataUrlType
-  quality?: number
+  quality?: number | undefined
 }
 
 export type ElementIds = Partial<{
@@ -58,11 +58,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the signature pad elements. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The translations of the signature pad. Useful for internationalization.
    */
-  translations?: IntlTranslations
+  translations?: IntlTranslations | undefined
   /**
    * Callback when the signature pad is drawing.
    */
@@ -79,19 +79,19 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the signature pad is disabled.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the signature pad is required.
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Whether the signature pad is read-only.
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * The name of the signature pad. Useful for form submission.
    */
-  name?: string
+  name?: string | undefined
 }
 
 interface PrivateContext {

--- a/packages/machines/slider/src/slider.types.ts
+++ b/packages/machines/slider/src/slider.types.ts
@@ -39,23 +39,23 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the range slider. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The aria-label of each slider thumb. Useful for providing an accessible name to the slider
    */
-  "aria-label"?: string[]
+  "aria-label"?: string[] | undefined
   /**
    * The `id` of the elements that labels each slider thumb. Useful for providing an accessible name to the slider
    */
-  "aria-labelledby"?: string[]
+  "aria-labelledby"?: string[] | undefined
   /**
    * The name associated with each slider thumb (when used in a form)
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the underlying input element.
    */
-  form?: string
+  form?: string | undefined
   /**
    * The value of the range slider
    */
@@ -63,15 +63,15 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the slider is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the slider is read-only
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Whether the slider is invalid
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * Function invoked when the value of the slider changes
    */
@@ -120,7 +120,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    *
    * @default "start"
    */
-  origin?: "start" | "center"
+  origin?: "start" | "center" | undefined
   /**
    * The alignment of the slider thumb relative to the track
    * - `center`: the thumb will extend beyond the bounds of the slider track.
@@ -128,7 +128,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    *
    * @default "contain"
    */
-  thumbAlignment?: "contain" | "center"
+  thumbAlignment?: "contain" | "center" | undefined
   /**
    * The slider thumbs dimensions
    */
@@ -216,7 +216,7 @@ export interface MarkerProps {
 
 export interface ThumbProps {
   index: number
-  name?: string
+  name?: string | undefined
 }
 
 export interface MachineApi<T extends PropTypes = PropTypes> {
@@ -300,13 +300,13 @@ export interface SharedContext {
   min: number
   max: number
   step: number
-  dir?: "ltr" | "rtl"
+  dir?: "ltr" | "rtl" | undefined
   isRtl: boolean
   isVertical: boolean
   isHorizontal: boolean
   value: number
   thumbSize: Size | null
-  thumbAlignment?: "contain" | "center"
-  orientation?: "horizontal" | "vertical"
+  thumbAlignment?: "contain" | "center" | undefined
+  orientation?: "horizontal" | "vertical" | undefined
   readonly hasMeasuredThumbSize: boolean
 }

--- a/packages/machines/splitter/src/splitter.types.ts
+++ b/packages/machines/splitter/src/splitter.types.ts
@@ -9,9 +9,9 @@ export type PanelId = string | number
 
 export interface PanelSizeData {
   id: PanelId
-  size?: number
-  minSize?: number
-  maxSize?: number
+  size?: number | undefined
+  minSize?: number | undefined
+  maxSize?: number | undefined
 }
 
 export interface SizeChangeDetails {
@@ -42,15 +42,15 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Function called when the splitter is resized.
    */
-  onSizeChange?: (details: SizeChangeDetails) => void
+  onSizeChange?: ((details: SizeChangeDetails) => void) | undefined
   /**
    * Function called when the splitter resize ends.
    */
-  onSizeChangeEnd?: (details: SizeChangeDetails) => void
+  onSizeChangeEnd?: ((details: SizeChangeDetails) => void) | undefined
   /**
    * The ids of the elements in the splitter. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
@@ -68,8 +68,8 @@ export type NormalizedPanelData = Array<
 type ComputedContext = Readonly<{
   isHorizontal: boolean
   panels: NormalizedPanelData
-  activeResizeBounds?: { min: number; max: number }
-  activeResizePanels?: { before: PanelSizeData; after: PanelSizeData }
+  activeResizeBounds?: { min: number; max: number } | undefined
+  activeResizePanels?: { before: PanelSizeData; after: PanelSizeData } | undefined
 }>
 
 interface PrivateContext {
@@ -98,13 +98,13 @@ export type Service = Machine<MachineContext, MachineState, S.AnyEventObject>
 
 export interface PanelProps {
   id: PanelId
-  snapSize?: number
+  snapSize?: number | undefined
 }
 
 export interface ResizeTriggerProps {
   id: `${PanelId}:${PanelId}`
-  step?: number
-  disabled?: boolean
+  step?: number | undefined
+  disabled?: boolean | undefined
 }
 
 export interface ResizeTriggerState {

--- a/packages/machines/steps/src/steps.types.ts
+++ b/packages/machines/steps/src/steps.types.ts
@@ -14,8 +14,8 @@ export interface StepChangeDetails {
  * -----------------------------------------------------------------------------*/
 
 export interface ElementIds {
-  root?: string
-  list?: string
+  root?: string | undefined
+  list?: string | undefined
   triggerId?(index: number): string
   contentId?(index: number): string
 }
@@ -24,7 +24,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The custom ids for the stepper elements
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The current value of the stepper
    */
@@ -36,15 +36,15 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Callback to be called when a step is completed
    */
-  onStepComplete?: VoidFunction
+  onStepComplete?: VoidFunction | undefined
   /**
    * If `true`, the stepper requires the user to complete the steps in order
    */
-  linear?: boolean
+  linear?: boolean | undefined
   /**
    * The orientation of the stepper
    */
-  orientation?: "horizontal" | "vertical"
+  orientation?: "horizontal" | "vertical" | undefined
   /**
    * The total number of steps
    */

--- a/packages/machines/switch/src/switch.types.ts
+++ b/packages/machines/switch/src/switch.types.ts
@@ -25,7 +25,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the switch. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Specifies the localized strings that identifies the accessibility elements and their states
    */
@@ -33,23 +33,23 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the switch is disabled.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * If `true`, the switch is marked as invalid.
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * If `true`, the switch input is marked as required,
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Whether the switch is read-only
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Function to call when the switch is clicked.
    */
-  onCheckedChange?: (details: CheckedChangeDetails) => void
+  onCheckedChange?: ((details: CheckedChangeDetails) => void) | undefined
   /**
    * Whether the switch is checked.
    */
@@ -58,16 +58,16 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    * The name of the input field in a switch
    * (Useful for form submission).
    */
-  name?: string
+  name?: string | undefined
   /**
    * The id of the form that the switch belongs to
    */
-  form?: string
+  form?: string | undefined
   /**
    * The value of switch input. Useful for form submission.
    * @default "on"
    */
-  value?: string | number
+  value?: string | number | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
@@ -84,22 +84,22 @@ interface PrivateContext {
    * @internal
    * Whether the checkbox is pressed
    */
-  active?: boolean
+  active?: boolean | undefined
   /**
    * @internal
    * Whether the checkbox has focus
    */
-  focused?: boolean
+  focused?: boolean | undefined
   /**
    * @internal
    * Whether the checkbox has focus visible
    */
-  focusVisible?: boolean
+  focusVisible?: boolean | undefined
   /**
    * @internal
    * Whether the checkbox is hovered
    */
-  hovered?: boolean
+  hovered?: boolean | undefined
   /**
    * @internal
    * Whether the checkbox fieldset is disabled

--- a/packages/machines/tabs/src/tabs.types.ts
+++ b/packages/machines/tabs/src/tabs.types.ts
@@ -18,7 +18,7 @@ export interface FocusChangeDetails {
  * -----------------------------------------------------------------------------*/
 
 export interface IntlTranslations {
-  listLabel?: string
+  listLabel?: string | undefined
 }
 
 export type ElementIds = Partial<{
@@ -33,11 +33,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the tabs. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Specifies the localized strings that identifies the accessibility elements and their states
    */
-  translations?: IntlTranslations
+  translations?: IntlTranslations | undefined
   /**
    * Whether the keyboard navigation will loop from last tab to first, and vice versa.
    * @default true
@@ -54,7 +54,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    *
    * @default "horizontal"
    */
-  orientation?: "horizontal" | "vertical"
+  orientation?: "horizontal" | "vertical" | undefined
   /**
    * The activation mode of the tabs. Can be `manual` or `automatic`
    * - `manual`: Tabs are activated when clicked or press `enter` key.
@@ -62,15 +62,15 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    *
    * @default "automatic"
    */
-  activationMode?: "manual" | "automatic"
+  activationMode?: "manual" | "automatic" | undefined
   /**
    * Callback to be called when the selected/active tab changes
    */
-  onValueChange?: (details: ValueChangeDetails) => void
+  onValueChange?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Callback to be called when the focused tab changes
    */
-  onFocusChange?: (details: FocusChangeDetails) => void
+  onFocusChange?: ((details: FocusChangeDetails) => void) | undefined
   /**
    * Whether the tab is composite
    */
@@ -78,7 +78,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the active tab can be deselected when clicking on it.
    */
-  deselectable?: boolean
+  deselectable?: boolean | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
@@ -106,7 +106,7 @@ interface PrivateContext {
    * @internal
    * Function to clean up the observer for the active tab's rect
    */
-  indicatorCleanup?: VoidFunction | null
+  indicatorCleanup?: VoidFunction | null | undefined
   /**
    * @internal
    * Whether the radio group is in server-side rendering
@@ -138,7 +138,7 @@ export interface TriggerProps {
   /**
    * Whether the tab is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export interface TriggerState {

--- a/packages/machines/tags-input/src/tags-input.types.ts
+++ b/packages/machines/tags-input/src/tags-input.types.ts
@@ -43,7 +43,7 @@ export interface IntlTranslations {
   tagEdited(value: string): string
   tagUpdated(value: string): string
   tagDeleted(value: string): string
-  noTagsSelected?: string
+  noTagsSelected?: string | undefined
   inputLabel?(count: number): string
 }
 
@@ -69,7 +69,7 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
   /**
    * The ids of the elements in the tags input. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Specifies the localized strings that identifies the accessibility elements and their states
    */
@@ -77,7 +77,7 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
   /**
    * The max length of the input.
    */
-  maxLength?: number
+  maxLength?: number | undefined
   /**
    * The character that serves has:
    * - event key to trigger the addition of a new tag
@@ -85,32 +85,32 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
    *
    * @default ","
    */
-  delimiter?: string | RegExp
+  delimiter?: string | RegExp | undefined
   /**
    * Whether the input should be auto-focused
    */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /**
    * Whether the tags input should be disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the tags input should be read-only
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * Whether the tags input is invalid
    */
-  invalid?: boolean
+  invalid?: boolean | undefined
   /**
    * Whether the tags input is required
    */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Whether a tag can be edited after creation, by presing `Enter` or double clicking.
    * @default true
    */
-  editable?: boolean
+  editable?: boolean | undefined
   /**
    * The tag input's value
    */
@@ -145,12 +145,12 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
    * - `"add"`: add the input value as a new tag
    * - `"clear"`: clear the input value
    */
-  blurBehavior?: "clear" | "add"
+  blurBehavior?: "clear" | "add" | undefined
   /**
    * Whether to add a tag when you paste values into the tag input
    * @default false
    */
-  addOnPaste?: boolean
+  addOnPaste?: boolean | undefined
   /**
    * The max number of tags
    * @default Infinity
@@ -160,15 +160,15 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
    * Whether to allow tags to exceed max. In this case,
    * we'll attach `data-invalid` to the root
    */
-  allowOverflow?: boolean
+  allowOverflow?: boolean | undefined
   /**
    * The name attribute for the input. Useful for form submissions
    */
-  name?: string
+  name?: string | undefined
   /**
    * The associate form of the underlying input element.
    */
-  form?: string
+  form?: string | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
@@ -231,7 +231,7 @@ interface PrivateContext {
    * @internal
    * The index of the deleted tag. Used to determine the next tag to focus.
    */
-  idx?: number
+  idx?: number | undefined
   /**
    * @internal
    * The `id` of the currently edited tag
@@ -267,7 +267,7 @@ export type Send = S.Send<S.AnyEventObject>
 export interface ItemProps {
   index: string | number
   value: string
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export interface ItemState {

--- a/packages/machines/time-picker/src/time-picker.types.ts
+++ b/packages/machines/time-picker/src/time-picker.types.ts
@@ -51,19 +51,19 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the timepicker is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the timepicker open state is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
   /**
    * The ids of the elements in the date picker. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The `name` attribute of the input element.
    */
-  name?: string
+  name?: string | undefined
   /**
    * The user provided options used to position the time picker content
    */
@@ -71,47 +71,47 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The placeholder text of the input.
    */
-  placeholder?: string
+  placeholder?: string | undefined
   /**
    * Whether the time picker is disabled.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the time picker is read-only.
    */
-  readOnly?: boolean
+  readOnly?: boolean | undefined
   /**
    * The minimum time that can be selected.
    */
-  min?: Time
+  min?: Time | undefined
   /**
    * The maximum time that can be selected.
    */
-  max?: Time
+  max?: Time | undefined
   /**
    * The steps of each time unit.
    */
-  steps?: { hour?: number; minute?: number; second?: number }
+  steps?: { hour?: number; minute?: number; second?: number } | undefined
   /**
    * Whether to show the seconds.
    */
-  allowSeconds?: boolean
+  allowSeconds?: boolean | undefined
   /**
    * Function called when the value changes.
    */
-  onValueChange?: (value: ValueChangeDetails) => void
+  onValueChange?: ((value: ValueChangeDetails) => void) | undefined
   /**
    * Function called when the time picker opens or closes.
    */
-  onOpenChange?: (details: OpenChangeDetails) => void
+  onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
    * Function called when the focused date changes.
    */
-  onFocusChange?: (details: FocusChangeDetails) => void
+  onFocusChange?: ((details: FocusChangeDetails) => void) | undefined
   /**
    * Whether to disable the interaction outside logic
    */
-  disableLayer?: boolean
+  disableLayer?: boolean | undefined
 }
 
 interface PrivateContext {
@@ -119,12 +119,12 @@ interface PrivateContext {
    * @internal
    * The computed placement (maybe different from initial placement)
    */
-  currentPlacement?: Placement
+  currentPlacement?: Placement | undefined
   /**
    * @internal
    * Whether the calendar should restore focus to the input when it closes.
    */
-  restoreFocus?: boolean
+  restoreFocus?: boolean | undefined
   /**
    * The focused unit column
    */

--- a/packages/machines/toast/src/toast.types.ts
+++ b/packages/machines/toast/src/toast.types.ts
@@ -15,11 +15,11 @@ export interface GenericOptions<T = string> {
   /**
    * The title of the toast.
    */
-  title?: T
+  title?: T | undefined
   /**
    * The description of the toast.
    */
-  description?: T
+  description?: T | undefined
 }
 
 export interface StatusChangeDetails {
@@ -50,24 +50,24 @@ export interface Options<T> extends GenericOptions<T> {
   /**
    * The duration the toast will be visible
    */
-  duration?: number
+  duration?: number | undefined
   /**
    * The duration for the toast to kept alive before it is removed.
    * Useful for exit transitions.
    */
-  removeDelay?: number
+  removeDelay?: number | undefined
   /**
    * The placement of the toast
    */
-  placement?: Placement
+  placement?: Placement | undefined
   /**
    * The unique id of the toast
    */
-  id?: string
+  id?: string | undefined
   /**
    * The type of the toast
    */
-  type?: Type
+  type?: Type | undefined
   /**
    * Function called when the toast is visible
    */
@@ -75,11 +75,11 @@ export interface Options<T> extends GenericOptions<T> {
   /**
    * The action of the toast
    */
-  action?: ActionOptions
+  action?: ActionOptions | undefined
   /**
    * The metadata of the toast
    */
-  meta?: Record<string, any>
+  meta?: Record<string, any> | undefined
 }
 
 /* -----------------------------------------------------------------------------
@@ -98,7 +98,7 @@ export interface MachineContext<T = any>
   /**
    * The document's text/writing direction.
    */
-  dir?: Direction
+  dir?: Direction | undefined
   /**
    * The time the toast was created
    */
@@ -144,7 +144,7 @@ interface MachinePrivateContext {
    * @internal
    * Whether the toast is stacked
    */
-  stacked?: boolean
+  stacked?: boolean | undefined
 }
 
 export interface MachineState {
@@ -191,7 +191,7 @@ interface GroupPublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the toasts should overlap each other
    */
-  overlap?: boolean
+  overlap?: boolean | undefined
   /**
    * The placement of the toast
    */
@@ -206,7 +206,7 @@ interface GroupPublicContext extends DirectionProperty, CommonProperties {
   /**
    * The duration the toast will be visible
    */
-  duration?: number
+  duration?: number | undefined
 }
 
 export interface UserDefinedGroupContext extends RequiredBy<GroupPublicContext, "id"> {}
@@ -233,7 +233,7 @@ interface GroupPrivateContext<T> extends GenericOptions<T> {
   /**
    * @internal
    */
-  _cleanup?: VoidFunction
+  _cleanup?: VoidFunction | undefined
   /**
    * @internal
    */
@@ -269,7 +269,7 @@ export interface PromiseOptions<V, O = any> {
   loading: Options<O>
   success: MaybeFunction<Options<O>, V>
   error: MaybeFunction<Options<O>, Error>
-  finally?: () => void | Promise<void>
+  finally?: (() => void | Promise<void>) | undefined
 }
 
 export interface GroupProps {
@@ -280,7 +280,7 @@ export interface GroupProps {
   /**
    * The human-readable label for the toast region
    */
-  label?: string
+  label?: string | undefined
 }
 
 export interface GroupMachineApi<T extends PropTypes = PropTypes, O = any> {

--- a/packages/machines/toggle-group/src/toggle-group.types.ts
+++ b/packages/machines/toggle-group/src/toggle-group.types.ts
@@ -22,11 +22,11 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the toggle. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * Whether the toggle is disabled.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * The values of the toggles in the group.
    */
@@ -34,7 +34,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Function to call when the toggle is clicked.
    */
-  onValueChange?: (details: ValueChangeDetails) => void
+  onValueChange?: ((details: ValueChangeDetails) => void) | undefined
   /**
    * Whether to loop focus inside the toggle group.
    * @default true
@@ -44,7 +44,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    *  Whether to use roving tab index to manage focus.
    * @default true
    */
-  rovingFocus?: boolean
+  rovingFocus?: boolean | undefined
   /**
    * The orientation of the toggle group.
    * @default "horizontal"
@@ -53,7 +53,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether to allow multiple toggles to be selected.
    */
-  multiple?: boolean
+  multiple?: boolean | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
@@ -104,7 +104,7 @@ export type Service = Machine<MachineContext, MachineState, S.AnyEventObject>
 
 export interface ItemProps {
   value: string
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export interface ItemState {

--- a/packages/machines/tooltip/src/tooltip.types.ts
+++ b/packages/machines/tooltip/src/tooltip.types.ts
@@ -25,7 +25,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the elements in the tooltip. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The `id` of the tooltip.
    */
@@ -49,17 +49,17 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    * Whether to close the tooltip when the Escape key is pressed.
    * @default true
    */
-  closeOnEscape?: boolean
+  closeOnEscape?: boolean | undefined
   /**
    * Whether the tooltip should close on scroll
    * @default true
    */
-  closeOnScroll?: boolean
+  closeOnScroll?: boolean | undefined
   /**
    * Whether the tooltip should close on click
    * @default true
    */
-  closeOnClick?: boolean
+  closeOnClick?: boolean | undefined
   /**
    * Whether the tooltip's content is interactive.
    * In this mode, the tooltip will remain open when user hovers over the content.
@@ -75,7 +75,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Custom label for the tooltip.
    */
-  "aria-label"?: string
+  "aria-label"?: string | undefined
   /**
    * The user provided options used to position the popover content
    */
@@ -83,15 +83,15 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Whether the tooltip is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Whether the tooltip is open
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Whether the tooltip is controlled by the user
    */
-  "open.controlled"?: boolean
+  "open.controlled"?: boolean | undefined
 }
 
 export type UserDefinedContext = RequiredBy<PublicContext, "id">
@@ -108,12 +108,12 @@ interface PrivateContext {
    * @internal
    * The computed placement of the tooltip.
    */
-  currentPlacement?: Placement
+  currentPlacement?: Placement | undefined
   /**
    * @internal
    * Whether the pointermove already opened the tooltip.
    */
-  hasPointerMoveOpened?: boolean
+  hasPointerMoveOpened?: boolean | undefined
 }
 
 export interface MachineContext extends PublicContext, ComputedContext, PrivateContext {}

--- a/packages/machines/tour/src/tour.types.ts
+++ b/packages/machines/tour/src/tour.types.ts
@@ -14,7 +14,7 @@ export interface StepEffectArgs {
   dismiss(): void
   show(): void
   update(data: Partial<StepBaseDetails>): void
-  target?: () => HTMLElement | null
+  target?: (() => HTMLElement | null) | undefined
 }
 
 export type StepType = "tooltip" | "dialog" | "wait" | "floating"
@@ -33,11 +33,11 @@ export interface StepAction {
   /**
    * The action to perform
    */
-  action?: StepActionType | StepActionFn
+  action?: StepActionType | StepActionFn | undefined
   /**
    * The attributes to apply to the action trigger
    */
-  attrs?: Record<string, any>
+  attrs?: Record<string, any> | undefined
 }
 
 export interface StepBaseDetails {
@@ -45,7 +45,7 @@ export interface StepBaseDetails {
    * The type of the step. If no target is provided,
    * the step will be treated as a modal step.
    */
-  type?: StepType
+  type?: StepType | undefined
   /**
    * Function to return the target element to highlight
    */
@@ -61,27 +61,27 @@ export interface StepBaseDetails {
   /**
    * The placement of the step
    */
-  placement?: StepPlacement
+  placement?: StepPlacement | undefined
   /**
    * The offset between the content and the target
    */
-  offset?: { mainAxis?: number; crossAxis?: number }
+  offset?: { mainAxis?: number; crossAxis?: number } | undefined
   /**
    * Additional metadata of the step
    */
-  meta?: Record<string, any>
+  meta?: Record<string, any> | undefined
   /**
    * Whether to show a backdrop behind the step
    */
-  backdrop?: boolean
+  backdrop?: boolean | undefined
   /**
    * Whether to show an arrow tip on the step
    */
-  arrow?: boolean
+  arrow?: boolean | undefined
   /**
    * The actions to perform when the step is completed
    */
-  actions?: StepAction[]
+  actions?: StepAction[] | undefined
 }
 
 export interface StepDetails extends StepBaseDetails {
@@ -125,10 +125,10 @@ export interface ProgressTextDetails {
 
 export interface IntlTranslations {
   progressText?(details: ProgressTextDetails): string
-  nextStep?: string
-  prevStep?: string
-  close?: string
-  skip?: string
+  nextStep?: string | undefined
+  prevStep?: string | undefined
+  close?: string | undefined
+  skip?: string | undefined
 }
 
 export type ElementIds = Partial<{
@@ -148,7 +148,7 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
   /**
    * The ids of the elements in the tour. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The steps of the tour
    */
@@ -211,7 +211,7 @@ interface PrivateContext {
    * @internal
    * The current placement of the menu
    */
-  currentPlacement?: StepPlacement
+  currentPlacement?: StepPlacement | undefined
   /**
    * @internal
    * The size of the boundary element (default to the window size)
@@ -221,12 +221,12 @@ interface PrivateContext {
    * @internal
    * The function to cleanup the target attributes
    */
-  _targetCleanup?: VoidFunction
+  _targetCleanup?: VoidFunction | undefined
   /**
    * @internal
    * The function to cleanup the step effects
    */
-  _effectCleanup?: VoidFunction
+  _effectCleanup?: VoidFunction | undefined
   /**
    * @internal
    * The resolved target element

--- a/packages/machines/tour/src/utils/wait.ts
+++ b/packages/machines/tour/src/utils/wait.ts
@@ -2,7 +2,7 @@ import { getDocument, getWindow } from "@zag-js/dom-query"
 
 export interface WaitOptions {
   timeout: number
-  rootNode?: Document | ShadowRoot
+  rootNode?: Document | ShadowRoot | undefined
 }
 
 type WaitForPromiseReturn<T> = [Promise<T>, () => void]

--- a/packages/machines/tree-view/src/tree-view.dom.ts
+++ b/packages/machines/tree-view/src/tree-view.dom.ts
@@ -2,8 +2,8 @@ import { createScope, getByTypeahead, isHTMLElement, isHiddenElement, query, que
 import type { MachineContext as Ctx } from "./tree-view.types"
 
 interface TreeWalkerOpts {
-  skipHidden?: boolean
-  root?: HTMLElement | null
+  skipHidden?: boolean | undefined
+  root?: HTMLElement | null | undefined
 }
 
 export const dom = createScope({

--- a/packages/machines/tree-view/src/tree-view.types.ts
+++ b/packages/machines/tree-view/src/tree-view.types.ts
@@ -32,7 +32,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * The ids of the tree elements. Useful for composition.
    */
-  ids?: ElementIds
+  ids?: ElementIds | undefined
   /**
    * The id of the expanded nodes
    */
@@ -56,25 +56,25 @@ interface PublicContext extends DirectionProperty, CommonProperties {
   /**
    * Called when the tree is opened or closed
    */
-  onExpandedChange?: (details: ExpandedChangeDetails) => void
+  onExpandedChange?: ((details: ExpandedChangeDetails) => void) | undefined
   /**
    * Called when the selection changes
    */
-  onSelectionChange?: (details: SelectionChangeDetails) => void
+  onSelectionChange?: ((details: SelectionChangeDetails) => void) | undefined
   /**
    * Called when the focused node changes
    */
-  onFocusChange?: (details: FocusChangeDetails) => void
+  onFocusChange?: ((details: FocusChangeDetails) => void) | undefined
   /**
    * Whether clicking on a branch should open it or not
    * @default true
    */
-  expandOnClick?: boolean
+  expandOnClick?: boolean | undefined
   /**
    * Whether the tree supports typeahead search
    * @default true
    */
-  typeahead?: boolean
+  typeahead?: boolean | undefined
 }
 
 interface PrivateContext {
@@ -128,7 +128,7 @@ export interface ItemProps {
   /**
    * Whether the item or branch is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export interface BranchProps extends ItemProps {}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,7 +13,7 @@ export interface OrientationProperty {
    * The orientation of the element.
    * @default "horizontal"
    */
-  orientation?: Orientation
+  orientation?: Orientation | undefined
 }
 
 export interface DirectionProperty {
@@ -21,7 +21,7 @@ export interface DirectionProperty {
    * The document's text/writing direction.
    * @default "ltr"
    */
-  dir?: "ltr" | "rtl"
+  dir?: "ltr" | "rtl" | undefined
 }
 
 export interface LocaleProperties extends DirectionProperty {
@@ -29,7 +29,7 @@ export interface LocaleProperties extends DirectionProperty {
    * The current locale. Based on the BCP 47 definition.
    * @default "en-US"
    */
-  locale?: string
+  locale?: string | undefined
 }
 
 export interface CommonProperties {
@@ -40,7 +40,7 @@ export interface CommonProperties {
   /**
    * A root node to correctly resolve document in custom environments. E.x.: Iframes, Electron.
    */
-  getRootNode?: () => ShadowRoot | Document | Node
+  getRootNode?: (() => ShadowRoot | Document | Node) | undefined
 }
 
 export type Style = JSX.CSSProperties

--- a/packages/types/src/prop-types.ts
+++ b/packages/types/src/prop-types.ts
@@ -3,43 +3,43 @@ import type { JSX } from "./jsx"
 type Dict<T = any> = Record<string, T>
 
 type DataAttr = {
-  "data-selected"?: any
-  "data-expanded"?: any
-  "data-highlighted"?: any
-  "data-readonly"?: any
-  "data-indeterminate"?: any
-  "data-invalid"?: any
-  "data-hover"?: any
-  "data-active"?: any
-  "data-focus"?: any
-  "data-focus-visible"?: any
-  "data-disabled"?: any
-  "data-open"?: any
-  "data-checked"?: any
-  "data-pressed"?: any
-  "data-complete"?: any
-  "data-side"?: any
-  "data-align"?: any
-  "data-empty"?: any
-  "data-placeholder-shown"?: any
-  "data-half"?: any
-  "data-scope"?: string
-  "data-uid"?: string
-  "data-name"?: string
-  "data-ownedby"?: string
-  "data-type"?: string
-  "data-valuetext"?: string
-  "data-placement"?: string
-  "data-controls"?: string
-  "data-part"?: string
-  "data-label"?: string
-  "data-state"?: string | null
-  "data-value"?: string | number
-  "data-orientation"?: "horizontal" | "vertical"
-  "data-count"?: number
-  "data-index"?: number
+  "data-selected"?: any | undefined
+  "data-expanded"?: any | undefined
+  "data-highlighted"?: any | undefined
+  "data-readonly"?: any | undefined
+  "data-indeterminate"?: any | undefined
+  "data-invalid"?: any | undefined
+  "data-hover"?: any | undefined
+  "data-active"?: any | undefined
+  "data-focus"?: any | undefined
+  "data-focus-visible"?: any | undefined
+  "data-disabled"?: any | undefined
+  "data-open"?: any | undefined
+  "data-checked"?: any | undefined
+  "data-pressed"?: any | undefined
+  "data-complete"?: any | undefined
+  "data-side"?: any | undefined
+  "data-align"?: any | undefined
+  "data-empty"?: any | undefined
+  "data-placeholder-shown"?: any | undefined
+  "data-half"?: any | undefined
+  "data-scope"?: string | undefined
+  "data-uid"?: string | undefined
+  "data-name"?: string | undefined
+  "data-ownedby"?: string | undefined
+  "data-type"?: string | undefined
+  "data-valuetext"?: string | undefined
+  "data-placement"?: string | undefined
+  "data-controls"?: string | undefined
+  "data-part"?: string | undefined
+  "data-label"?: string | undefined
+  "data-state"?: string | null | undefined
+  "data-value"?: string | number | undefined
+  "data-orientation"?: "horizontal" | "vertical" | undefined
+  "data-count"?: number | undefined
+  "data-index"?: number | undefined
 } & {
-  [key in `data-${string}`]?: any
+  [key in `data-${string}`]?: any | undefined
 }
 
 export type PropTypes<T = Dict> = Record<

--- a/packages/utilities/collection/src/types.ts
+++ b/packages/utilities/collection/src/types.ts
@@ -6,7 +6,7 @@ export interface CollectionSearchState {
 export interface CollectionSearchOptions {
   state: CollectionSearchState
   currentValue: string | null
-  timeout?: number
+  timeout?: number | undefined
 }
 
 export type CollectionItem = any

--- a/packages/utilities/color-utils/src/area-gradient.ts
+++ b/packages/utilities/color-utils/src/area-gradient.ts
@@ -15,7 +15,7 @@ import type { ColorChannel } from "./types"
 interface GradientOptions {
   xChannel: ColorChannel
   yChannel: ColorChannel
-  dir?: "rtl" | "ltr"
+  dir?: "rtl" | "ltr" | undefined
 }
 
 interface GradientStyles {

--- a/packages/utilities/dismissable/src/dismissable-layer.ts
+++ b/packages/utilities/dismissable/src/dismissable-layer.ts
@@ -18,7 +18,7 @@ export interface DismissableElementHandlers extends InteractOutsideHandlers {
   /**
    * Function called when the escape key is pressed
    */
-  onEscapeKeyDown?: (event: KeyboardEvent) => void
+  onEscapeKeyDown?: ((event: KeyboardEvent) => void) | undefined
 }
 
 export interface PersistentElementOptions {
@@ -27,18 +27,18 @@ export interface PersistentElementOptions {
    * - should not have pointer-events disabled
    * - should not trigger the dismiss event
    */
-  persistentElements?: Array<() => Element | null>
+  persistentElements?: Array<() => Element | null> | undefined
 }
 
 export interface DismissableElementOptions extends DismissableElementHandlers, PersistentElementOptions {
   /**
    * Whether to log debug information
    */
-  debug?: boolean
+  debug?: boolean | undefined
   /**
    * Whether to block pointer events outside the dismissable element
    */
-  pointerBlocking?: boolean
+  pointerBlocking?: boolean | undefined
   /**
    * Function called when the dismissable element is dismissed
    */
@@ -46,11 +46,11 @@ export interface DismissableElementOptions extends DismissableElementHandlers, P
   /**
    * Exclude containers from the interact outside event
    */
-  exclude?: MaybeFunction<Container>
+  exclude?: MaybeFunction<Container> | undefined
   /**
    * Defer the interact outside event to the next frame
    */
-  defer?: boolean
+  defer?: boolean | undefined
 }
 
 function trackDismissableElementImpl(node: MaybeElement, options: DismissableElementOptions) {

--- a/packages/utilities/dismissable/src/layer-stack.ts
+++ b/packages/utilities/dismissable/src/layer-stack.ts
@@ -3,7 +3,7 @@ import { contains } from "@zag-js/dom-query"
 export interface Layer {
   dismiss: VoidFunction
   node: HTMLElement
-  pointerBlocking?: boolean
+  pointerBlocking?: boolean | undefined
 }
 
 export const layerStack = {

--- a/packages/utilities/dom-event/src/track-press.ts
+++ b/packages/utilities/dom-event/src/track-press.ts
@@ -27,7 +27,7 @@ export interface TrackPressOptions {
   /**
    * The element that will be used to track the keyboard focus events.
    */
-  keyboardNode?: Element | null
+  keyboardNode?: Element | null | undefined
   /**
    * A function that determines if the key is valid for the press event.
    */

--- a/packages/utilities/dom-event/src/types.ts
+++ b/packages/utilities/dom-event/src/types.ts
@@ -23,6 +23,6 @@ export type EventKeyMap = {
 }
 
 export interface EventKeyOptions {
-  dir?: "ltr" | "rtl"
-  orientation?: "horizontal" | "vertical"
+  dir?: "ltr" | "rtl" | undefined
+  orientation?: "horizontal" | "vertical" | undefined
 }

--- a/packages/utilities/dom-query/src/data-url.ts
+++ b/packages/utilities/dom-query/src/data-url.ts
@@ -4,7 +4,7 @@ export type DataUrlType = "image/png" | "image/jpeg" | "image/svg+xml"
 
 export interface DataUrlOptions {
   type: DataUrlType
-  quality?: number
+  quality?: number | undefined
 }
 
 export function getDataUrl(svg: SVGElement | undefined | null, opts: DataUrlOptions): Promise<string> {

--- a/packages/utilities/dom-query/src/get-by-typeahead.ts
+++ b/packages/utilities/dom-query/src/get-by-typeahead.ts
@@ -10,8 +10,8 @@ export interface TypeaheadOptions {
   state: TypeaheadState
   activeId: string | null
   key: string
-  timeout?: number
-  itemToId?: ItemToId<HTMLElement>
+  timeout?: number | undefined
+  itemToId?: ItemToId<HTMLElement> | undefined
 }
 
 function getByTypeaheadImpl<T extends HTMLElement>(_items: T[], options: TypeaheadOptions) {

--- a/packages/utilities/dom-query/src/initial-focus.ts
+++ b/packages/utilities/dom-query/src/initial-focus.ts
@@ -2,9 +2,9 @@ import { getTabbableEdges, getTabbables } from "./tabbable"
 
 export interface InitialFocusOptions {
   root: HTMLElement | null
-  getInitialEl?: () => HTMLElement | null
-  enabled?: boolean
-  filter?: (el: HTMLElement) => boolean
+  getInitialEl?: (() => HTMLElement | null) | undefined
+  enabled?: boolean | undefined
+  filter?: ((el: HTMLElement) => boolean) | undefined
 }
 
 export function getInitialFocus(options: InitialFocusOptions): HTMLElement | undefined {

--- a/packages/utilities/dom-query/src/observe-attributes.ts
+++ b/packages/utilities/dom-query/src/observe-attributes.ts
@@ -6,7 +6,7 @@ type NodeOrFn = MaybeElement | (() => MaybeElement)
 export interface ObserveAttributeOptions {
   attributes: string[]
   callback(record: MutationRecord): void
-  defer?: boolean
+  defer?: boolean | undefined
 }
 
 function observeAttributesImpl(node: MaybeElement, options: ObserveAttributeOptions) {

--- a/packages/utilities/dom-query/src/observe-children.ts
+++ b/packages/utilities/dom-query/src/observe-children.ts
@@ -5,7 +5,7 @@ type NodeOrFn = MaybeElement | (() => MaybeElement)
 
 export interface ObserveChildrenOptions {
   callback: MutationCallback
-  defer?: boolean
+  defer?: boolean | undefined
 }
 
 function observeChildrenImpl(node: MaybeElement, options: ObserveChildrenOptions) {

--- a/packages/utilities/dom-query/src/proxy-tab-focus.ts
+++ b/packages/utilities/dom-query/src/proxy-tab-focus.ts
@@ -5,9 +5,9 @@ type MaybeElement = HTMLElement | null
 type NodeOrFn = MaybeElement | (() => MaybeElement)
 
 interface ProxyTabFocusOptions<T = MaybeElement> {
-  triggerElement?: T
-  onFocus?: (elementToFocus: HTMLElement) => void
-  defer?: boolean
+  triggerElement?: T | undefined
+  onFocus?: ((elementToFocus: HTMLElement) => void) | undefined
+  defer?: boolean | undefined
 }
 
 /**

--- a/packages/utilities/dom-query/src/types.ts
+++ b/packages/utilities/dom-query/src/types.ts
@@ -1,6 +1,6 @@
 interface VirtualElement {
   getBoundingClientRect(): DOMRect
-  contextElement?: Element
+  contextElement?: Element | undefined
 }
 
 export type MeasurableElement = Element | VirtualElement

--- a/packages/utilities/element-size/src/track-sizes.ts
+++ b/packages/utilities/element-size/src/track-sizes.ts
@@ -2,7 +2,7 @@ import { trackElementSize, type ElementSize } from "./track-size"
 
 export interface TrackElementsSizeOptions<T extends HTMLElement | null> {
   getNodes: () => T[]
-  observeMutation?: boolean
+  observeMutation?: boolean | undefined
   callback: (size: ElementSize | undefined, index: number) => void
 }
 

--- a/packages/utilities/file-utils/src/download-file.ts
+++ b/packages/utilities/file-utils/src/download-file.ts
@@ -7,11 +7,11 @@ interface DownloadFileOptions {
   /**
    * The name of the file
    */
-  name?: string
+  name?: string | undefined
   /**
    * The MIME type of the file
    */
-  type?: string
+  type?: string | undefined
   /**
    * The file contents
    */

--- a/packages/utilities/focus-visible/src/index.ts
+++ b/packages/utilities/focus-visible/src/index.ts
@@ -231,7 +231,7 @@ export interface InteractionModalityChangeDetails {
 
 export interface InteractionModalityProps {
   /** The root element to track focus visibility for. */
-  root?: RootNode
+  root?: RootNode | undefined
   /** Callback to be called when the interaction modality changes. */
   onChange: (details: InteractionModalityChangeDetails) => void
 }
@@ -266,13 +266,13 @@ export interface FocusVisibleChangeDetails {
 
 export interface FocusVisibleProps {
   /** The root element to track focus visibility for. */
-  root?: RootNode
+  root?: RootNode | undefined
   /** Whether the element is a text input. */
-  isTextInput?: boolean
+  isTextInput?: boolean | undefined
   /** Whether the element will be auto focused. */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /** Callback to be called when the focus visibility changes. */
-  onChange?: (details: FocusVisibleChangeDetails) => void
+  onChange?: ((details: FocusVisibleChangeDetails) => void) | undefined
 }
 
 export function trackFocusVisible(props: FocusVisibleProps = {}): VoidFunction {

--- a/packages/utilities/form-utils/src/input-event.ts
+++ b/packages/utilities/form-utils/src/input-event.ts
@@ -1,6 +1,6 @@
 interface DescriptorOptions {
-  type?: "HTMLInputElement" | "HTMLTextAreaElement" | "HTMLSelectElement"
-  property?: "value" | "checked"
+  type?: "HTMLInputElement" | "HTMLTextAreaElement" | "HTMLSelectElement" | undefined
+  property?: "value" | "checked" | undefined
 }
 
 const getWindow = (el: HTMLElement) => el.ownerDocument.defaultView || window

--- a/packages/utilities/i18n-utils/src/filter.ts
+++ b/packages/utilities/i18n-utils/src/filter.ts
@@ -7,7 +7,7 @@ export interface FilterReturn {
 }
 
 export interface FilterOptions extends Intl.CollatorOptions {
-  locale?: string
+  locale?: string | undefined
 }
 
 const collatorCache = i18nCache(Intl.Collator)

--- a/packages/utilities/i18n-utils/src/format-bytes.ts
+++ b/packages/utilities/i18n-utils/src/format-bytes.ts
@@ -4,8 +4,8 @@ const bitPrefixes = ["", "kilo", "mega", "giga", "tera"]
 const bytePrefixes = ["", "kilo", "mega", "giga", "tera", "peta"]
 
 export interface FormatBytesOptions {
-  unit?: "bit" | "byte"
-  unitDisplay?: "long" | "short" | "narrow"
+  unit?: "bit" | "byte" | undefined
+  unitDisplay?: "long" | "short" | "narrow" | undefined
 }
 
 export const formatBytes = (bytes: number, locale = "en-US", options: FormatBytesOptions = {}) => {

--- a/packages/utilities/i18n-utils/src/format-date.ts
+++ b/packages/utilities/i18n-utils/src/format-date.ts
@@ -29,7 +29,7 @@ type Format = (typeof FORMATS)[number]
 interface FormatDateOptions {
   locale: string
   format: Format
-  timeZone?: string
+  timeZone?: string | undefined
 }
 
 function ordinal(num: string | number) {

--- a/packages/utilities/i18n-utils/src/track-locale.ts
+++ b/packages/utilities/i18n-utils/src/track-locale.ts
@@ -2,9 +2,9 @@ import { getWindow } from "@zag-js/dom-query"
 import { getDefaultLocale, type Locale } from "./locale"
 
 export interface LocaleOptions {
-  locale?: string
-  getRootNode?: () => ShadowRoot | Document | Node
-  onLocaleChange?: (locale: Locale) => void
+  locale?: string | undefined
+  getRootNode?: (() => ShadowRoot | Document | Node) | undefined
+  onLocaleChange?: ((locale: Locale) => void) | undefined
 }
 
 export function trackLocale(options: LocaleOptions = {}) {

--- a/packages/utilities/interact-outside/src/index.ts
+++ b/packages/utilities/interact-outside/src/index.ts
@@ -16,20 +16,20 @@ export interface InteractOutsideHandlers {
   /**
    * Function called when the pointer is pressed down outside the component
    */
-  onPointerDownOutside?: (event: PointerDownOutsideEvent) => void
+  onPointerDownOutside?: ((event: PointerDownOutsideEvent) => void) | undefined
   /**
    * Function called when the focus is moved outside the component
    */
-  onFocusOutside?: (event: FocusOutsideEvent) => void
+  onFocusOutside?: ((event: FocusOutsideEvent) => void) | undefined
   /**
    * Function called when an interaction happens outside the component
    */
-  onInteractOutside?: (event: InteractOutsideEvent) => void
+  onInteractOutside?: ((event: InteractOutsideEvent) => void) | undefined
 }
 
 export interface InteractOutsideOptions extends InteractOutsideHandlers {
-  exclude?: (target: HTMLElement) => boolean
-  defer?: boolean
+  exclude?: ((target: HTMLElement) => boolean) | undefined
+  defer?: boolean | undefined
 }
 
 export interface EventDetails<T> {

--- a/packages/utilities/live-region/src/index.ts
+++ b/packages/utilities/live-region/src/index.ts
@@ -1,8 +1,8 @@
 export interface LiveRegionOptions {
   level: "polite" | "assertive"
-  document?: Document
-  root?: HTMLElement | null
-  delay?: number
+  document?: Document | undefined
+  root?: HTMLElement | null | undefined
+  delay?: number | undefined
 }
 
 export type LiveRegion = ReturnType<typeof createLiveRegion>

--- a/packages/utilities/popper/src/get-styles.ts
+++ b/packages/utilities/popper/src/get-styles.ts
@@ -3,7 +3,7 @@ import { cssVars } from "./middleware"
 import type { PositioningOptions } from "./types"
 
 export interface GetPlacementStylesOptions {
-  placement?: Placement
+  placement?: Placement | undefined
 }
 
 const ARROW_FLOATING_STYLE = {

--- a/packages/utilities/popper/src/types.ts
+++ b/packages/utilities/popper/src/types.ts
@@ -10,75 +10,75 @@ export type PlacementSide = "top" | "right" | "bottom" | "left"
 export type PlacementAlign = "start" | "center" | "end"
 
 export interface AnchorRect {
-  x?: number
-  y?: number
-  width?: number
-  height?: number
+  x?: number | undefined
+  y?: number | undefined
+  width?: number | undefined
+  height?: number | undefined
 }
 
 export interface PositioningOptions {
   /**
    * Whether the popover should be hidden when the reference element is detached
    */
-  hideWhenDetached?: boolean
+  hideWhenDetached?: boolean | undefined
   /**
    * The strategy to use for positioning
    */
-  strategy?: "absolute" | "fixed"
+  strategy?: "absolute" | "fixed" | undefined
   /**
    * The initial placement of the floating element
    */
-  placement?: Placement
+  placement?: Placement | undefined
   /**
    * The offset of the floating element
    */
-  offset?: { mainAxis?: number; crossAxis?: number }
+  offset?: { mainAxis?: number; crossAxis?: number } | undefined
   /**
    * The main axis offset or gap between the reference and floating elements
    */
-  gutter?: number
+  gutter?: number | undefined
   /**
    * The secondary axis offset or gap between the reference and floating elements
    */
-  shift?: number
+  shift?: number | undefined
   /**
    * The virtual padding around the viewport edges to check for overflow
    */
-  overflowPadding?: number
+  overflowPadding?: number | undefined
   /**
    * The minimum padding between the arrow and the floating element's corner.
    * @default 4
    */
-  arrowPadding?: number
+  arrowPadding?: number | undefined
   /**
    * Whether to flip the placement
    */
-  flip?: boolean | Placement[]
+  flip?: boolean | Placement[] | undefined
   /**
    * Whether the popover should slide when it overflows.
    */
-  slide?: boolean
+  slide?: boolean | undefined
   /**
    * Whether the floating element can overlap the reference element
    * @default false
    */
-  overlap?: boolean
+  overlap?: boolean | undefined
   /**
    * Whether to make the floating element same width as the reference element
    */
-  sameWidth?: boolean
+  sameWidth?: boolean | undefined
   /**
    * Whether the popover should fit the viewport.
    */
-  fitViewport?: boolean
+  fitViewport?: boolean | undefined
   /**
    * The overflow boundary of the reference element
    */
-  boundary?: () => Boundary
+  boundary?: (() => Boundary) | undefined
   /**
    * Options to activate auto-update listeners
    */
-  listeners?: boolean | AutoUpdateOptions
+  listeners?: boolean | AutoUpdateOptions | undefined
   /**
    * Function called when the placement is computed
    */
@@ -90,12 +90,12 @@ export interface PositioningOptions {
   /**
    *  Function that returns the anchor rect
    */
-  getAnchorRect?: (element: HTMLElement | VirtualElement | null) => AnchorRect | null
+  getAnchorRect?: ((element: HTMLElement | VirtualElement | null) => AnchorRect | null) | undefined
   /**
    * A callback that will be called when the popover needs to calculate its
    * position.
    */
-  updatePosition?: (data: { updatePosition: () => Promise<void> }) => void | Promise<void>
+  updatePosition?: ((data: { updatePosition: () => Promise<void> }) => void | Promise<void>) | undefined
 }
 
 export type { AutoUpdateOptions, Boundary, ComputePositionReturn, Placement }

--- a/packages/utilities/rect/src/types.ts
+++ b/packages/utilities/rect/src/types.ts
@@ -69,8 +69,8 @@ export type RectCenters = Record<RectCenter, Point> & {
 export type RectInset = Partial<Record<RectSide, number>>
 
 export interface SymmetricRectInset {
-  dx?: number
-  dy?: number
+  dx?: number | undefined
+  dy?: number | undefined
 }
 
 export interface ScalingOptions {

--- a/packages/utilities/text-selection/src/index.ts
+++ b/packages/utilities/text-selection/src/index.ts
@@ -7,9 +7,9 @@ let userSelect = ""
 const elementMap = new WeakMap<HTMLElement, string>()
 
 export interface DisableTextSelectionOptions<T = MaybeElement> {
-  target?: T
-  doc?: Document
-  defer?: boolean
+  target?: T | undefined
+  doc?: Document | undefined
+  defer?: boolean | undefined
 }
 
 function disableTextSelectionImpl(options: DisableTextSelectionOptions = {}) {


### PR DESCRIPTION
## 📝 Description

Add support for TS `exactOptionalPropertyTypes` setting.

## ⛳️ Current behavior (updates)

This code results in TS error.
https://stackblitz.com/edit/stackblitz-starters-lc9fiz?description=The%20React%20framework%20for%20production&file=app%2Fpage.tsx,node_modules%2F%40ark-ui%2Freact%2Fnode_modules%2F%40zag-js%2Fdialog%2Fdist%2Findex.d.ts,tsconfig.json&title=Next.js%20Starter

## 🚀 New behavior

https://www.typescriptlang.org/play/?exactOptionalPropertyTypes=true#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wG4Aoc4AOxiSk3STgHkwlqBhACxWoHMkAESQwUwADYBnOAG9ycRXAjtqALjgAjCBAmpqFAL6UadBkzhCoKAO70EOmAAUcYGfKVwA9ACofCzx84ThQJCU10AGs4GAgtZhoANwhIpAATOBtuDhjsuDTgUIh+OGAZFQ505Sg4NAkIKXSApR8vZuVqNg4ePkEAfg0ACkG00XFpDS6uXgFhMckpAEo4AF4APjhk4DTlgB84AFdqUcwadIp2tG5JNKJqAbg+AE8jSjQIail4K1t7R1W4IMwK4pBofnYoA4IM4Qct1nBgSopAA6K43O4XJAAD0gsDgmCOGGAH0s1ghg1ktWuEluHAANB0pj1ZgzkWyiF84IYwWS-tCXEjlh44EQYAcoNRAe0ADzgvnwD5MmaCFayRWqZmCQxyNnIjkwQxrdqKWRoml3YyeaVeOWQxxGxSLIxAA

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
React types are doing the same https://github.com/DefinitelyTyped/DefinitelyTyped/blob/41f2a0221e6b885fe7b271198f0b913b11c188ba/types/react/index.d.ts#L2495
