### PR TITLE
fix(file-upload): prevent undefined in acceptedFiles when no files accepted

### DIFF
--- a/.changeset/wide-suits-wonder.md
+++ b/.changeset/wide-suits-wonder.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/file-upload": patch
+---
+
+fix(file-upload): prevent undefined in acceptedFiles when no files accepted

--- a/packages/machines/file-upload/src/file-upload.machine.ts
+++ b/packages/machines/file-upload/src/file-upload.machine.ts
@@ -167,7 +167,10 @@ export const machine = createMachine<FileUploadSchema>({
       setFiles(params) {
         const { computed, context, event } = params
         const { acceptedFiles, rejectedFiles } = getEventFiles(params, event.files)
-        context.set("acceptedFiles", computed("multiple") ? acceptedFiles : [acceptedFiles[0]])
+        context.set(
+          "acceptedFiles",
+          computed("multiple") ? acceptedFiles : acceptedFiles.length > 0 ? [acceptedFiles[0]] : [],
+        )
         context.set("rejectedFiles", rejectedFiles)
       },
       setEventFiles(params) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2513 

## 📝 Description


Fix undefined value being set in acceptedFiles array when no files are accepted in single-file upload mode.

## ⛳️ Current behavior (updates)


When `maxFiles` is 1 and all files are rejected during validation, the `setFiles` action sets `acceptedFiles` to `[undefined]` because it accesses `acceptedFiles[0]` on an empty array.

## 🚀 New behavior


When no files are accepted in single-file mode, `acceptedFiles` is now set to an empty array `[]` instead of `[undefined]`, ensuring type safety and preventing potential runtime errors.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->

No

## 📝 Additional Information

