### PR TITLE
fix: :pencil2: fix a typo for carouselControls

### DIFF
--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -199,7 +199,7 @@ export const transitionControls = defineControls({
 })
 
 export const carouselControls = defineControls({
-  orientatation: { type: "select", options: ["horizontal", "vertical"] as const, defaultValue: "horizontal" },
+  orientation: { type: "select", options: ["horizontal", "vertical"] as const, defaultValue: "horizontal" },
   slidesPerView: { type: "number", defaultValue: 1 },
   align: { type: "select", options: ["start", "center", "end"] as const, defaultValue: "start" },
   loop: { type: "boolean", defaultValue: false },


### PR DESCRIPTION
## 📝 Description

tiny carouselControls prop key type fix


## 💣 Is this a breaking change (Yes/No):

Yes but easy to be updated from consumer.

## 📝 Additional Information

N/A
