### PR TITLE
feat(date-picker): inline data attribute

### DIFF
--- a/.changeset/dull-schools-kneel.md
+++ b/.changeset/dull-schools-kneel.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-picker": patch
+---
+
+feat(date-picker): expose `data-inline` attribute on Content part to enable distinct styling for inline date pickers versus popover date pickers

--- a/examples/next-ts/pages/date-picker-inline.tsx
+++ b/examples/next-ts/pages/date-picker-inline.tsx
@@ -1,0 +1,141 @@
+import * as datePicker from "@zag-js/date-picker"
+import { normalizeProps, useMachine } from "@zag-js/react"
+import { datePickerControls } from "@zag-js/shared"
+import { useId } from "react"
+import { StateVisualizer } from "../components/state-visualizer"
+import { Toolbar } from "../components/toolbar"
+import { useControls } from "../hooks/use-controls"
+
+export default function Page() {
+  const controls = useControls(datePickerControls)
+  const service = useMachine(datePicker.machine, {
+    id: useId(),
+    locale: "en",
+    selectionMode: "single",
+    inline: true,
+    defaultValue: [datePicker.parse(new Date())],
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    ...controls.context,
+  })
+
+  const api = datePicker.connect(service, normalizeProps)
+
+  return (
+    <>
+      <main className="date-picker">
+        <div>
+          <button>Outside Element</button>
+        </div>
+        <p>{`Visible range: ${api.visibleRangeText.formatted}`}</p>
+
+        <output className="date-output">
+          <div>Selected: {api.valueAsString ?? "-"}</div>
+          <div>Focused: {api.focusedValueAsString}</div>
+        </output>
+
+        <div {...api.getContentProps()}>
+          <div style={{ marginBottom: "20px" }}>
+            <select {...api.getMonthSelectProps()}>
+              {api.getMonths().map((month, i) => (
+                <option key={i} value={month.value}>
+                  {month.label}
+                </option>
+              ))}
+            </select>
+
+            <select {...api.getYearSelectProps()}>
+              {api.getYears().map((year, i) => (
+                <option key={i} value={year.value}>
+                  {year.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div hidden={api.view !== "day"}>
+            <div {...api.getViewControlProps({ view: "year" })}>
+              <button {...api.getPrevTriggerProps()}>Prev</button>
+              <button {...api.getViewTriggerProps()}>{api.visibleRangeText.start}</button>
+              <button {...api.getNextTriggerProps()}>Next</button>
+            </div>
+
+            <table {...api.getTableProps({ view: "day" })}>
+              <thead {...api.getTableHeaderProps({ view: "day" })}>
+                <tr {...api.getTableRowProps({ view: "day" })}>
+                  {api.weekDays.map((day, i) => (
+                    <th scope="col" key={i} aria-label={day.long}>
+                      {day.narrow}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody {...api.getTableBodyProps({ view: "day" })}>
+                {api.weeks.map((week, i) => (
+                  <tr key={i} {...api.getTableRowProps({ view: "day" })}>
+                    {week.map((value, i) => (
+                      <td key={i} {...api.getDayTableCellProps({ value })}>
+                        <div {...api.getDayTableCellTriggerProps({ value })}>{value.day}</div>
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{ display: "flex", gap: "40px" }}>
+            <div hidden={api.view !== "month"} style={{ width: "100%" }}>
+              <div {...api.getViewControlProps({ view: "month" })}>
+                <button {...api.getPrevTriggerProps({ view: "month" })}>Prev</button>
+                <button {...api.getViewTriggerProps({ view: "month" })}>{api.visibleRange.start.year}</button>
+                <button {...api.getNextTriggerProps({ view: "month" })}>Next</button>
+              </div>
+
+              <table {...api.getTableProps({ view: "month", columns: 4 })}>
+                <tbody {...api.getTableBodyProps({ view: "month" })}>
+                  {api.getMonthsGrid({ columns: 4, format: "short" }).map((months, row) => (
+                    <tr key={row} {...api.getTableRowProps()}>
+                      {months.map((month, index) => (
+                        <td key={index} {...api.getMonthTableCellProps({ ...month, columns: 4 })}>
+                          <div {...api.getMonthTableCellTriggerProps({ ...month, columns: 4 })}>{month.label}</div>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div hidden={api.view !== "year"} style={{ width: "100%" }}>
+              <div {...api.getViewControlProps({ view: "year" })}>
+                <button {...api.getPrevTriggerProps({ view: "year" })}>Prev</button>
+                <span>
+                  {api.getDecade().start} - {api.getDecade().end}
+                </span>
+                <button {...api.getNextTriggerProps({ view: "year" })}>Next</button>
+              </div>
+
+              <table {...api.getTableProps({ view: "year", columns: 4 })}>
+                <tbody {...api.getTableBodyProps()}>
+                  {api.getYearsGrid({ columns: 4 }).map((years, row) => (
+                    <tr key={row} {...api.getTableRowProps({ view: "year" })}>
+                      {years.map((year, index) => (
+                        <td key={index} {...api.getYearTableCellProps({ ...year, columns: 4 })}>
+                          <div {...api.getYearTableCellTriggerProps({ ...year, columns: 4 })}>{year.label}</div>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <Toolbar viz controls={controls.ui}>
+        <StateVisualizer state={service} omit={["weeks"]} />
+      </Toolbar>
+    </>
+  )
+}

--- a/packages/machines/date-picker/src/date-picker.connect.ts
+++ b/packages/machines/date-picker/src/date-picker.connect.ts
@@ -347,6 +347,7 @@ export function connect<T extends PropTypes>(
         dir: prop("dir"),
         "data-state": open ? "open" : "closed",
         "data-placement": currentPlacement,
+        "data-inline": dataAttr(prop("inline")),
         id: dom.getContentId(scope),
         tabIndex: -1,
         role: "application",

--- a/shared/src/css/date-picker.css
+++ b/shared/src/css/date-picker.css
@@ -58,6 +58,12 @@
   border-radius: 8px;
 }
 
+[data-scope="date-picker"][data-part="content"][data-inline] {
+  border: 0;
+  padding: 0;
+  border-radius: 0;
+}
+
 [data-scope="date-picker"][data-part="table"] {
   min-width: 240px;
   width: 100%;


### PR DESCRIPTION
## 📝 Description
- expose `data-inline` attribute on Content part to enable distinct styling for inline date pickers versus popover date pickers
- implement `/date-picker-inline` route in the next-ts example

<img width="2230" height="1262" alt="image" src="https://github.com/user-attachments/assets/fbe3c4a2-4ca9-4aaa-abab-2ee0df72ce45" />
