### PR TITLE
fix: error in range mode with month view due to incorrect value in resetSelection

### DIFF
--- a/.changeset/gentle-tomatoes-remain.md
+++ b/.changeset/gentle-tomatoes-remain.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/date-picker": patch
+"@zag-js/shared": patch
+"next-ts": patch
+---
+
+Fix issue where datepicker errors when setting `selectionMode=range` and `minView=year`

--- a/examples/next-ts/pages/date-picker-month-range.tsx
+++ b/examples/next-ts/pages/date-picker-month-range.tsx
@@ -1,0 +1,172 @@
+import * as datePicker from "@zag-js/date-picker"
+import { normalizeProps, useMachine } from "@zag-js/react"
+import { datePickerControls } from "@zag-js/shared"
+import { useId } from "react"
+import { StateVisualizer } from "../components/state-visualizer"
+import { Toolbar } from "../components/toolbar"
+import { useControls } from "../hooks/use-controls"
+import { CalendarDate, DateValue } from "@internationalized/date"
+
+const format = (date: DateValue) => {
+  if (!date) {
+    return undefined
+  }
+  const month = date?.month?.toString()?.padStart(2, "0")
+  const year = date?.year?.toString()
+  return `${month}/${year}`
+}
+
+// Handle full mm/yyyy format
+const parse = (string: string) => {
+  const fullRegex = /^(\d{1,2})\/(\d{4})$/
+  const fullMatch = string.match(fullRegex)
+  if (fullMatch) {
+    const [_, month, year] = fullMatch.map(Number)
+    return new CalendarDate(year, month, 1)
+  }
+}
+
+export default function Page() {
+  const controls = useControls(datePickerControls)
+  const service = useMachine(datePicker.machine, {
+    id: useId(),
+    locale: "en",
+    selectionMode: "range",
+    minView: "month",
+    defaultView: "month",
+    parse,
+    format,
+    placeholder: "mm/yyyy",
+    ...controls.context,
+  })
+
+  const api = datePicker.connect(service, normalizeProps)
+
+  return (
+    <>
+      <main className="date-picker">
+        <div>
+          <button>Outside Element</button>
+        </div>
+        <p>{`Visible range: ${api.visibleRangeText.formatted}`}</p>
+
+        <output className="date-output">
+          <div>Selected: {api.valueAsString ?? "-"}</div>
+          <div>Focused: {api.focusedValueAsString}</div>
+        </output>
+
+        <div {...api.getControlProps()}>
+          <input {...api.getInputProps({ index: 0 })} />
+          <input {...api.getInputProps({ index: 1 })} />
+          <button {...api.getClearTriggerProps()}>❌</button>
+          <button {...api.getTriggerProps()}>🗓</button>
+        </div>
+
+        <div {...api.getPositionerProps()}>
+          <div {...api.getContentProps()}>
+            <div style={{ marginBottom: "20px" }}>
+              <select {...api.getMonthSelectProps()}>
+                {api.getMonths().map((month, i) => (
+                  <option key={i} value={month.value}>
+                    {month.label}
+                  </option>
+                ))}
+              </select>
+
+              <select {...api.getYearSelectProps()}>
+                {api.getYears().map((year, i) => (
+                  <option key={i} value={year.value}>
+                    {year.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div hidden={api.view !== "day"} style={{ width: "100%" }}>
+              <div {...api.getViewControlProps({ view: "year" })}>
+                <button {...api.getPrevTriggerProps()}>Prev</button>
+                <button {...api.getViewTriggerProps()}>{api.visibleRangeText.start}</button>
+                <button {...api.getNextTriggerProps()}>Next</button>
+              </div>
+
+              <table {...api.getTableProps()}>
+                <thead {...api.getTableHeaderProps()}>
+                  <tr>
+                    {api.weekDays.map((day, i) => (
+                      <th scope="col" key={i} aria-label={day.long}>
+                        {day.narrow}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody {...api.getTableBodyProps()}>
+                  {api.weeks.map((week, i) => (
+                    <tr key={i}>
+                      {week.map((value, i) => (
+                        <td key={i} {...api.getDayTableCellProps({ value })}>
+                          <div {...api.getDayTableCellTriggerProps({ value })}>{value.day}</div>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div style={{ display: "flex", gap: "40px", marginTop: "24px" }}>
+              <div hidden={api.view !== "month"} style={{ width: "100%" }}>
+                <div {...api.getViewControlProps({ view: "year" })}>
+                  <button {...api.getPrevTriggerProps({ view: "month" })}>Prev</button>
+                  <button {...api.getViewTriggerProps({ view: "month" })}>{api.visibleRange.start.year}</button>
+                  <button {...api.getNextTriggerProps({ view: "month" })}>Next</button>
+                </div>
+
+                <table {...api.getTableProps({ view: "month", columns: 4 })}>
+                  <tbody {...api.getTableBodyProps({ view: "month" })}>
+                    {api.getMonthsGrid({ columns: 4, format: "short" }).map((months, row) => (
+                      <tr key={row}>
+                        {months.map((month, index) => (
+                          <td key={index} {...api.getMonthTableCellProps({ ...month, columns: 4 })}>
+                            <div {...api.getMonthTableCellTriggerProps({ ...month, columns: 4 })}>{month.label}</div>
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div hidden={api.view !== "year"} style={{ width: "100%" }}>
+                <div {...api.getViewControlProps({ view: "year" })}>
+                  <button {...api.getPrevTriggerProps({ view: "year" })}>Prev</button>
+                  <span>
+                    {api.getDecade().start} - {api.getDecade().end}
+                  </span>
+                  <button {...api.getNextTriggerProps({ view: "year" })}>Next</button>
+                </div>
+
+                <table {...api.getTableProps({ view: "year", columns: 4 })}>
+                  <tbody {...api.getTableBodyProps({ view: "year" })}>
+                    {api.getYearsGrid({ columns: 4 }).map((years, row) => (
+                      <tr key={row}>
+                        {years.map((year, index) => (
+                          <td key={index} {...api.getYearTableCellProps({ ...year, columns: 4 })}>
+                            <div {...api.getYearTableCellTriggerProps({ ...year, columns: 4 })}>{year.label}</div>
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <Toolbar viz controls={controls.ui}>
+        <StateVisualizer state={service} omit={["weeks"]} />
+      </Toolbar>
+    </>
+  )
+}

--- a/packages/machines/date-picker/src/date-picker.connect.ts
+++ b/packages/machines/date-picker/src/date-picker.connect.ts
@@ -138,6 +138,9 @@ export function connect<T extends PropTypes>(
       selectable: !isDateOutsideRange(normalized, min, max),
       selected: !!selectedValue.find((date) => date.month === value && date.year === focusedValue.year),
       valueText: formatter.format(normalized.toDate(timeZone)),
+      inRange:
+        isRangePicker &&
+        (isDateWithinRange(normalized, selectedValue) || isDateWithinRange(normalized, hoveredRangeValue)),
       get disabled() {
         return disabled || !cellState.selectable
       },
@@ -185,6 +188,8 @@ export function connect<T extends PropTypes>(
     const { view = "day", id } = props
     return [view, id].filter(Boolean).join(" ")
   }
+
+  console.log("selectedValue", selectedValue)
 
   return {
     focused,
@@ -513,7 +518,7 @@ export function connect<T extends PropTypes>(
         dir: prop("dir"),
         colSpan: columns,
         role: "gridcell",
-        "aria-selected": ariaAttr(cellState.selected),
+        "aria-selected": ariaAttr(cellState.selected || cellState.inRange),
         "data-selected": dataAttr(cellState.selected),
         "aria-disabled": ariaAttr(!cellState.selectable),
         "data-value": value,
@@ -532,6 +537,7 @@ export function connect<T extends PropTypes>(
         "aria-disabled": ariaAttr(!cellState.selectable),
         "data-disabled": dataAttr(!cellState.selectable),
         "data-focus": dataAttr(cellState.focused),
+        "data-in-range": dataAttr(cellState.inRange),
         "aria-label": cellState.valueText,
         "data-view": "month",
         "data-value": value,

--- a/packages/machines/date-picker/src/date-picker.connect.ts
+++ b/packages/machines/date-picker/src/date-picker.connect.ts
@@ -189,8 +189,6 @@ export function connect<T extends PropTypes>(
     return [view, id].filter(Boolean).join(" ")
   }
 
-  console.log("selectedValue", selectedValue)
-
   return {
     focused,
     open,

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -782,7 +782,8 @@ export const machine = createMachine<DatePickerSchema>({
       },
       resetSelection(params) {
         const { context, event } = params
-        context.set("value", [event.value ?? context.get("focusedValue")])
+        const value = normalizeValue(params, event.value ?? context.get("focusedValue"))
+        context.set("value", [value])
       },
       toggleSelectedDate(params) {
         const { context, event } = params

--- a/packages/machines/date-picker/src/date-picker.types.ts
+++ b/packages/machines/date-picker/src/date-picker.types.ts
@@ -396,6 +396,7 @@ export interface TableCellState {
   selectable: boolean
   selected: boolean
   valueText: string
+  inRange?: boolean
   readonly disabled: boolean
 }
 

--- a/shared/src/routes.ts
+++ b/shared/src/routes.ts
@@ -33,6 +33,7 @@ export const routesData: RouteData[] = [
   { label: "Date Picker (Range)", path: "/date-picker-range" },
   { label: "Date Picker (Multi)", path: "/date-picker-multi" },
   { label: "Date Picker (Inline)", path: "/date-picker-inline" },
+  { label: "Date Picker (Month + Range)", path: "/date-picker-month-range" },
   { label: "Select", path: "/select" },
   { label: "Accordion", path: "/accordion" },
   { label: "Checkbox", path: "/checkbox" },


### PR DESCRIPTION
Closes #2556

## 📝 Description

When using selectionMode="range" with view="month", two issues were present:

1. An error was thrown when resetting the selection (e.g., third selection):
```
Uncaught TypeError: date.toDate is not a function
// or
Cannot read properties of undefined (reading 'toString')
```

2. The `in-range` styling didn’t work correctly—between selected months, the intermediate months lacked the data-in-range attribute.

Both issues stemmed from incorrect handling of month values (number instead of Date) and missing logic for marking range states.

This PR corrects both:
- Ensures resetSelection wraps month values as Date.
- Fixes cellState.inRange logic

And added a working example demonstrating both resetSelection behavior and in-range styling for month + range.


## ⛳️ Current behavior (updates)

- Runtime error occurs on third selection.
- Intermediate months are missing data-in-range, making range styling incomplete.


## 🚀 New behavior

- No runtime error, and selection resets cleanly.
- Intermediate months in month view receive data-in-range, enabling full range styling.
- Accessibility attributes (aria-selected) account for both selected and in-range states.


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This resolves the root issue described in #2556 and ensures range mode is compatible with month view.
If there are better ways to handle the value conversion or integration, I’m happy to revise this PR based on feedback.
