### PR TITLE
feat: add in-range hover preview for month view

### DIFF
--- a/examples/next-ts/pages/date-picker-year-range.tsx
+++ b/examples/next-ts/pages/date-picker-year-range.tsx
@@ -1,0 +1,171 @@
+import * as datePicker from "@zag-js/date-picker"
+import { normalizeProps, useMachine } from "@zag-js/react"
+import { datePickerControls } from "@zag-js/shared"
+import { useId } from "react"
+import { StateVisualizer } from "../components/state-visualizer"
+import { Toolbar } from "../components/toolbar"
+import { useControls } from "../hooks/use-controls"
+import { CalendarDate, DateValue } from "@internationalized/date"
+
+const format = (date: DateValue) => {
+  if (!date) {
+    return undefined
+  }
+  const year = date?.year?.toString()
+  return year
+}
+
+// Handle full mm/yyyy format
+const parse = (string: string) => {
+  const fullRegex = /^(\d{4})$/
+  const fullMatch = string.match(fullRegex)
+  if (fullMatch) {
+    const [_, year] = fullMatch.map(Number)
+    return new CalendarDate(year, 1, 1)
+  }
+}
+
+export default function Page() {
+  const controls = useControls(datePickerControls)
+  const service = useMachine(datePicker.machine, {
+    id: useId(),
+    locale: "en",
+    selectionMode: "range",
+    minView: "year",
+    defaultView: "year",
+    parse,
+    format,
+    placeholder: "yyyy",
+    ...controls.context,
+  })
+
+  const api = datePicker.connect(service, normalizeProps)
+
+  return (
+    <>
+      <main className="date-picker">
+        <div>
+          <button>Outside Element</button>
+        </div>
+        <p>{`Visible range: ${api.visibleRangeText.formatted}`}</p>
+
+        <output className="date-output">
+          <div>Selected: {api.valueAsString ?? "-"}</div>
+          <div>Focused: {api.focusedValueAsString}</div>
+        </output>
+
+        <div {...api.getControlProps()}>
+          <input {...api.getInputProps({ index: 0 })} />
+          <input {...api.getInputProps({ index: 1 })} />
+          <button {...api.getClearTriggerProps()}>❌</button>
+          <button {...api.getTriggerProps()}>🗓</button>
+        </div>
+
+        <div {...api.getPositionerProps()}>
+          <div {...api.getContentProps()}>
+            <div style={{ marginBottom: "20px" }}>
+              <select {...api.getMonthSelectProps()}>
+                {api.getMonths().map((month, i) => (
+                  <option key={i} value={month.value}>
+                    {month.label}
+                  </option>
+                ))}
+              </select>
+
+              <select {...api.getYearSelectProps()}>
+                {api.getYears().map((year, i) => (
+                  <option key={i} value={year.value}>
+                    {year.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div hidden={api.view !== "day"} style={{ width: "100%" }}>
+              <div {...api.getViewControlProps({ view: "year" })}>
+                <button {...api.getPrevTriggerProps()}>Prev</button>
+                <button {...api.getViewTriggerProps()}>{api.visibleRangeText.start}</button>
+                <button {...api.getNextTriggerProps()}>Next</button>
+              </div>
+
+              <table {...api.getTableProps()}>
+                <thead {...api.getTableHeaderProps()}>
+                  <tr>
+                    {api.weekDays.map((day, i) => (
+                      <th scope="col" key={i} aria-label={day.long}>
+                        {day.narrow}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody {...api.getTableBodyProps()}>
+                  {api.weeks.map((week, i) => (
+                    <tr key={i}>
+                      {week.map((value, i) => (
+                        <td key={i} {...api.getDayTableCellProps({ value })}>
+                          <div {...api.getDayTableCellTriggerProps({ value })}>{value.day}</div>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div style={{ display: "flex", gap: "40px", marginTop: "24px" }}>
+              <div hidden={api.view !== "month"} style={{ width: "100%" }}>
+                <div {...api.getViewControlProps({ view: "year" })}>
+                  <button {...api.getPrevTriggerProps({ view: "month" })}>Prev</button>
+                  <button {...api.getViewTriggerProps({ view: "month" })}>{api.visibleRange.start.year}</button>
+                  <button {...api.getNextTriggerProps({ view: "month" })}>Next</button>
+                </div>
+
+                <table {...api.getTableProps({ view: "month", columns: 4 })}>
+                  <tbody {...api.getTableBodyProps({ view: "month" })}>
+                    {api.getMonthsGrid({ columns: 4, format: "short" }).map((months, row) => (
+                      <tr key={row}>
+                        {months.map((month, index) => (
+                          <td key={index} {...api.getMonthTableCellProps({ ...month, columns: 4 })}>
+                            <div {...api.getMonthTableCellTriggerProps({ ...month, columns: 4 })}>{month.label}</div>
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div hidden={api.view !== "year"} style={{ width: "100%" }}>
+                <div {...api.getViewControlProps({ view: "year" })}>
+                  <button {...api.getPrevTriggerProps({ view: "year" })}>Prev</button>
+                  <span>
+                    {api.getDecade().start} - {api.getDecade().end}
+                  </span>
+                  <button {...api.getNextTriggerProps({ view: "year" })}>Next</button>
+                </div>
+
+                <table {...api.getTableProps({ view: "year", columns: 4 })}>
+                  <tbody {...api.getTableBodyProps({ view: "year" })}>
+                    {api.getYearsGrid({ columns: 4 }).map((years, row) => (
+                      <tr key={row}>
+                        {years.map((year, index) => (
+                          <td key={index} {...api.getYearTableCellProps({ ...year, columns: 4 })}>
+                            <div {...api.getYearTableCellTriggerProps({ ...year, columns: 4 })}>{year.label}</div>
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <Toolbar viz controls={controls.ui}>
+        <StateVisualizer state={service} omit={["weeks"]} />
+      </Toolbar>
+    </>
+  )
+}

--- a/packages/machines/date-picker/src/date-picker.types.ts
+++ b/packages/machines/date-picker/src/date-picker.types.ts
@@ -396,7 +396,8 @@ export interface TableCellState {
   selectable: boolean
   selected: boolean
   valueText: string
-  inRange?: boolean
+  inRange: boolean
+  normalizedDate: DateValue
   readonly disabled: boolean
 }
 

--- a/shared/src/routes.ts
+++ b/shared/src/routes.ts
@@ -34,6 +34,7 @@ export const routesData: RouteData[] = [
   { label: "Date Picker (Multi)", path: "/date-picker-multi" },
   { label: "Date Picker (Inline)", path: "/date-picker-inline" },
   { label: "Date Picker (Month + Range)", path: "/date-picker-month-range" },
+  { label: "Date Picker (Year + Range)", path: "/date-picker-year-range" },
   { label: "Select", path: "/select" },
   { label: "Accordion", path: "/accordion" },
   { label: "Checkbox", path: "/checkbox" },


### PR DESCRIPTION
Thank you so much for merging #2563 so quickly! @segunadebayo 
This PR is a follow-up that improves the range interaction further, especially around month and year views. 

## 📝 Description

This PR enhances the range selection experience in the month and year views of the `datepicker` component by adding in-range preview and styling support, consistent with the behavior in day view.

To support this, it also introduces a new `normalizedDate` field to the `TableCellState` type.

## ⛳️ Current behavior (updates)

- In range mode with month view:
   - Hovering over a future month after selecting a start value does not preview the in-range area.
- In range mode with year view:
   - Even after both start and end years are selected, intermediate years are not marked with data-in-range.
- The TableCellState structure lacks a normalized Date value to support consistent comparisons across views.


## 🚀 New behavior

**month view**
- Now supports hover-based in-range preview using onPointerMove, matching day view behavior.

**year view**
- Hover preview is intentionally not implemented due to edge cases (e.g., infinite navigation when hovering the last cell like 2030).
- However, already-selected year ranges now correctly apply the data-in-range attribute to intermediate years.

A normalizedDate field has been added to TableCellState to enable robust comparisons in range logic.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
- The decision to exclude hover preview for year view is based on an observed issue: when the year grid spans 2019–2030, hovering the last cell (2030) can cause infinite next-page transitions.
- The normalizedDate addition has been kept internal to avoid side effects. Please let me know if this introduces any unintended consequences — happy to adjust based on feedback.
