### PR TITLE
Add inverted prop to slider machine

### DIFF
--- a/packages/docs/data/api.json
+++ b/packages/docs/data/api.json
@@ -4066,6 +4066,10 @@
         "type": "{ width: number; height: number; }",
         "description": "The slider thumbs dimensions"
       },
+      "inverted": {
+        "type": "boolean",
+        "description": "Whether the visual direction of the slider is inverted.\n- Horizontal: value increases towards the left when `true`.\n- Vertical: value increases towards the bottom when `true`.\n\nThis affects pointer interactions, thumb/range positioning, and arrow key behavior."
+      },
       "dir": {
         "type": "\"ltr\" | \"rtl\"",
         "description": "The document's text/writing direction.",

--- a/packages/docs/data/data-attr.json
+++ b/packages/docs/data/data-attr.json
@@ -1245,7 +1245,7 @@
       "data-part": "scrollbar",
       "data-orientation": "The orientation of the scrollbar",
       "data-scrolling": "Present when scrolling",
-      "data-hover": "Present when hovering",
+      "data-hover": "Present when hovered",
       "data-overflow-x": "Present when the content overflows the x-axis",
       "data-overflow-y": "Present when the content overflows the y-axis"
     },

--- a/packages/machines/slider/src/slider.connect.ts
+++ b/packages/machines/slider/src/slider.connect.ts
@@ -201,23 +201,28 @@ export function connect<T extends PropTypes>(service: SliderService, normalize: 
           if (!interactive) return
 
           const step = getEventStep(event) * prop("step")
+          const isInverted = !!prop("inverted")
 
           const keyMap: EventKeyMap = {
             ArrowUp() {
               if (isHorizontal) return
-              send({ type: "ARROW_INC", step, src: "ArrowUp" })
+              const type = isInverted ? "ARROW_DEC" : "ARROW_INC"
+              send({ type, step, src: "ArrowUp" })
             },
             ArrowDown() {
               if (isHorizontal) return
-              send({ type: "ARROW_DEC", step, src: "ArrowDown" })
+              const type = isInverted ? "ARROW_INC" : "ARROW_DEC"
+              send({ type, step, src: "ArrowDown" })
             },
             ArrowLeft() {
               if (isVertical) return
-              send({ type: "ARROW_DEC", step, src: "ArrowLeft" })
+              const type = isInverted ? "ARROW_INC" : "ARROW_DEC"
+              send({ type, step, src: "ArrowLeft" })
             },
             ArrowRight() {
               if (isVertical) return
-              send({ type: "ARROW_INC", step, src: "ArrowRight" })
+              const type = isInverted ? "ARROW_DEC" : "ARROW_INC"
+              send({ type, step, src: "ArrowRight" })
             },
             PageUp() {
               send({ type: "ARROW_INC", step, src: "PageUp" })

--- a/packages/machines/slider/src/slider.props.ts
+++ b/packages/machines/slider/src/slider.props.ts
@@ -13,6 +13,7 @@ export const props = createProps<SliderProps>()([
   "id",
   "ids",
   "invalid",
+  "inverted",
   "max",
   "min",
   "minStepsBetweenThumbs",

--- a/packages/machines/slider/src/slider.types.ts
+++ b/packages/machines/slider/src/slider.types.ts
@@ -146,6 +146,14 @@ export interface SliderProps extends DirectionProperty, CommonProperties {
    * The slider thumbs dimensions
    */
   thumbSize?: { width: number; height: number } | undefined
+  /**
+   * Whether the visual direction of the slider is inverted.
+   * - Horizontal: value increases towards the left when `true`.
+   * - Vertical: value increases towards the bottom when `true`.
+   *
+   * This affects pointer interactions, thumb/range positioning, and arrow key behavior.
+   */
+  inverted?: boolean | undefined
 }
 
 type PropsWithDefault =


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #

## 📝 Description

This PR adds an `inverted` prop to the slider machine, allowing its visual and interactive direction to be reversed.

## ⛳️ Current behavior (updates)

Currently, the slider's value always increases towards the right (horizontal LTR), left (horizontal RTL), or top (vertical). Pointer interactions, thumb/range positioning, and arrow key behavior follow this default direction.

## 🚀 New behavior

When `inverted` is set to `true`:
-   **Horizontal LTR**: Value increases towards the left.
-   **Horizontal RTL**: Value increases towards the right.
-   **Vertical**: Value increases towards the bottom.

This inversion affects pointer-to-value mapping, the visual positioning of the thumb and range, and the behavior of arrow keys (e.g., `ArrowRight` will decrease value in an inverted horizontal slider).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The `inverted` prop is integrated into:
-   `slider.types.ts` and `slider.props.ts`: Prop definition.
-   `slider.dom.ts`: Adjusts pointer-to-value conversion based on `inverted` state, considering orientation and `dir`.
-   `slider.style.ts`: Modifies range and thumb offset calculations to reflect the inverted visual direction.
-   `slider.connect.ts`: Flips the `ARROW_INC`/`ARROW_DEC` actions for arrow keys when `inverted` is true.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1fc7313-3be9-46ff-8991-d0ca326c1122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1fc7313-3be9-46ff-8991-d0ca326c1122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

