### PR TITLE
chore: fix typo in tags input changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ See the [Changesets](./.changeset) for the latest changes.
 
 ### Fixed
 
-- **TagsInput**: Fix issue where `api.addTag(...)` doesn't work in tags input
+- **TagsInput**: Fix issue where `api.addValue(...)` doesn't work in tags input
 - **RatingGroup**: Fix issue where both rating group and rating item have focus when `readOnly` is set to `true`
 - **Combobox**: Fix issue where `getSelectionValue` could gets called multiple times. Now, it only gets called when a
   selection is made

--- a/packages/machines/tags-input/CHANGELOG.md
+++ b/packages/machines/tags-input/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - [`bd45a73`](https://github.com/chakra-ui/zag/commit/bd45a73076475d2b75fd1b60bc48a9a754925d19) Thanks
-  [@segunadebayo](https://github.com/segunadebayo)! - Fix issue where `api.addTag(...)` doesn't work in tags input
+  [@segunadebayo](https://github.com/segunadebayo)! - Fix issue where `api.addValue(...)` doesn't work in tags input
 
 - Updated dependencies []:
   - @zag-js/anatomy@0.76.0


### PR DESCRIPTION
fix typo in tags input changelog