### PR TITLE
Fix scrollbar width calculation before DOM change for scroll-lock workaround compatibility

### DIFF
--- a/.changeset/moody-lamps-cheat.md
+++ b/.changeset/moody-lamps-cheat.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/remove-scroll": patch
+---
+
+Fix scrollbar width calculation before DOM change for scroll-lock workaround compatibility

--- a/packages/utilities/remove-scroll/src/index.ts
+++ b/packages/utilities/remove-scroll/src/index.ts
@@ -18,9 +18,10 @@ export function preventBodyScroll(_document?: Document) {
   const locked = body.hasAttribute(LOCK_CLASSNAME)
   if (locked) return
 
+  const scrollbarWidth = win.innerWidth - documentElement.clientWidth
+
   body.setAttribute(LOCK_CLASSNAME, "")
 
-  const scrollbarWidth = win.innerWidth - documentElement.clientWidth
   const setScrollbarWidthProperty = () => setStyleProperty(documentElement, "--scrollbar-width", `${scrollbarWidth}px`)
   const paddingProperty = getPaddingProperty(documentElement)
 


### PR DESCRIPTION

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes: no issue to close, but related to [#2451](https://github.com/chakra-ui/zag/issues/2451#issuecomment-2876831171)

## 📝 Description

This PR updates the scroll-lock utility to calculate scrollbarWidth before setting the data-scroll-lock attribute.
This makes it compatible with CSS workarounds like:

```css
html:has([data-scroll-lock]) {
  overflow: hidden;
}
```
...which are used in setups where the html element is a container. 

## ⛳️ Current behavior (updates)

- `scrollbarWidth` is calculated after adding the scroll-lock attribute to the `<body>`.
- In setups using `html:has([data-scroll-lock])`, this changes the layout before scrollbarWidth is calculated, leading to incorrect values and layout shifts. 

## 🚀 New behavior

- The `scroll-lock` attribute is applied after `scrollbarWidth` is calculated.
- This ensures that the width is measured before the DOM layout changes when using the above css.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

While issue #2451 was closed as "not planned," this change introduces no breaking behavior and improves compatibility with modern container-based layouts.
It supports edge-case workarounds without impacting the scroll-lock logic for other use cases.