### PR TITLE
Escape animation names in presence machine

### DIFF
--- a/packages/machines/presence/src/presence.machine.ts
+++ b/packages/machines/presence/src/presence.machine.ts
@@ -155,17 +155,19 @@ export const machine = createMachine<PresenceSchema>({
         if (!node) return
 
         const onStart = (event: AnimationEvent) => {
-          const target = event.composedPath?.()?.[0] ?? event.target
+          const target = getEventTarget(event)
           if (target === node) {
             context.set("prevAnimationName", getAnimationName(refs.get("styles")))
           }
         }
 
         const onEnd = (event: AnimationEvent) => {
-          const animationName = getAnimationName(refs.get("styles"))
           const target = getEventTarget(event)
-          if (target === node && animationName === context.get("unmountAnimationName")) {
-            send({ type: "UNMOUNT", src: "animationend" })
+          if (target === node) {
+            const endedName = CSS.escape(event.animationName)
+            if (endedName === context.get("unmountAnimationName")) {
+              send({ type: "UNMOUNT", src: "animationend" })
+            }
           }
         }
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #

## 📝 Description

Ensures animation names from `AnimationEvent` are properly escaped before comparison in the presence machine, preventing mismatches for animation names containing special characters.

## ⛳️ Current behavior (updates)

Previously, the `animationName` from `AnimationEvent` was compared directly with the stored `unmountAnimationName`. This could lead to incorrect unmounting if the animation name contained characters that require CSS escaping (e.g., spaces, special symbols).

## 🚀 New behavior

The `animationName` from `AnimationEvent` is now escaped using `CSS.escape()` before being compared to the `unmountAnimationName`. This ensures accurate matching and reliable unmounting, even when animation names include characters that would otherwise cause mismatches.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Inspired by a similar fix in Radix UI primitives (https://github.com/radix-ui/primitives/pull/3466). The `unmountAnimationName` itself (derived from computed styles) is not escaped, as the issue specifically pertains to the `animationName` property of the `AnimationEvent`.

---
<a href="https://cursor.com/background-agent?bcId=bc-11985435-1af9-4a90-a5ef-800a0f0fb537">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11985435-1af9-4a90-a5ef-800a0f0fb537">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

