### PR TITLE
docs: fix typo

### DIFF
--- a/website/data/snippets/svelte/accordion/usage.mdx
+++ b/website/data/snippets/svelte/accordion/usage.mdx
@@ -15,13 +15,13 @@
 
 <div {...api.getRootProps()}>
   {#each data as item}
-    <div {...api.getItemProps({ value: item.item.title })}>
+    <div {...api.getItemProps({ value: item.title })}>
       <h3>
-        <button {...api.getItemTriggerProps({ value: item.item.title })}>
+        <button {...api.getItemTriggerProps({ value: item.title })}>
           {item.title}
         </button>
       </h3>
-      <div {...api.getItemContentProps({ value: item.item.title })}>
+      <div {...api.getItemContentProps({ value: item.title })}>
         {item.content}
       </div>
     </div>


### PR DESCRIPTION
## 📝 Description

`item.item` is a typo.

## 💣 Is this a breaking change (Yes/No):

No
