### PR TITLE
Fix zag github issue 2612

### DIFF
--- a/packages/machines/carousel/src/carousel.machine.ts
+++ b/packages/machines/carousel/src/carousel.machine.ts
@@ -13,7 +13,7 @@ export const machine = createMachine<CarouselSchema>({
       defaultPage: 0,
       orientation: "horizontal",
       snapType: "mandatory",
-      loop: !!props.autoplay,
+      loop: false,
       slidesPerPage: 1,
       slidesPerMove: "auto",
       spacing: "0px",
@@ -199,9 +199,16 @@ export const machine = createMachine<CarouselSchema>({
       effects: ["trackDocumentVisibility", "trackScroll", "autoUpdateSlide"],
       exit: ["invokeAutoplayEnd"],
       on: {
-        "AUTOPLAY.TICK": {
-          actions: ["setNextPage", "invokeAutoplay"],
-        },
+        "AUTOPLAY.TICK": [
+          {
+            guard: "canScrollNext",
+            actions: ["setNextPage", "invokeAutoplay"],
+          },
+          {
+            target: "idle",
+            actions: ["invokeAutoplayEnd"],
+          },
+        ],
         "DRAGGING.START": {
           target: "dragging",
           actions: ["invokeDragStart"],
@@ -372,12 +379,12 @@ export const machine = createMachine<CarouselSchema>({
         context.set("page", page)
       },
       setNextPage({ context, prop, state }) {
-        const loop = state.matches("autoplay") || prop("loop")
+        const loop = prop("loop")
         const page = nextIndex(context.get("pageSnapPoints"), context.get("page"), { loop })
         context.set("page", page)
       },
       setPrevPage({ context, prop, state }) {
-        const loop = state.matches("autoplay") || prop("loop")
+        const loop = prop("loop")
         const page = prevIndex(context.get("pageSnapPoints"), context.get("page"), { loop })
         context.set("page", page)
       },


### PR DESCRIPTION
Closes #2612

## 📝 Description

Fixes an issue where the carousel autoplay would ignore the `loop: false` option, causing it to continuously loop instead of stopping at the last slide.

## ⛳️ Current behavior (updates)

Previously, the carousel's autoplay mechanism would:
- Force the `loop` property to `true` when autoplay was enabled, overriding any explicit `loop: false` setting.
- Continue to loop indefinitely even when `loop: false` was intended, due to incorrect logic in `setNextPage` and `setPrevPage` actions.
- Not pause autoplay when reaching the end of slides with `loop: false`.

## 🚀 New behavior

With this fix, the carousel now:
- Properly respects the `loop: false` option when `autoplay: true` is set.
- Automatically pauses autoplay when it reaches the last slide and `loop: false` is configured.
- Allows explicit `loop: true` with autoplay for continuous playback.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The fix addresses three root causes:
1.  **Default Override**: Changed `loop: !!props.autoplay` to `loop: false` in the initial context to prevent `autoplay` from forcing `loop`.
2.  **Action Logic**: Modified `setNextPage` and `setPrevPage` actions to only use `prop("loop")` instead of `state.matches("autoplay") || prop("loop")`, ensuring the `loop` prop is respected.
3.  **Missing Pause Logic**: Added a guard to the `AUTOPLAY.TICK` event to check `canScrollNext`. If unable to scroll next (i.e., at the end with `loop: false`), the carousel transitions to the `idle` state and invokes `autoplayEnd`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5374ae14-8a16-4509-95a4-4cd98a3566f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5374ae14-8a16-4509-95a4-4cd98a3566f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

