### PR TITLE
Typo

### DIFF
--- a/website/data/snippets/svelte/toast/usage.mdx
+++ b/website/data/snippets/svelte/toast/usage.mdx
@@ -50,7 +50,7 @@
 
 <!-- 3. Wrap your app with the toast group provider -->
 <script lang="ts">
-  import { ToastProvier } from "./toast-provider.svelte"
+  import ToastProvider from "./toast-provider.svelte"
 </script>
 
 <ToastProvider>


### PR DESCRIPTION
1. Should be a default import.
2. Imported name was incorrect.
