### PR TITLE
fix: ensure accept attribute is applied to file upload input

### DIFF
--- a/.changeset/cold-trainers-bathe.md
+++ b/.changeset/cold-trainers-bathe.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/file-upload": patch
+---
+
+fix: ensure accept attribute is applied to file upload input

--- a/packages/machines/file-upload/src/file-upload.machine.ts
+++ b/packages/machines/file-upload/src/file-upload.machine.ts
@@ -14,9 +14,10 @@ export function machine(userContext: UserDefinedContext) {
       initial: "idle",
       context: {
         minFileSize: 0,
-        maxFileSize: Infinity,
+        maxFileSize: Number.POSITIVE_INFINITY,
         maxFiles: 1,
         allowDrop: true,
+        accept: ctx.accept,
         ...ctx,
         acceptedFiles: ref([]),
         rejectedFiles: ref([]),


### PR DESCRIPTION
Closes https://github.com/chakra-ui/zag/issues/2107

## 📝 Description

Adds support for the `accept` attribute in the File Upload machine, ensuring that the hidden input respects the file type restrictions.

## ⛳️ Current behavior (updates)

Previously, the file upload component did not pass the `accept` attribute to the hidden input, which meant that the file picker would accept all file types regardless of any specified restrictions.

## 🚀 New behavior

- Added `accept: ctx.accept` to the machine's context
- The hidden input now receives the `accept` attribute, limiting file selection to specified file types
- Maintains existing functionality while improving file type filtering

## 💣 Is this a breaking change (No): 

The change is a non-breaking improvement to the existing File Upload component.

## 📝 Additional Information

- Bug discovered on documentation page for File Upload
- Reproduces at: zagjs.com/components/svelte/file-upload
- Fixed by adding `accept` to the machine context