### PR TITLE
chore(file-upload, progress): add default type parameter to api interface

### DIFF
--- a/.changeset/twenty-singers-notice.md
+++ b/.changeset/twenty-singers-notice.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/file-upload": patch
+"@zag-js/progress": patch
+---
+
+Add default `PropTypes` type parameter to `Api` interface

--- a/packages/machines/file-upload/src/file-upload.types.ts
+++ b/packages/machines/file-upload/src/file-upload.types.ts
@@ -193,7 +193,7 @@ export interface DropzoneProps {
   disableClick?: boolean
 }
 
-export interface FileUploadApi<T extends PropTypes> {
+export interface FileUploadApi<T extends PropTypes = PropTypes> {
   /**
    * Whether the user is dragging something over the root element
    */

--- a/packages/machines/progress/src/progress.types.ts
+++ b/packages/machines/progress/src/progress.types.ts
@@ -119,7 +119,7 @@ export interface ViewProps {
   state: ProgressState
 }
 
-export interface ProgressApi<T extends PropTypes> {
+export interface ProgressApi<T extends PropTypes = PropTypes> {
   /**
    * The current value of the progress bar.
    */


### PR DESCRIPTION
## 📝 Description

This PR updates the `FileUploadApi` and `ProgressApi` interfaces by adding a default type parameter (`= PropTypes`).
This change allows consumers to omit the type argument when the default is sufficient.

## ⛳️ Current behavior (updates)

Previously, both API types required explicitly providing a `PropTypes` every time they were used.

## 🚀 New behavior

The generic interfaces now default to `PropTypes` if no type argument is provided, reducing boilerplate and improving developer experience.

## 💣 Is this a breaking change (Yes/No):

No