### PR TITLE
fix: use Object.defineProperty instead of assignment

### DIFF
--- a/.changeset/slimy-suns-brake.md
+++ b/.changeset/slimy-suns-brake.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/focus-visible": patch
+---
+
+Fix an issue where an assignment to the browser's HTMLElement prototype is not supported (e.g. happy-dom).

--- a/packages/utilities/focus-visible/src/index.ts
+++ b/packages/utilities/focus-visible/src/index.ts
@@ -135,7 +135,7 @@ function setupGlobalFocusEvents(root?: RootNode) {
   const doc = getDocument(root)
 
   let focus = win.HTMLElement.prototype.focus
-  win.HTMLElement.prototype.focus = function () {
+  function patchedFocus(this: HTMLElement) {
     // For programmatic focus, we remove the focus visible state to prevent showing focus rings
     // When `options.focusVisible` is supported in most browsers, we can remove this
     // @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focusvisible
@@ -145,6 +145,13 @@ function setupGlobalFocusEvents(root?: RootNode) {
     hasEventBeforeFocus = true
     focus.apply(this, arguments as unknown as [options?: FocusOptions | undefined])
   }
+
+  // Overwrite via assignment does not work in happy dom:
+  // https://github.com/capricorn86/happy-dom/issues/1214
+  Object.defineProperty(win.HTMLElement.prototype, "focus", {
+    configurable: true,
+    value: patchedFocus,
+  })
 
   doc.addEventListener("keydown", handleKeyboardEvent, true)
   doc.addEventListener("keyup", handleKeyboardEvent, true)


### PR DESCRIPTION
## 📝 Description

Assigning to the HTMLElement's prototype directly may lead to an error in some setups.
For example, happy-dom's prototypes seem to be readonly (see https://github.com/capricorn86/happy-dom/issues/1214).

## ⛳️ Current behavior (updates)

Testing a UI using Chakra's Checkbox component can lead to errors such as this:

```
TypeError: Cannot set property focus of [object Object] which has only a getter
 ❯ setupGlobalFocusEvents ../node_modules/.pnpm/@zag-js+focus-visible@1.12.0/node_modules/@zag-js/focus-visible/dist/index.mjs:71:35
 ❯ trackFocusVisible ../node_modules/.pnpm/@zag-js+focus-visible@1.12.0/node_modules/@zag-js/focus-visible/dist/index.mjs:145:3
 ❯ trackFocusVisible ../node_modules/.pnpm/@zag-js+radio-group@1.12.0/node_modules/@zag-js/radio-group/dist/index.mjs:343:16
 ❯ effect ../node_modules/.pnpm/@zag-js+react@1.12.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/@zag-js/react/dist/index.mjs:204:27
 ❯ Object.onChange ../node_modules/.pnpm/@zag-js+react@1.12.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/@zag-js/react/dist/index.mjs:245:26
 ❯ Object.invoke ../node_modules/.pnpm/@zag-js+react@1.12.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/@zag-js/react/dist/index.mjs:51:25
 ❯ ../node_modules/.pnpm/@zag-js+react@1.12.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/@zag-js/react/dist/index.mjs:259:13
 ❯ ../node:internal/process/task_queues:140:7
 ❯ AsyncResource.runInAsyncScope ../node:async_hooks:206:9
 ❯ AsyncResource.runMicrotask ../node:internal/process/task_queues:137:8
```

This happes when using `@testing-library/react` (e.g. `userEvent.type()`) together with `happy-dom`.

## 🚀 New behavior

The PR uses Object.defineProperty() instead of assignment. This does not lead to an error.

## 💣 Is this a breaking change (Yes/No):

The package should still behave the same. I tested this briefly in Firefox and Chrome.

## 📝 Additional Information
