### PR TITLE
fix(hover-card): add missing type attribute to getTriggerProps

### DIFF
--- a/.changeset/odd-mice-flash.md
+++ b/.changeset/odd-mice-flash.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/hover-card": patch
+---
+
+Fix issue where `api.getTriggerProps()` was missing `type: 'button'` attribute

--- a/packages/machines/hover-card/src/hover-card.connect.ts
+++ b/packages/machines/hover-card/src/hover-card.connect.ts
@@ -43,6 +43,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
       return normalize.element({
         ...parts.trigger.attrs,
         dir: state.context.dir,
+        type: "button",
         "data-placement": state.context.currentPlacement,
         id: dom.getTriggerId(state.context),
         "data-state": open ? "open" : "closed",


### PR DESCRIPTION
## 📝 Description

Add missing `type: 'button'` attribute to the `getTriggerProps` function for the `hover-card` machine.

## ⛳️ Current behavior (updates)

The current `getTriggerProps` function does not return the `type: 'button'` attribute causing the HTML button element to not have the `type="button"` attribute. Without this attribute, the button's default behavior is like a "submit" button which is not the desired behavior.

## 🚀 New behavior

Now the HTML button element have the `type="button"` attribute properly added, so it won't submit the closest form on click.

## 💣 Is this a breaking change (Yes/No):

No