### PR TITLE
fix(accordion): check multiple values

### DIFF
--- a/.changeset/mean-apes-build.md
+++ b/.changeset/mean-apes-build.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/accordion": patch
+---
+
+Fix issue where `api.setValue` doesn't work well when `multiple` is set to `true`

--- a/packages/machines/accordion/src/accordion.connect.ts
+++ b/packages/machines/accordion/src/accordion.connect.ts
@@ -11,7 +11,7 @@ export function connect<T extends PropTypes>(state: State, send: Send, normalize
 
   function setValue(value: string[]) {
     let nextValue = value
-    if (multiple && nextValue.length > 1) {
+    if (!multiple && nextValue.length > 1) {
       nextValue = [nextValue[0]]
     }
     send({ type: "VALUE.SET", value: nextValue })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2246 

## 📝 Description
Fix the bug #2246

## ⛳️ Current behavior (updates)
Only the first value of the array was set when call `setValue` of `Accordion` 

## 🚀 New behavior
all the values passed provided to setValue is set correctly.

## 💣 Is this a breaking change (Yes/No):
No.

## 📝 Additional Information
It looks like V1 has the same issue, hopefully this pull request will help.
