### PR TITLE
refactor(date-picker): Introduced isOutsideVisibleRangeEnabled

### DIFF
--- a/packages/machines/date-picker/src/date-picker.connect.ts
+++ b/packages/machines/date-picker/src/date-picker.connect.ts
@@ -147,6 +147,8 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
   function getDayTableCellState(props: DayTableCellProps): DayTableCellState {
     const { value, disabled, visibleRange = state.context.visibleRange } = props
 
+    const isOutsideVisibleRangeEnabled = state.context.isOutsideVisibleRangeEnabled
+
     const formatter = getDayFormatter(locale, timeZone)
     const unitDuration = getUnitDuration(state.context.visibleDuration)
 
@@ -154,7 +156,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
 
     const cellState = {
       invalid: isDateInvalid(value, min, max),
-      disabled: disabled || isDateDisabled(value, visibleRange.start, end, min, max),
+      disabled: disabled || isDateDisabled(value, visibleRange.start, end, min, max, isOutsideVisibleRangeEnabled),
       selected: selectedValue.some((date) => isDateEqual(value, date)),
       unavailable: isDateUnavailable(value, isDateUnavailableFn, locale, min, max) && !disabled,
       outsideRange: isDateOutsideVisibleRange(value, visibleRange.start, end),

--- a/packages/machines/date-picker/src/date-picker.props.ts
+++ b/packages/machines/date-picker/src/date-picker.props.ts
@@ -22,7 +22,7 @@ export const props = createProps<UserDefinedContext>()([
   "id",
   "ids",
   "isDateUnavailable",
-  "isDateUnavailable",
+  "isOutsideVisibleRangeEnabled",
   "locale",
   "max",
   "min",

--- a/packages/machines/date-picker/src/date-picker.types.ts
+++ b/packages/machines/date-picker/src/date-picker.types.ts
@@ -174,9 +174,14 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    */
   onOpenChange?: ((details: OpenChangeDetails) => void) | undefined
   /**
-   * Returns whether a date of the calendar is available.
+   * Returns whether a date of the calendar is available in the current visible range.
    */
   isDateUnavailable?: ((date: DateValue, locale: string) => boolean) | undefined
+  /**
+   * By default the dates outside of the visible range are not selectable.
+   * This option allows the dates outside of the visible range to be selectable.
+   */
+  isOutsideVisibleRangeEnabled?: boolean | undefined
   /**
    * The selection mode of the calendar.
    * - `single` - only one date can be selected

--- a/packages/utilities/date-utils/src/assertion.ts
+++ b/packages/utilities/date-utils/src/assertion.ts
@@ -15,8 +15,12 @@ export function isDateDisabled(
   endDate: DateValue,
   minValue?: DateValue | null,
   maxValue?: DateValue | null,
+  isOutsideVisibleRangeEnabled?: boolean,
 ) {
-  return isDateOutsideVisibleRange(date, startDate, endDate) || isDateInvalid(date, minValue, maxValue)
+  return (
+    (!isOutsideVisibleRangeEnabled && isDateOutsideVisibleRange(date, startDate, endDate)) ||
+    isDateInvalid(date, minValue, maxValue)
+  )
 }
 
 export function isDateUnavailable(


### PR DESCRIPTION
## 📝 Description
This PR addressed the issue with date-picker, where it is not possible to make dates out of visible range clickable.
More details are covered in [the discussion](https://github.com/chakra-ui/ark/discussions/3186). 

## ⛳️ Current behavior (updates)
E.g. when January 2025 is selected, the dates outside the range but present on the screen (Dec 29-31 and Feb 1-2) are disabled. Currently, there is no way to make them interactive.

## 🚀 New behavior
Setting `isOutsideVisibleRangeEnabled: true` allows us to make the dates described above clickable. 

## 💣 Is this a breaking change (Yes/No):
No
