### PR TITLE
fix(aria-hidden): skip empty elements hide

### DIFF
--- a/packages/utilities/aria-hidden/src/index.ts
+++ b/packages/utilities/aria-hidden/src/index.ts
@@ -21,6 +21,7 @@ export function ariaHidden(targetsOrFn: TargetsOrFn, options: Options = {}) {
     func(() => {
       const targets = typeof targetsOrFn === "function" ? targetsOrFn() : targetsOrFn
       const elements = targets.filter(Boolean) as HTMLElement[]
+      if (elements.length === 0) return
       cleanups.push(hideOthers(elements))
     }),
   )


### PR DESCRIPTION
📝 Description

This PR updates the ariaHidden function to handle cases where the targets array is empty.

⛳️ Current behavior (updates)

The hideOthers function does not handle cases where the array is empty, which results in a type error.

<img width="1396" alt="스크린샷 2024-11-04 오후 2 10 50" src="https://github.com/user-attachments/assets/82f4544e-75c6-44bd-95b4-a1f033442e05">

🚀 New behavior

I added a conditional check to handle cases where the array is empty, just like it was done previously.

💣 Is this a breaking change (Yes/No):

No

📝 Additional Information