### PR TITLE
docs: pull out FrameworkButton component definition

### DIFF
--- a/website/components/multi-framework.tsx
+++ b/website/components/multi-framework.tsx
@@ -7,29 +7,29 @@ import { ReactIcon, SolidIcon, VueIcon, SvelteIcon } from "./icons"
 import { NumberInput } from "../demos/number-input"
 import { Playground } from "./playground"
 
+const FrameworkButton = chakra("button", {
+  baseStyle: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "120px",
+    height: "120px",
+    rounded: "md",
+    borderWidth: "1px",
+    borderColor: "border-bold",
+    bg: "bg-subtle",
+    _selected: {
+      bg: "bg-tertiary-subtle",
+      borderBottomWidth: "4px",
+      borderBottomColor: "border-primary-subtle",
+    },
+  },
+})
+
 export function MultiframeworkTabs() {
   const service = useMachine(tabs.machine, {
     id: "m2",
     defaultValue: "react",
-  })
-
-  const FrameworkButton = chakra("button", {
-    baseStyle: {
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      width: "120px",
-      height: "120px",
-      rounded: "md",
-      borderWidth: "1px",
-      borderColor: "border-bold",
-      bg: "bg-subtle",
-      _selected: {
-        bg: "bg-tertiary-subtle",
-        borderBottomWidth: "4px",
-        borderBottomColor: "border-primary-subtle",
-      },
-    },
   })
 
   const api = tabs.connect(service, normalizeProps)


### PR DESCRIPTION
A different version FrameworkButton is created every render because the component definition is nested within another component definition.

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Extract the FrameworkButton component definition outside so it isn't a nested component definition.

## ⛳️ Current behavior (updates)

A different version of FrameworkButton is created every render, requiring you to double click the buttons to trigger the tab change.

## 🚀 New behavior

A single click will now cause the tab change.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

https://react.dev/learn/preserving-and-resetting-state#different-components-at-the-same-position-reset-state:~:text=This%20is%20why%20you%20should%20not%20nest%20component%20function%20definitions.