### PR TITLE
fix(core): ensure setTimeout delay value in machine action not overflowing

### DIFF
--- a/.changeset/little-mice-compete.md
+++ b/.changeset/little-mice-compete.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/core": patch
+---
+
+Fix issue where after actions is executed immediately when setting Infinity or the over max delay value

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -382,12 +382,18 @@ export class Machine<
   private getAfterActions = (transition: S.Transitions<TContext, TState, TEvent>, delay?: number) => {
     let id: ReturnType<typeof globalThis.setTimeout>
     const current = this.state.value!
+
+    const safeDelay =
+      delay != null
+        ? Math.min(delay, 2_147_483_647) // Ensure the delay does not exceed the maximum value for setTimeout
+        : undefined
+
     return {
       entry: () => {
         id = globalThis.setTimeout(() => {
           const next = this.getNextStateInfo(transition, this.state.event)
           this.performStateChangeEffects(current, next, this.state.event)
-        }, delay)
+        }, safeDelay)
       },
       exit: () => {
         globalThis.clearTimeout(id)

--- a/packages/core/tests/after.test.ts
+++ b/packages/core/tests/after.test.ts
@@ -179,4 +179,28 @@ describe("after.test.ts", async () => {
     vi.advanceTimersByTime(200)
     expect(actor.state.matches("active")).toBe(true)
   })
+
+  it("should execute after the max delay value if the over maximum value is specified", () => {
+    const machine = createMachine({
+      initial: "inactive",
+      states: {
+        inactive: {
+          after: {
+            2_147_483_648: "active",
+            Infinity: "active",
+          },
+        },
+        active: {},
+      },
+    })
+
+    const actor = machine.start()
+    expect(actor.state.matches("inactive")).toBe(true)
+
+    vi.advanceTimersByTime(100)
+    expect(actor.state.matches("inactive")).toBe(true)
+
+    vi.advanceTimersByTime(2_147_483_647 - 100)
+    expect(actor.state.matches("active")).toBe(true)
+  })
 })


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description
The actions function would be executed immediately if the delay of actions was specified to exceed the max range.
This PR fixes this issue by set the maximum value for setTimeout if exceeded value set.


## ⛳️ Current behavior (updates)
If set the exceeded value, setTimeout's handler is executed immediately.
(strictly, the overflow results in faster execution than specified.)

## 🚀 New behavior
If set the exceeded max value, setTimeout's handler is executed after max delay time.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
`setTimeout`’s timeout value is defined as `long` type([interface](https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope-mixin)), and `long` type’s range is [−2147483648, 2147483647] ([Web IDL](https://webidl.spec.whatwg.org/#idl-long)). 

If it is exceeded, it will be overflowing and set value as 0 in many case. ([converting algorithm](https://webidl.spec.whatwg.org/#js-long))
As a result, the handler of setTimeout will be executed immediately.