### PR TITLE
fix: remove dpr logic due incompatibility with Firefox

### DIFF
--- a/packages/utilities/dom-query/src/data-url.ts
+++ b/packages/utilities/dom-query/src/data-url.ts
@@ -24,21 +24,19 @@ export function getDataUrl(svg: SVGElement | undefined | null, opts: DataUrlOpti
   }
 
   const svgBounds = svg.getBoundingClientRect()
-  const dpr = win.devicePixelRatio || 1
 
   const canvas = doc.createElement("canvas")
   const image = new win.Image()
   image.src = svgString
 
-  canvas.width = svgBounds.width * dpr
-  canvas.height = svgBounds.height * dpr
+  canvas.width = svgBounds.width
+  canvas.height = svgBounds.height
 
   const context = canvas.getContext("2d")
-  context!.scale(dpr, dpr)
 
   return new Promise((resolve) => {
     image.onload = () => {
-      context!.drawImage(image, 0, 0)
+      context!.drawImage(image, 0, 0, canvas.width, canvas.height)
       resolve(canvas.toDataURL(type, quality))
     }
   })


### PR DESCRIPTION
Closes #2080

## 📝 Description

Remove dpr logic due incompatibility with Firefox. For some reason it seems Firefox does not work properly when we scale the canvas.

## ⛳️ Current behavior (updates)

![image](https://github.com/user-attachments/assets/00635e87-0e07-4c21-ae34-2e7b2b32d836)

## 🚀 New behavior

![image](https://github.com/user-attachments/assets/a70dfbbf-b08d-4f4d-8e35-3ca60c5a455f)
