### PR TITLE
feat(slider): add option "end" to the slider's origin property

### DIFF
--- a/.changeset/sixty-sides-fail.md
+++ b/.changeset/sixty-sides-fail.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/slider": minor
+---
+
+Add `end` to slider `origin` property.

--- a/packages/machines/slider/src/slider.style.ts
+++ b/packages/machines/slider/src/slider.style.ts
@@ -27,6 +27,9 @@ export function getRangeOffsets(params: Pick<Ctx, "prop" | "computed">) {
       const end = isNegative ? "50%" : `${100 - valuePercent[0]}%`
       return { start, end }
     }
+    if (prop("origin") === "end") {
+      return { start: `${lastPercent}%`, end: "0%" }
+    }
 
     return { start: "0%", end: `${100 - lastPercent}%` }
   }

--- a/packages/machines/slider/src/slider.types.ts
+++ b/packages/machines/slider/src/slider.types.ts
@@ -119,13 +119,15 @@ export interface SliderProps extends DirectionProperty, CommonProperties {
    */
   orientation?: "vertical" | "horizontal" | undefined
   /**
-   * The origin of the slider range
+   * The origin of the slider range. The track is filled from the origin
+   * to the thumb for single values.
    * - "start": Useful when the value represents an absolute value
    * - "center": Useful when the value represents an offset (relative)
+   * - "end": Useful when the value represents an offset from the end
    *
    * @default "start"
    */
-  origin?: "start" | "center" | undefined
+  origin?: "start" | "center" | "end" | undefined
   /**
    * The alignment of the slider thumb relative to the track
    * - `center`: the thumb will extend beyond the bounds of the slider track.

--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -117,7 +117,7 @@ export const sliderControls = defineControls({
   orientation: { type: "select", options: ["horizontal", "vertical"] as const, defaultValue: "horizontal" },
   thumbAlignment: { type: "select", options: ["contain", "center"] as const, defaultValue: "contain" },
   dir: { type: "select", options: ["ltr", "rtl"] as const, defaultValue: "ltr" },
-  origin: { type: "select", options: ["center", "start"] as const, defaultValue: "start" },
+  origin: { type: "select", options: ["center", "start", "end"] as const, defaultValue: "start" },
   min: { type: "number", defaultValue: 0 },
   max: { type: "number", defaultValue: 100 },
   step: { type: "number", defaultValue: 1 },

--- a/website/data/components/slider.mdx
+++ b/website/data/components/slider.mdx
@@ -143,18 +143,29 @@ const service = useMachine(slider.machine, {
 
 ## Changing the start position
 
-By default, the slider's "zero position" is usually at the start position (left
-in LTR and right in RTL).
+By default, the slider's origin is at the `start` position (left
+in LTR and right in RTL). Change it by setting the `origin` property to these values:
 
-In scenarios where the value represents an offset (or relative value), it might
-be useful to change the "zero position" to center. To do this, pass the `origin`
-context property to `center`.
+- `start`: the track will be filled from start to the thumb (default).
+- `center`: the track will be filled from the center (50%) to the thumb.
+- `end`: the track will be filled from the thumb to the end.
+
+This applies to sliders with single values.
+
+In scenarios where the value represents an offset (or relative value) on a
+diverging scale, it might be useful to change the origin to center. To do this, 
+set the `origin` context property to `center`.
 
 ```jsx {2}
 const service = useMachine(slider.machine, {
   origin: "center",
 })
 ```
+
+In scenarios where the slider value is used as a threshold to include values above it, 
+it might make more sense to set the `origin` to `end` to have the track filled from the 
+thumb to the end.
+
 
 ## Changing the thumb alignment
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2236

## 📝 Description

The slider has an origin property that sets the start position of the filled track for single values. It currently includes "start" and "center" but misses an "end" option. 

An "end" option is useful in scenarios where the slider value functions as a threshold to include values above it. Then it might make more sense to have the track filled from the thumb to the end rather than from the start to the thumb.

## ⛳️ Current behavior (updates)

Now the origin property has option "start" (default) and "center". For the "start" value, the track is filled from start (left in LTR contexts, right in RTL contexts) to the thumb. For "center", the track is filled from the center (50%) to the thumb.

## 🚀 New behavior

This PR adds the origin option "end" to the slider. 

This PR also explains effect of this property more clearly.

## 💣 Is this a breaking change (Yes/No):

No
