### PR TITLE
fix(carousel): Prevent infinite loop when slidesPerPage is 0

### DIFF
--- a/.changeset/stale-clouds-listen.md
+++ b/.changeset/stale-clouds-listen.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/carousel": patch
+---
+
+Fix issue where carousel crashes when `slidesPerPage` is 0

--- a/packages/machines/carousel/src/carousel.machine.ts
+++ b/packages/machines/carousel/src/carousel.machine.ts
@@ -481,9 +481,21 @@ export const machine = createMachine<CarouselSchema>({
 })
 
 function getPageSnapPoints(totalSlides: number | undefined, slidesPerMove: number | "auto", slidesPerPage: number) {
-  if (totalSlides == null) return []
+  // If there are no total slides or if slidesPerPage is 0, do nothing.
+  if (totalSlides == null || slidesPerPage === 0) {
+    return []
+  }
+
   const snapPoints: number[] = []
   const perMove = slidesPerMove === "auto" ? Math.floor(slidesPerPage) : slidesPerMove
-  for (let i = 0; i < totalSlides - 1; i += perMove) snapPoints.push(i)
+
+  // An additional safety check in case perMove becomes 0 through other means
+  if (perMove === 0) {
+    return []
+  }
+
+  for (let i = 0; i < totalSlides - 1; i += perMove) {
+    snapPoints.push(i)
+  }
   return snapPoints
 }

--- a/packages/machines/carousel/src/carousel.machine.ts
+++ b/packages/machines/carousel/src/carousel.machine.ts
@@ -482,7 +482,7 @@ export const machine = createMachine<CarouselSchema>({
 
 function getPageSnapPoints(totalSlides: number | undefined, slidesPerMove: number | "auto", slidesPerPage: number) {
   // If there are no total slides or if slidesPerPage is 0, do nothing.
-  if (totalSlides == null || slidesPerPage === 0) {
+  if (totalSlides == null || slidesPerPage <= 0) {
     return []
   }
 

--- a/packages/machines/carousel/src/carousel.machine.ts
+++ b/packages/machines/carousel/src/carousel.machine.ts
@@ -490,7 +490,7 @@ function getPageSnapPoints(totalSlides: number | undefined, slidesPerMove: numbe
   const perMove = slidesPerMove === "auto" ? Math.floor(slidesPerPage) : slidesPerMove
 
   // An additional safety check in case perMove becomes 0 through other means
-  if (perMove === 0) {
+  if (perMove <= 0) {
     return []
   }
 


### PR DESCRIPTION
This pull request resolves the high-priority bug reported in #2508,

 where the carousel machine enters an infinite loop if the slidesPerPage prop is set to 0.

**The Problem**
As identified in the issue, when slidesPerPage is 0 and slidesPerMove is "auto", the perMove variable within the getPageSnapPoints utility is calculated as 0. This causes the for loop responsible for generating snap points to become an infinite loop (i += 0), leading to the browser tab hanging and crashing.

The Solution
This PR implements a simple guard clause at the beginning of the getPageSnapPoints function.
It now checks if slidesPerPage is 0 before any calculations occur.
If the condition is met, the function immediately returns an empty array, gracefully handling the invalid configuration and preventing the infinite loop.

This ensures the application remains stable even with this edge-case configuration.

How to Verify
To Reproduce the Bug (on main):
Render the carousel component with the prop slidesPerPage={0}.

The browser tab will freeze.
To Confirm the Fix (on this branch):
Render the carousel component with slidesPerPage={0}.
The application will run without errors, and the page remains responsive.
Related Issues

Closes #2508
Checklist
My code follows the project's style guidelines.
I have tested my changes locally and they resolve the reported bug.
The commit message is clear and follows conventional commit standards.
I have added corresponding tests for my changes (if applicable).
I have updated the documentation accordingly (if applicable).