### PR TITLE
fix: angle-slider max value

### DIFF
--- a/.changeset/clever-oranges-deny.md
+++ b/.changeset/clever-oranges-deny.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/angle-slider": patch
+---
+
+Fix angle slider max value

--- a/packages/machines/angle-slider/src/angle-slider.machine.ts
+++ b/packages/machines/angle-slider/src/angle-slider.machine.ts
@@ -176,6 +176,8 @@ const invoke = {
 const set = {
   value: (ctx: MachineContext, value: number) => {
     if (ctx.value === value) return
+    if (value < MIN_VALUE || value > MAX_VALUE) return
+
     ctx.value = value
     invoke.valueChange(ctx)
   },

--- a/packages/machines/angle-slider/src/angle-slider.machine.ts
+++ b/packages/machines/angle-slider/src/angle-slider.machine.ts
@@ -8,7 +8,7 @@ import { dom } from "./angle-slider.dom"
 import type { MachineContext, MachineState, UserDefinedContext } from "./angle-slider.types"
 
 const MIN_VALUE = 0
-const MAX_VALUE = 360
+const MAX_VALUE = 359
 
 export function machine(userContext: UserDefinedContext) {
   const ctx = compact(userContext)


### PR DESCRIPTION
The end key sets value to 360.
Expected behaviour is 359
This PR fixes that