### PR TITLE
Fixing CVE-2024-57079 : zag-js/core prototype pollution

### DIFF
--- a/packages/core/src/deep-merge.ts
+++ b/packages/core/src/deep-merge.ts
@@ -1,16 +1,22 @@
 import { compact, isPlainObject } from "@zag-js/utils"
 
-export function deepMerge<T extends Record<string, any>>(source: T, ...objects: T[]): T {
+export function deepMerge<T extends Record<string, any>>(source: any, ...objects: any[]): T {
   for (const obj of objects) {
-    const target = compact(obj)
-    for (const key in target) {
-      if (isPlainObject(obj[key])) {
-        if (!source[key]) {
-          source[key] = {} as any
+    if (Object.prototype.hasOwnProperty.call(objects, obj)) {
+      if (obj === '__proto__' || obj === 'constructor' || obj === 'prototype') {
+        continue;
+      }
+
+      const target = compact(obj)
+      for (const key in target) {
+        if (isPlainObject(obj[key])) {
+          if (!source[key]) {
+            source[key] = {} as any
+          }
+          deepMerge(source[key], obj[key])
+        } else {
+          source[key] = obj[key]
         }
-        deepMerge(source[key], obj[key])
-      } else {
-        source[key] = obj[key]
       }
     }
   }


### PR DESCRIPTION
fixing CVE-2024-57079

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> CVE-2024-57079 : A prototype pollution in the lib.deepMerge function of @zag-js/core v0.50.0 allows attackers to cause a Denial of Service (DoS) via supplying a crafted payload.

## ⛳️ Current behavior (updates)

> Current version More vulnerable DoS attack.


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
