### PR TITLE
fix(number-input): activate scrubber only on main button

### DIFF
--- a/packages/machines/number-input/src/number-input.connect.ts
+++ b/packages/machines/number-input/src/number-input.connect.ts
@@ -263,6 +263,9 @@ export function connect<T extends PropTypes>(
         onMouseDown(event) {
           if (disabled) return
 
+          // activate scrubber only when main button is clicked
+          if (event.button !== 1) return
+
           const point = getEventPoint(event)
           const win = getWindow(event.currentTarget)
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description  & ⛳️ Current behavior (updates)

When you right click on scrubber icon the conext menu is opened but cursor cannot be moved. The issue is not present in Safari since they do not support `requestPointerLock` API

## 🚀 New behavior

This PR changes the behaviour to only activate a scrubber on primary button click. Uses [MouseEvent: button property](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button) to detect that.

## 💣 Is this a breaking change (Yes/No):

No
