### PR TITLE
feat(highlight-word): add `exactMatch` option to match whole words only

### DIFF
--- a/packages/utilities/highlight-word/src/escape-regex.ts
+++ b/packages/utilities/highlight-word/src/escape-regex.ts
@@ -1,0 +1,1 @@
+export const escapeRegex = (term: string): string => term.replace(/[|\\{}()[\]^$+*?.-]/g, (char: string) => `\\${char}`)

--- a/packages/utilities/highlight-word/src/highlight-first.ts
+++ b/packages/utilities/highlight-word/src/highlight-first.ts
@@ -1,8 +1,28 @@
 import { normalizeSpan } from "./normalize-span"
+import { escapeRegex } from "./escape-regex"
 import type { HighlightChunk, HighlightWordProps } from "./types"
 
 export function highlightFirst(props: HighlightWordProps): HighlightChunk[] {
-  const { text, query, ignoreCase } = props
+  const { text, query, ignoreCase, exactMatch } = props
+
+  if (exactMatch) {
+    const escapedQuery = escapeRegex(query as string)
+    const regex = new RegExp(`\\b(${escapedQuery})\\b`, ignoreCase ? "i" : "")
+
+    const match = text.match(regex)
+    if (!match || match.index === undefined) {
+      return [{ text, match: false }]
+    }
+
+    const start = match.index
+    const end = start + match[0].length
+    const spans = [{ start, end }]
+
+    return normalizeSpan(spans, text.length).map((chunk) => ({
+      text: text.slice(chunk.start, chunk.end),
+      match: !!chunk.match,
+    }))
+  }
 
   const searchText = ignoreCase ? text.toLowerCase() : text
   const searchQuery = ignoreCase ? (typeof query === "string" ? query.toLowerCase() : query) : query

--- a/packages/utilities/highlight-word/src/highlight-multiple.ts
+++ b/packages/utilities/highlight-word/src/highlight-multiple.ts
@@ -1,25 +1,26 @@
 import { normalizeSpan } from "./normalize-span"
+import { escapeRegex } from "./escape-regex"
 import type { HighlightChunk, HighlightWordProps } from "./types"
 
-const escapeRegexp = (term: string): string => term.replace(/[|\\{}()[\]^$+*?.-]/g, (char: string) => `\\${char}`)
+const buildRegex = (queryProp: string[], flags: string, exactMatch: boolean | undefined): RegExp => {
+  const query = queryProp.filter(Boolean).map((text) => escapeRegex(text))
+  const pattern = exactMatch ? `\\b(${query.join("|")})\\b` : `(${query.join("|")})`
 
-const buildRegex = (queryProp: string[], flags: string): RegExp => {
-  const query = queryProp.filter(Boolean).map((text) => escapeRegexp(text))
-  return new RegExp(`(${query.join("|")})`, flags)
+  return new RegExp(pattern, flags)
 }
 
 const getRegexFlags = (ignoreCase: boolean | undefined, matchAll = true): string =>
   `${ignoreCase ? "i" : ""}${matchAll ? "g" : ""}`
 
 export function highlightMultiple(props: HighlightWordProps): HighlightChunk[] {
-  const { text, query, ignoreCase, matchAll } = props
+  const { text, query, ignoreCase, matchAll, exactMatch } = props
 
   if (query.length === 0) {
     return [{ text, match: false }]
   }
 
   const flags = getRegexFlags(ignoreCase, matchAll)
-  const regex = buildRegex(Array.isArray(query) ? query : [query], flags)
+  const regex = buildRegex(Array.isArray(query) ? query : [query], flags, exactMatch)
 
   const spans = [...text.matchAll(regex)].map((match) => ({
     start: match.index || 0,

--- a/packages/utilities/highlight-word/src/types.ts
+++ b/packages/utilities/highlight-word/src/types.ts
@@ -7,6 +7,10 @@ export interface HighlightRegexOptions {
    * Whether to match multiple instances of the query
    */
   matchAll?: boolean | undefined
+  /**
+   * Whether to match whole words only
+   */
+  exactMatch?: boolean | undefined
 }
 
 export interface HighlightWordProps extends HighlightRegexOptions {

--- a/packages/utilities/highlight-word/tests/highlight-word.test.ts
+++ b/packages/utilities/highlight-word/tests/highlight-word.test.ts
@@ -105,6 +105,70 @@ describe("highlightWord / First Occurrence", () => {
   test("throw when query is array and matchAll is false", () => {
     expect(() => highlightWord({ text: "Hello world", query: ["rld", "llo"], matchAll: false })).toThrow()
   })
+
+  test("not exact match partial words", () => {
+    const result = highlightWord({ text: "The quickly brown fox", query: "quick", exactMatch: true })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The quickly brown fox",
+        },
+      ]
+    `)
+  })
+
+  test("exact match complete words", () => {
+    const result = highlightWord({ text: "The quick brown fox", query: "quick", exactMatch: true })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The ",
+        },
+        {
+          "match": true,
+          "text": "quick",
+        },
+        {
+          "match": false,
+          "text": " brown fox",
+        },
+      ]
+    `)
+  })
+
+  test("exact match without ignore case", () => {
+    const result = highlightWord({ text: "The QUICK brown fox", query: "quick", exactMatch: true, ignoreCase: false })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The QUICK brown fox",
+        },
+      ]
+    `)
+  })
+
+  test("exact match with ignore case", () => {
+    const result = highlightWord({ text: "The QUICK brown fox", query: "quick", exactMatch: true, ignoreCase: true })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The ",
+        },
+        {
+          "match": true,
+          "text": "QUICK",
+        },
+        {
+          "match": false,
+          "text": " brown fox",
+        },
+      ]
+    `)
+  })
 })
 
 describe("highlightWord / Multiple Occurrences", () => {
@@ -334,6 +398,175 @@ describe("highlightWord / Multiple Occurrences", () => {
         {
           "match": true,
           "text": "fox",
+        },
+      ]
+    `)
+  })
+
+  test("not exact match partial words", () => {
+    const result = highlightWord({
+      text: "The quickly brown fox quick runs",
+      query: "quick",
+      exactMatch: true,
+      matchAll: true,
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The quickly brown fox ",
+        },
+        {
+          "match": true,
+          "text": "quick",
+        },
+        {
+          "match": false,
+          "text": " runs",
+        },
+      ]
+    `)
+  })
+
+  test("exact match without ignore case", () => {
+    const result = highlightWord({
+      text: "The QUICK brown fox quick runs",
+      query: "quick",
+      exactMatch: true,
+      ignoreCase: false,
+      matchAll: true,
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The QUICK brown fox ",
+        },
+        {
+          "match": true,
+          "text": "quick",
+        },
+        {
+          "match": false,
+          "text": " runs",
+        },
+      ]
+    `)
+  })
+
+  test("exact match with ignore case", () => {
+    const result = highlightWord({
+      text: "The QUICK brown fox quick runs",
+      query: "quick",
+      exactMatch: true,
+      ignoreCase: true,
+      matchAll: true,
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The ",
+        },
+        {
+          "match": true,
+          "text": "QUICK",
+        },
+        {
+          "match": false,
+          "text": " brown fox ",
+        },
+        {
+          "match": true,
+          "text": "quick",
+        },
+        {
+          "match": false,
+          "text": " runs",
+        },
+      ]
+    `)
+  })
+
+  test("exact match with array query", () => {
+    const result = highlightWord({
+      text: "The quickly brown fox runs fast",
+      query: ["quick", "fast"],
+      exactMatch: true,
+      matchAll: true,
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The quickly brown fox runs ",
+        },
+        {
+          "match": true,
+          "text": "fast",
+        },
+      ]
+    `)
+  })
+
+  test("exact match with array query and ignore case", () => {
+    const result = highlightWord({
+      text: "The QUICKLY brown FOX runs FAST",
+      query: ["quick", "fox", "fast"],
+      exactMatch: true,
+      ignoreCase: true,
+      matchAll: true,
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "The QUICKLY brown ",
+        },
+        {
+          "match": true,
+          "text": "FOX",
+        },
+        {
+          "match": false,
+          "text": " runs ",
+        },
+        {
+          "match": true,
+          "text": "FAST",
+        },
+      ]
+    `)
+  })
+
+  test("exact match with punctuation boundaries", () => {
+    const result = highlightWord({
+      text: "Hello, world! The world is nice.",
+      query: "world",
+      exactMatch: true,
+      matchAll: true,
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "match": false,
+          "text": "Hello, ",
+        },
+        {
+          "match": true,
+          "text": "world",
+        },
+        {
+          "match": false,
+          "text": "! The ",
+        },
+        {
+          "match": true,
+          "text": "world",
+        },
+        {
+          "match": false,
+          "text": " is nice.",
         },
       ]
     `)


### PR DESCRIPTION
## 📝 Description

This PR introduces a new `exactMatch` option to the `highlightWord` utility that enables whole-word matching using regex word boundaries. This enhancement provides more precise text highlighting when users need to avoid partial matches within larger words.

## ⛳️ Current behavior (updates)

Currently, the `highlightWord` utility performs substring matching, which means:

- Searching for "quick" will match both "quick" and "quickly".
- The search term is found anywhere within words, not just as complete words.
- Users cannot distinguish between partial and complete word matches.
- This can lead to false positives in search results and highlighting.

## 🚀 New behavior

With the new `exactMatch` option, the `highlightWord` utility now supports precise whole-word matching:

- **Search precision**: Prevents unwanted matches like finding "cat" in "category".
- **Flexible integration**: Works seamlessly with all existing options (`ignoreCase`, `matchAll`).
- **Smart boundaries**: Recognizes punctuation, spaces, and special characters as natural word boundaries.
- **Backward compatibility**: Maintains existing functionality while adding powerful new features.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This enhancement significantly improves the utility's flexibility while maintaining its simplicity and performance characteristics.

#### Before

```javascript
// ❌ Highlights "quick" inside "quickly", often undesired behavior
highlightWord({ text: "The quickly runs", query: "quick" })
```

#### After

```javascript
// ✅ Doesn't highlight "quick" inside "quickly", desired behavior
highlightWord({ text: "The quickly runs", query: "quick", exactMatch: true })
```
