### PR TITLE
fix(timer): timer stops when switching tabs

### DIFF
--- a/.xstate/timer.js
+++ b/.xstate/timer.js
@@ -36,6 +36,7 @@ const fetchMachine = createMachine({
       }
     },
     running: {
+      entry: ["setStartTime"],
       invoke: {
         src: "interval",
         id: "interval"

--- a/packages/machines/timer/src/timer.types.ts
+++ b/packages/machines/timer/src/timer.types.ts
@@ -74,6 +74,11 @@ interface PrivateContext {
    * The timer count in milliseconds.
    */
   currentMs: number
+  /**
+   * @internal
+   * Timestamp at the beginning of counting.
+   */
+  startTimeMs: number
 }
 
 type ComputedContext = Readonly<{


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes  Timer stops when switching tabs #2226

## 📝 Description

Change calculation behaviour of `currentMs` for timer.machine

## ⛳️ Current behavior (updates)

`currentMs` depends on `setInterval` it leads to incorrect calculation in case of collapsed browser tab

## 🚀 New behavior

`currentMs` calucalted independent of `interval` using only timestamp.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information
