### PR TITLE
docs: update snippets missing required props: panels for splitter

### DIFF
--- a/website/data/snippets/react/splitter/usage.mdx
+++ b/website/data/snippets/react/splitter/usage.mdx
@@ -6,9 +6,10 @@ import { useId } from "react"
 export function Splitter() {
   const service = useMachine(splitter.machine, {
     id: useId(),
-    defaultSize: [
-      { id: "a", size: 50 },
-      { id: "b", size: 50 },
+    defaultSize: [80, 20],
+    panels: [
+      { id: "a", minSize: 10 },
+      { id: "b", minSize: 10 },
     ],
   })
 

--- a/website/data/snippets/solid/splitter/usage.mdx
+++ b/website/data/snippets/solid/splitter/usage.mdx
@@ -6,9 +6,10 @@ import { createMemo, createUniqueId } from "solid-js"
 export function Splitter() {
   const service = useMachine(splitter.machine, {
     id: createUniqueId(),
-    defaultSize: [
-      { id: "a", size: 50 },
-      { id: "b", size: 50 },
+    defaultSize: [80, 20],
+    panels: [
+      { id: "a", minSize: 10 },
+      { id: "b", minSize: 10 },
     ],
   })
 

--- a/website/data/snippets/svelte/splitter/usage.mdx
+++ b/website/data/snippets/svelte/splitter/usage.mdx
@@ -6,10 +6,11 @@
   const id = $props.id()
   const service = useMachine(splitter.machine, {
     id,
-    defaultSize: [
-        { id: "a", size: 50 },
-        { id: "b", size: 50 },
-      ],
+    defaultSize: [80, 20],
+    panels: [
+      { id: "a", minSize: 10 },
+      { id: "b", minSize: 10 },
+    ],
   })
   const api = $derived(splitter.connect(service, normalizeProps))
 </script>

--- a/website/data/snippets/vue/splitter/usage.mdx
+++ b/website/data/snippets/vue/splitter/usage.mdx
@@ -6,9 +6,10 @@
 
   const service = useMachine(splitter.machine, {
     id: "1",
-    defaultSize: [
-      { id: "a", size: 50 },
-      { id: "b", size: 50 },
+    defaultSize: [80, 20],
+    panels: [
+      { id: "a", minSize: 10 },
+      { id: "b", minSize: 10 },
     ],
   })
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Update snippets missing required props: panels , and `defaultSize` props for splitter

## ⛳️ Current behavior (updates)

- `defaultSize` is not assignable to type `number`
- missing required props: `panels`

```javascript
  const service = useMachine(splitter.machine, {
    id: useId(),
    defaultSize: [
      { id: "a", size: 50 },
      { id: "b", size: 50 },
    ]
  })
```

## 🚀 New behavior
```javascript
  const service = useMachine(splitter.machine, {
    id: useId(),
    defaultSize: [80, 20],
    panels: [
      { id: "a", minSize: 10 },
      { id: "b", minSize: 10 },
    ],
  })
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
