### PR TITLE
fix: :pencil2: fix typos from packages/ folders

### DIFF
--- a/.xstate/floating-panel.js
+++ b/.xstate/floating-panel.js
@@ -72,7 +72,7 @@ const fetchMachine = createMachine({
           actions: ["setRestored"]
         },
         MOVE: {
-          actions: ["setPositionFromKeybord"]
+          actions: ["setPositionFromKeyboard"]
         }
       }
     },

--- a/.xstate/menu.js
+++ b/.xstate/menu.js
@@ -184,14 +184,14 @@ const fetchMachine = createMachine({
           actions: ["invokeOnClose"]
         }, {
           target: "closed",
-          actions: ["focusParentMenu", "restoreParentHiglightedItem", "invokeOnClose"]
+          actions: ["focusParentMenu", "restoreParentHighlightedItem", "invokeOnClose"]
         }]
       },
       on: {
         "CONTROLLED.OPEN": "open",
         "CONTROLLED.CLOSE": {
           target: "closed",
-          actions: ["focusParentMenu", "restoreParentHiglightedItem"]
+          actions: ["focusParentMenu", "restoreParentHighlightedItem"]
         },
         // don't invoke on open here since the menu is still open (we're only keeping it open)
         MENU_POINTERENTER: {
@@ -203,7 +203,7 @@ const fetchMachine = createMachine({
           actions: "invokeOnClose"
         }, {
           target: "closed",
-          actions: ["focusParentMenu", "restoreParentHiglightedItem"]
+          actions: ["focusParentMenu", "restoreParentHighlightedItem"]
         }]
       }
     },

--- a/packages/anatomy/tests/create-anatomy.test.ts
+++ b/packages/anatomy/tests/create-anatomy.test.ts
@@ -3,8 +3,8 @@ import { createAnatomy } from "../src"
 
 describe("Anatomy", () => {
   it("should allow to set parts", () => {
-    const anamtomy = createAnatomy("accordion").parts("root").build()
-    expect(anamtomy).toMatchInlineSnapshot(`
+    const anatomy = createAnatomy("accordion").parts("root").build()
+    expect(anatomy).toMatchInlineSnapshot(`
       {
         "root": {
           "attrs": {
@@ -18,8 +18,8 @@ describe("Anatomy", () => {
   })
 
   it("should convert string to kebab case if needed", () => {
-    const anamtomy = createAnatomy("hoverCard").parts("toggleButton").build()
-    expect(anamtomy).toMatchInlineSnapshot(`
+    const anatomy = createAnatomy("hoverCard").parts("toggleButton").build()
+    expect(anatomy).toMatchInlineSnapshot(`
       {
         "toggleButton": {
           "attrs": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -103,7 +103,7 @@ A `Machine`, which provides:
   - `event`: the event that triggered the transition to the current state
   - `nextEvents`: the list of events the machine can respond to at its current state
   - `tags`: the tags associated with this state
-  - `done`: whehter the machine that reached its final state
+  - `done`: whether the machine that reached its final state
   - `context`: the current context value
   - `matches(...)`: a function used to test whether the current state matches one or more state values
 

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -85,7 +85,7 @@ export class Machine<
     this.activityMap = this.options?.activities ?? {}
     this.sync = this.options?.sync ?? false
 
-    // create mutatable state
+    // create mutable state
     this.state = createProxy(this.config)
 
     this.initialContext = snapshot(this.state.context)
@@ -400,7 +400,7 @@ export class Machine<
    * All `after` events leverage `setTimeout` and `clearTimeout`,
    * we invoke the `clearTimeout` on exit and `setTimeout` on entry.
    *
-   * To achieve this, we split the `after` defintion into `entry` and `exit`
+   * To achieve this, we split the `after` definition into `entry` and `exit`
    *  functions and append them to the state's `entry` and `exit` actions
    */
   private getDelayedEventActions = (state: TState["value"]) => {

--- a/packages/core/tests/delayed-transitions.test.ts
+++ b/packages/core/tests/delayed-transitions.test.ts
@@ -145,7 +145,7 @@ it("does not transition into state after options defined timer delay has passed 
   counter.send("START")
   expect(counter.state.context.value).toBe(0)
   vi.advanceTimersByTime(200)
-  // since guard doesnt approve yet
+  // since guard doesn't approve yet
   expect(counter.state.value).toBe("running")
   expect(counter.state.context.value).toBe(2)
 

--- a/packages/docs/data/api.json
+++ b/packages/docs/data/api.json
@@ -25,7 +25,7 @@
       },
       "multiple": {
         "type": "boolean",
-        "description": "Whether multple accordion items can be expanded at the same time.",
+        "description": "Whether multiple accordion items can be expanded at the same time.",
         "defaultValue": "false"
       },
       "collapsible": {
@@ -3682,7 +3682,7 @@
       },
       "editable": {
         "type": "boolean",
-        "description": "Whether a tag can be edited after creation, by presing `Enter` or double clicking.",
+        "description": "Whether a tag can be edited after creation, by pressing `Enter` or double clicking.",
         "defaultValue": "true"
       },
       "inputValue": {

--- a/packages/machines/accordion/src/accordion.types.ts
+++ b/packages/machines/accordion/src/accordion.types.ts
@@ -30,7 +30,7 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    */
   ids?: ElementIds | undefined
   /**
-   * Whether multple accordion items can be expanded at the same time.
+   * Whether multiple accordion items can be expanded at the same time.
    * @default false
    */
   multiple?: boolean | undefined

--- a/packages/machines/combobox/src/combobox.types.ts
+++ b/packages/machines/combobox/src/combobox.types.ts
@@ -255,12 +255,12 @@ interface PrivateContext<T extends CollectionItem = CollectionItem> {
    */
   highlightedItem: T | null
   /**
-   * @interal
+   * @internal
    * The selected items
    */
   selectedItems: T[]
   /**
-   * @interal
+   * @internal
    * The display value of the combobox (based on the selected items)
    */
   valueAsString: string

--- a/packages/machines/floating-panel/src/floating-panel.machine.ts
+++ b/packages/machines/floating-panel/src/floating-panel.machine.ts
@@ -111,7 +111,7 @@ export function machine(userContext: UserDefinedContext) {
               actions: ["setRestored"],
             },
             MOVE: {
-              actions: ["setPositionFromKeybord"],
+              actions: ["setPositionFromKeyboard"],
             },
           },
         },
@@ -367,7 +367,7 @@ export function machine(userContext: UserDefinedContext) {
             ctx.prevPosition = null
           }
         },
-        setPositionFromKeybord(ctx, evt) {
+        setPositionFromKeyboard(ctx, evt) {
           invariant(evt.step == null, "step is required")
 
           let nextPosition = match(evt.direction, {

--- a/packages/machines/menu/src/menu.machine.ts
+++ b/packages/machines/menu/src/menu.machine.ts
@@ -226,7 +226,7 @@ export function machine(userContext: UserDefinedContext) {
               },
               {
                 target: "closed",
-                actions: ["focusParentMenu", "restoreParentHiglightedItem", "invokeOnClose"],
+                actions: ["focusParentMenu", "restoreParentHighlightedItem", "invokeOnClose"],
               },
             ],
           },
@@ -234,7 +234,7 @@ export function machine(userContext: UserDefinedContext) {
             "CONTROLLED.OPEN": "open",
             "CONTROLLED.CLOSE": {
               target: "closed",
-              actions: ["focusParentMenu", "restoreParentHiglightedItem"],
+              actions: ["focusParentMenu", "restoreParentHighlightedItem"],
             },
             // don't invoke on open here since the menu is still open (we're only keeping it open)
             MENU_POINTERENTER: {
@@ -248,7 +248,7 @@ export function machine(userContext: UserDefinedContext) {
               },
               {
                 target: "closed",
-                actions: ["focusParentMenu", "restoreParentHiglightedItem"],
+                actions: ["focusParentMenu", "restoreParentHighlightedItem"],
               },
             ],
           },
@@ -694,7 +694,7 @@ export function machine(userContext: UserDefinedContext) {
           set.highlighted(ctx, ctx.lastHighlightedValue)
           ctx.lastHighlightedValue = null
         },
-        restoreParentHiglightedItem(ctx) {
+        restoreParentHighlightedItem(ctx) {
           ctx.parent?.send("HIGHLIGHTED.RESTORE")
         },
         invokeOnOpen(ctx) {

--- a/packages/machines/number-input/src/number-input.dom.ts
+++ b/packages/machines/number-input/src/number-input.dom.ts
@@ -58,7 +58,7 @@ export const dom = createScope({
     }
   },
 
-  getMousementValue(ctx: Ctx, event: MouseEvent) {
+  getMousemoveValue(ctx: Ctx, event: MouseEvent) {
     const x = roundToDevicePixel(event.movementX)
     const y = roundToDevicePixel(event.movementY)
 

--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -285,7 +285,7 @@ export function machine(userContext: UserDefinedContext) {
 
           function onMousemove(event: MouseEvent) {
             if (!ctx.scrubberCursorPoint) return
-            const value = dom.getMousementValue(ctx, event)
+            const value = dom.getMousemoveValue(ctx, event)
             if (!value.hint) return
             send({
               type: "SCRUBBER.POINTER_MOVE",

--- a/packages/machines/pin-input/src/pin-input.machine.ts
+++ b/packages/machines/pin-input/src/pin-input.machine.ts
@@ -190,7 +190,7 @@ export function machine(userContext: UserDefinedContext) {
             const startIndex = Math.min(ctx.focusedIndex, ctx.filledValueLength)
 
             // keep value left of cursor
-            // replace value from curor to end with pasted text
+            // replace value from cursor to end with pasted text
             const left = startIndex > 0 ? ctx.valueAsString.substring(0, ctx.focusedIndex) : ""
             const right = evt.value.substring(0, ctx.valueLength - startIndex)
 

--- a/packages/machines/tags-input/src/tags-input.types.ts
+++ b/packages/machines/tags-input/src/tags-input.types.ts
@@ -107,7 +107,7 @@ interface PublicContext extends DirectionProperty, CommonProperties, InteractOut
    */
   required?: boolean | undefined
   /**
-   * Whether a tag can be edited after creation, by presing `Enter` or double clicking.
+   * Whether a tag can be edited after creation, by pressing `Enter` or double clicking.
    * @default true
    */
   editable?: boolean | undefined

--- a/packages/utilities/dismissable/src/pointer-event-outside.ts
+++ b/packages/utilities/dismissable/src/pointer-event-outside.ts
@@ -13,7 +13,7 @@ export function clearPointerEvent(node: HTMLElement) {
   node.style.pointerEvents = ""
 }
 
-export function disablePointerEventsOutside(node: HTMLElement, peristentElements?: Array<() => Element | null>) {
+export function disablePointerEventsOutside(node: HTMLElement, persistentElements?: Array<() => Element | null>) {
   const doc = getDocument(node)
 
   const cleanups: VoidFunction[] = []
@@ -26,8 +26,8 @@ export function disablePointerEventsOutside(node: HTMLElement, peristentElements
     })
   }
 
-  if (peristentElements) {
-    const persistedCleanup = waitForElements(peristentElements, (el) => {
+  if (persistentElements) {
+    const persistedCleanup = waitForElements(persistentElements, (el) => {
       cleanups.push(setStyle(el, { pointerEvents: "auto" }))
     })
     cleanups.push(persistedCleanup)

--- a/packages/utilities/dom-event/src/request-pointer-lock.ts
+++ b/packages/utilities/dom-event/src/request-pointer-lock.ts
@@ -12,7 +12,7 @@ export function requestPointerLock(doc: Document, fn?: (locked: boolean) => void
 
   function onPointerError(event: Event) {
     if (isLocked()) fn?.(false)
-    console.error("PointerLock error occured:", event)
+    console.error("PointerLock error occurred:", event)
     doc.exitPointerLock()
   }
 

--- a/packages/utilities/i18n-utils/README.md
+++ b/packages/utilities/i18n-utils/README.md
@@ -1,6 +1,6 @@
 # @zag-js/i18n-utils
 
-Interationalization utilities for Zag.js
+Internationalization utilities for Zag.js
 
 ## Installation
 

--- a/packages/utilities/interact-outside/README.md
+++ b/packages/utilities/interact-outside/README.md
@@ -1,6 +1,6 @@
 # @zag-js/interact-outside
 
-Track interations or focus outside an element
+Track interactions or focus outside an element
 
 ## Installation
 

--- a/packages/utilities/interact-outside/package.json
+++ b/packages/utilities/interact-outside/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zag-js/interact-outside",
   "version": "0.78.2",
-  "description": "Track interations or focus outside an element",
+  "description": "Track interactions or focus outside an element",
   "keywords": [
     "js",
     "utils",

--- a/packages/utilities/number/src/scale.ts
+++ b/packages/utilities/number/src/scale.ts
@@ -1,4 +1,4 @@
-export type AlgoritmType = "linear" | "geometric" | "logarithmic"
+export type AlgorithmType = "linear" | "geometric" | "logarithmic"
 
 export type Algorithm = {
   valueToPercent(value: number, min: number, max: number): number

--- a/packages/utilities/rect/src/from-window.ts
+++ b/packages/utilities/rect/src/from-window.ts
@@ -9,7 +9,7 @@ export type WindowRectOptions = {
 }
 
 /**
- * Creates a rectange from window object
+ * Creates a rectangle from window object
  */
 export function getWindowRect(win: Window, opts: WindowRectOptions = {}): Rect {
   return createRect(getViewportRect(win, opts))

--- a/packages/utilities/remove-scroll/src/index.ts
+++ b/packages/utilities/remove-scroll/src/index.ts
@@ -63,7 +63,7 @@ export function preventBodyScroll(_document?: Document) {
   const setIOSStyle = () => {
     const { scrollX, scrollY, visualViewport } = win
 
-    // iOS 12 does not support `visuaViewport`.
+    // iOS 12 does not support `visualViewport`.
     const offsetLeft = visualViewport?.offsetLeft ?? 0
     const offsetTop = visualViewport?.offsetTop ?? 0
 


### PR DESCRIPTION
## 📝 Description

More typo fixes from `packages/` folder

## 💣 Is this a breaking change (Yes/No):

Might be some breaking changes from the following files, but they tend to be minor changes.
`.xstate/floating-panel.js`, `.xstate/menu.js`, `packages/machines/menu/src/menu.machine.ts` , `packages/machines/floating-panel/src/floating-panel.machine.ts`, `packages/machines/number-input/src/number-input.dom.ts` 

## 📝 Additional Information
N/A