### PR TITLE
Introducing Zag Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   <a href="https://zagjs.com/discord">
     <img alt="Discord" src="https://img.shields.io/discord/660863154703695893.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2" />
   </a>
+  <a href="https://gurubase.io/g/zag">
+    <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Zag%20Guru-006BFF" />
+  </a>
 </p>
 
 
@@ -107,7 +110,7 @@ export function ToggleGroup() {
 **Zag** means to _take a sharp change in direction_. This clearly describes our approach of using state machines to
 power the logic behind UI components.
 
-### Teasers
+them to **"zag it!"** ⚡️
 
 - When you see someone using classic react, vue or solid to build an interactive UI component that exists in Zag, tell
   them to **"zag it!"** ⚡️

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ export function ToggleGroup() {
 **Zag** means to _take a sharp change in direction_. This clearly describes our approach of using state machines to
 power the logic behind UI components.
 
-them to **"zag it!"** ⚡️
+### Teasers
 
 - When you see someone using classic react, vue or solid to build an interactive UI component that exists in Zag, tell
   them to **"zag it!"** ⚡️


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Zag Guru](https://gurubase.io/g/zag) to Gurubase. Zag Guru uses the data from this repo and data from the [docs](https://zagjs.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Zag Guru", which highlights that Zag now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Zag Guru in Gurubase, just let me know that's totally fine.
