### PR TITLE
fix(date-picker): prefer date time contraint to allow dates set to the end of day

### DIFF
--- a/.changeset/polite-cobras-pull.md
+++ b/.changeset/polite-cobras-pull.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-utils": patch
+---
+
+Fix date picker constraint logic to properly handle end-of-day times by using `toCalendarDateTime` instead of `toCalendarDate` when applying min/max constraints.

--- a/packages/utilities/date-utils/src/constrain.ts
+++ b/packages/utilities/date-utils/src/constrain.ts
@@ -6,7 +6,7 @@ import {
   startOfMonth,
   startOfWeek,
   startOfYear,
-  toCalendarDate,
+  toCalendarDateTime,
 } from "@internationalized/date"
 
 /* -----------------------------------------------------------------------------
@@ -96,11 +96,11 @@ export function constrainStart(
   max?: DateValue,
 ): DateValue {
   if (min && date.compare(min) >= 0) {
-    aligned = maxDate(aligned, alignStart(toCalendarDate(min), duration, locale))!
+    aligned = maxDate(aligned, alignStart(toCalendarDateTime(min), duration, locale))!
   }
 
   if (max && date.compare(max) <= 0) {
-    aligned = minDate(aligned, alignEnd(toCalendarDate(max), duration, locale))!
+    aligned = minDate(aligned, alignEnd(toCalendarDateTime(max), duration, locale))!
   }
 
   return aligned
@@ -108,10 +108,10 @@ export function constrainStart(
 
 export function constrainValue(date: DateValue, minValue?: DateValue, maxValue?: DateValue): DateValue {
   if (minValue) {
-    date = maxDate(date, toCalendarDate(minValue))!
+    date = maxDate(date, toCalendarDateTime(minValue))!
   }
   if (maxValue) {
-    date = minDate(date, toCalendarDate(maxValue))!
+    date = minDate(date, toCalendarDateTime(maxValue))!
   }
   return date
 }

--- a/packages/utilities/date-utils/src/constrain.ts
+++ b/packages/utilities/date-utils/src/constrain.ts
@@ -1,4 +1,3 @@
-import { toCalendarDate } from "@internationalized/date"
 import {
   type DateDuration,
   type DateValue,

--- a/packages/utilities/date-utils/src/constrain.ts
+++ b/packages/utilities/date-utils/src/constrain.ts
@@ -1,3 +1,4 @@
+import { toCalendarDate } from "@internationalized/date"
 import {
   type DateDuration,
   type DateValue,
@@ -108,10 +109,10 @@ export function constrainStart(
 
 export function constrainValue(date: DateValue, minValue?: DateValue, maxValue?: DateValue): DateValue {
   if (minValue) {
-    date = maxDate(date, toCalendarDateTime(minValue))!
+    date = maxDate(date, minValue)!
   }
   if (maxValue) {
-    date = minDate(date, toCalendarDateTime(maxValue))!
+    date = minDate(date, maxValue)!
   }
   return date
 }

--- a/packages/utilities/date-utils/tests/date.test.ts
+++ b/packages/utilities/date-utils/tests/date.test.ts
@@ -16,14 +16,39 @@ const stringify = (opts: any) => ({
 })
 
 describe("Date utilities", () => {
-  test("constrain", () => {
+  test("constrain to max value", () => {
     const focusedDate = parseDate("2024-03-15")
     expect(constrainValue(focusedDate, min, max).toString()).toMatchInlineSnapshot(`"2023-12-31T23:59:59.999"`)
+  })
+
+  test("constrain to min value", () => {
+    const focusedDate = parseDate("2022-03-15")
+    expect(constrainValue(focusedDate, min, max).toString()).toMatchInlineSnapshot(`"2023-01-01T00:00:00"`)
+  })
+
+  test("unchange date when focused date is within min and max", () => {
+    const focusedDate = parseDate("2023-03-15")
+    expect(constrainValue(focusedDate, min, max).toString()).toMatchInlineSnapshot(`"2023-03-15"`)
   })
 
   test("pagination / next page", () => {
     const focusedDate = parseDate("2023-01-12")
     const startDate = parseDate("2023-01-01")
+    const nextPage = getNextPage(focusedDate, startDate, duration, locale, min, max)
+    expect(stringify(nextPage)).toMatchInlineSnapshot(`
+      {
+        "endDate": "2023-02-28",
+        "focusedDate": "2023-02-12",
+        "startDate": "2023-02-01",
+      }
+    `)
+  })
+
+  test("pagination / next page with CalendarDate min and max", () => {
+    const focusedDate = parseDate("2023-01-12")
+    const startDate = parseDate("2023-01-01")
+    const min = parseDate("2023-01-01")
+    const max = parseDate("2023-12-31")
     const nextPage = getNextPage(focusedDate, startDate, duration, locale, min, max)
     expect(stringify(nextPage)).toMatchInlineSnapshot(`
       {

--- a/packages/utilities/date-utils/tests/date.test.ts
+++ b/packages/utilities/date-utils/tests/date.test.ts
@@ -1,4 +1,4 @@
-import { parseDate } from "@internationalized/date"
+import { parseDate, parseDateTime } from "@internationalized/date"
 import { describe, expect, test } from "vitest"
 import { constrainValue, getNextPage, getPreviousPage } from "../src"
 
@@ -6,8 +6,8 @@ const locale = "en-US"
 // const timeZone = "UTC"
 const duration = { months: 1 }
 
-const min = parseDate("2023-01-01")
-const max = parseDate("2023-12-31")
+const min = parseDateTime("2023-01-01T00:00:00")
+const max = parseDateTime("2023-12-31T23:59:59.999")
 
 const stringify = (opts: any) => ({
   startDate: opts.startDate.toString(),
@@ -18,7 +18,7 @@ const stringify = (opts: any) => ({
 describe("Date utilities", () => {
   test("constrain", () => {
     const focusedDate = parseDate("2024-03-15")
-    expect(constrainValue(focusedDate, min, max).toString()).toMatchInlineSnapshot(`"2023-12-31"`)
+    expect(constrainValue(focusedDate, min, max).toString()).toMatchInlineSnapshot(`"2023-12-31T23:59:59.999"`)
   })
 
   test("pagination / next page", () => {
@@ -40,9 +40,9 @@ describe("Date utilities", () => {
     const prevPage = getPreviousPage(focusedDate, startDate, duration, locale, min, max)
     expect(stringify(prevPage)).toMatchInlineSnapshot(`
       {
-        "endDate": "2023-01-31",
-        "focusedDate": "2023-01-01",
-        "startDate": "2023-01-01",
+        "endDate": "2023-01-31T00:00:00",
+        "focusedDate": "2023-01-01T00:00:00",
+        "startDate": "2023-01-01T00:00:00",
       }
     `)
   })


### PR DESCRIPTION
## 📝 Description

Fix date picker constraint logic to properly handle end-of-day times by using `toCalendarDateTime` instead of `toCalendarDate` when applying min/max constraints.

## ⛳️ Current behavior (updates)

When constraining dates to min/max boundaries, the date picker was using `toCalendarDate()` which strips time information, forcing dates to the beginning of the day (e.g., `2023-12-31T00:00:00`). This prevented users from setting dates to the end of the specified day range.

## 🚀 New behavior

The date picker now uses `toCalendarDateTime()` to preserve time information when applying constraints, allowing dates to be set to the end of the day (e.g., `2023-12-31T23:59:59.999`). This provides more accurate and expected constraint behavior for date ranges.

## 💣 Is this a breaking change (Yes/No): No

This is a bug fix that improves constraint accuracy without changing the public API.

## 📝 Additional Information

- Updated `constrainValue()` and `constrainStart()` functions in date-utils
- Enhanced test coverage to verify end-of-day constraint behavior
- Affects date picker min/max value handling across all framework adapters
