### PR TITLE
feat(progress): allow for more precise (decimal) values

### DIFF
--- a/packages/machines/progress/src/progress.machine.ts
+++ b/packages/machines/progress/src/progress.machine.ts
@@ -42,7 +42,7 @@ export const machine = createMachine<ProgressSchema>({
     percent({ context, prop }) {
       const value = context.get("value")
       if (!isNumber(value)) return -1
-      return Math.round(((value - prop("min")) / (prop("max") - prop("min"))) * 100)
+      return ((value - prop("min")) / (prop("max") - prop("min"))) * 100
     },
     isAtMax: ({ context, prop }) => context.get("value") === prop("max"),
     isHorizontal: ({ prop }) => prop("orientation") === "horizontal",


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2285

## 📝 Description

Removes the `Math.round` from the `percent` function to allow decimal values

## ⛳️ Current behavior (updates)

If a user inputs `0.5` into the machine the output would be `1`.

## 🚀 New behavior

If a user inputs `0.5` into the machine the output would be `0.5`.

## 💣 Is this a breaking change (Yes/No):

Yes, if you relied on this rounding behaviour you'd have to round it yourself like:

```diff
const service = useMachine(progress.machine, {
-   defaultValue: value
+   defaultValue: Math.round(value)
});

## 📝 Additional Information
