### PR TITLE
Updated default pattern in number input to allow negative numbers with decimal point

### DIFF
--- a/e2e/models/number-input.model.ts
+++ b/e2e/models/number-input.model.ts
@@ -48,6 +48,12 @@ export class NumberInputModel extends Model {
     await expect(this.input).toHaveAttribute("aria-invalid", "true")
   }
 
+  async seeInputIsValid() {
+    const isValid = await this.input.evaluate((el: HTMLInputElement) => el.checkValidity())
+
+    await expect(isValid).toBe(true)
+  }
+
   async clickInc() {
     await this.incButton.click()
   }

--- a/e2e/number-input.e2e.ts
+++ b/e2e/number-input.e2e.ts
@@ -140,4 +140,24 @@ test.describe("number input", () => {
     await I.mouseup()
     await I.seeInputHasValue("10")
   })
+
+  test("should allow negative integer values", async () => {
+    await I.type("-12345")
+    await I.seeInputIsValid()
+  })
+
+  test("should allow positive integer values", async () => {
+    await I.type("12345")
+    await I.seeInputIsValid()
+  })
+
+  test("should allow positive values with decimal point", async () => {
+    await I.type("0.30")
+    await I.seeInputIsValid()
+  })
+
+  test("should allow negative values with decimal point", async () => {
+    await I.type("-0.30")
+    await I.seeInputIsValid()
+  })
 })

--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -37,7 +37,7 @@ export const machine = createMachine({
       clampValueOnBlur: !props.allowOverflow,
       allowOverflow: false,
       inputMode: "decimal",
-      pattern: "[0-9]*(.[0-9]+)?",
+      pattern: "-?[0-9]*(.[0-9]+)?",
       defaultValue: "",
       step,
       min: Number.MIN_SAFE_INTEGER,


### PR DESCRIPTION
## 📝 Description
The current default pattern in the number input `"[0-9]*(.[0-9]+)?"` does not allow negative numbers with a decimal point. 

## ⛳️ Current behavior (updates)
HTML validator throws a validation error on negative numbers with a decimal point
<img width="452" height="149" alt="image" src="https://github.com/user-attachments/assets/e42b36bc-dd50-4eda-a545-b7824afaaaa7" />

## 🚀 New behavior
Allows you to submit a form that contains a number input with a negative decimal point value. 

## 💣 Is this a breaking change (Yes/No):
No
