### PR TITLE
feat(radio-group): maintain data-focus-visible on arrow key navigation

### DIFF
--- a/packages/machines/radio-group/src/radio-group.connect.ts
+++ b/packages/machines/radio-group/src/radio-group.connect.ts
@@ -16,7 +16,7 @@ export function connect<T extends PropTypes>(
 
   function getItemState(props: ItemProps): ItemState {
     const focused = context.get("focusedValue") === props.value
-    const focusVisible = focused && isFocusVisible()
+    const focusVisible = context.get("focusVisibleValue") === props.value
     return {
       value: props.value,
       invalid: !!props.invalid,
@@ -172,9 +172,14 @@ export function connect<T extends PropTypes>(
         },
         onBlur() {
           send({ type: "SET_FOCUSED", value: null, focused: false })
+          send({ type: "SET_FOCUS_VISIBLE", value: null, focusVisible: false })
         },
         onFocus() {
           send({ type: "SET_FOCUSED", value: props.value, focused: true })
+          const focusVisible = isFocusVisible()
+          if (focusVisible) {
+            send({ type: "SET_FOCUS_VISIBLE", value: props.value, focusVisible: true })
+          }
         },
         onKeyDown(event) {
           if (event.defaultPrevented) return

--- a/packages/machines/radio-group/src/radio-group.machine.ts
+++ b/packages/machines/radio-group/src/radio-group.machine.ts
@@ -34,6 +34,9 @@ export const machine = createMachine<RadioGroupSchema>({
       focusedValue: bindable<string | null>(() => ({
         defaultValue: null,
       })),
+      focusVisibleValue: bindable<string | null>(() => ({
+        defaultValue: null,
+      })),
       hoveredValue: bindable<string | null>(() => ({
         defaultValue: null,
       })),
@@ -93,6 +96,9 @@ export const machine = createMachine<RadioGroupSchema>({
     SET_FOCUSED: {
       actions: ["setFocused"],
     },
+    SET_FOCUS_VISIBLE: {
+      actions: ["setFocusVisible"],
+    },
   },
 
   states: {
@@ -132,6 +138,9 @@ export const machine = createMachine<RadioGroupSchema>({
       },
       setFocused({ context, event }) {
         context.set("focusedValue", event.value)
+      },
+      setFocusVisible({ context, event }) {
+        context.set("focusVisibleValue", event.value)
       },
       syncInputElements({ context, scope }) {
         const inputs = dom.getInputEls(scope)

--- a/packages/machines/radio-group/src/radio-group.types.ts
+++ b/packages/machines/radio-group/src/radio-group.types.ts
@@ -81,6 +81,10 @@ interface PrivateContext {
    */
   focusedValue: string | null
   /**
+   * The id of the focused radio
+   */
+  focusVisibleValue: string | null
+  /**
    * The id of the hovered radio
    */
   hoveredValue: string | null


### PR DESCRIPTION
Closes #2629

## 📝 Description

Ensures that the data-focus-visible attribute is preserved when navigating between items in the RadioGroup component using arrow keys.
This improves keyboard accessibility by keeping the visual focus indicator visible throughout arrow key navigation, aligning with WAI-ARIA Authoring Practices.


## ⛳️ Current behavior (updates)

Currently, data-focus-visible is only applied when the RadioGroup first receives focus via keyboard entry (e.g., Tab).
When navigating with arrow keys, focusedValue updates to the new item, but data-focus-visible is not applied, causing the visual focus indicator to disappear for keyboard users.

## 🚀 New behavior

- Added focusVisibleValue state and SET_FOCUS_VISIBLE action
- Updated keyboard event handling to update focusVisibleValue when navigating via arrow keys
- Changed data-focus-visible logic to use focusVisibleValue instead of focusedValue
- As a result, data-focus-visible is maintained during both initial Tab entry and arrow key navigation

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- This change follows the [WAI-ARIA Authoring Practices 1.2 – Radio Group Keyboard Interaction](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) guidelines.
- focusedValue still tracks the focus position, while focusVisibleValue specifically tracks whether the focus should be visually indicated based on keyboard modality.
- If this approach differs from the intended design or there’s a better integration path, feedback would be greatly appreciated.
