### PR TITLE
fix(website): faq links to 404 page

### DIFF
--- a/website/data/overview/faq.mdx
+++ b/website/data/overview/faq.mdx
@@ -12,7 +12,7 @@ format that is compatible with the respective framework.
 
 It is also used to ensure that the returned properties are strongly typed.
 
-There are subtle difference between how element attributes are named across
+There are subtle differences between how element attributes are named across
 frameworks like React, Solid and Vue. Here are some examples:
 
 **Keydown listener**
@@ -32,11 +32,11 @@ These little nuances between frameworks are handled automatically when you use
 
 ## How can I attach custom extra event handlers to the elements?
 
-See the approach [here](/overview/composition#event-composition).
+See the approach [here](/guides/composition#event-composition).
 
 ## How can I get Zag working in a custom window environment?
 
-See the approach [here](/overview/composition#custom-window-environment).
+See the approach [here](/guides/composition#custom-window-environment).
 
 ## What would it take to support other frameworks?
 


### PR DESCRIPTION
Small fix. Noticed when reading the docs.

Closes #2526
