### PR TITLE
feat(scroll-area): add dragging state to scroll area context and machine

### DIFF
--- a/.changeset/tricky-meals-appear.md
+++ b/.changeset/tricky-meals-appear.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/scroll-area": patch
+---
+
+Add `data-dragging` attribute to scroll area parts for ease of styling.

--- a/packages/machines/scroll-area/src/scroll-area.connect.ts
+++ b/packages/machines/scroll-area/src/scroll-area.connect.ts
@@ -40,6 +40,7 @@ export function connect<T extends PropTypes>(
       const horizontal = props.orientation === "horizontal"
       return {
         hovering: context.get("hovering"),
+        dragging: context.get("dragging"),
         scrolling: context.get(horizontal ? "scrollingX" : "scrollingY"),
         hidden: horizontal ? hiddenState.scrollbarXHidden : hiddenState.scrollbarYHidden,
       }
@@ -126,6 +127,7 @@ export function connect<T extends PropTypes>(
         "data-orientation": orientation,
         "data-scrolling": dataAttr(context.get(orientation === "horizontal" ? "scrollingX" : "scrollingY")),
         "data-hover": dataAttr(context.get("hovering")),
+        "data-dragging": dataAttr(context.get("dragging")),
         "data-overflow-x": dataAttr(!hiddenState.scrollbarXHidden),
         "data-overflow-y": dataAttr(!hiddenState.scrollbarYHidden),
         onPointerUp() {

--- a/packages/machines/scroll-area/src/scroll-area.connect.ts
+++ b/packages/machines/scroll-area/src/scroll-area.connect.ts
@@ -169,6 +169,8 @@ export function connect<T extends PropTypes>(
         ...parts.thumb.attrs,
         "data-ownedby": dom.getRootId(scope),
         "data-orientation": orientation,
+        "data-hover": dataAttr(context.get("hovering")),
+        "data-dragging": dataAttr(context.get("dragging")),
         onPointerDown(event) {
           if (event.button !== 0) return
           const point = getEventPoint(event)

--- a/packages/machines/scroll-area/src/scroll-area.machine.ts
+++ b/packages/machines/scroll-area/src/scroll-area.machine.ts
@@ -24,6 +24,7 @@ export const machine = createMachine<ScrollAreaSchema>({
       scrollingX: bindable<boolean>(() => ({ defaultValue: false })),
       scrollingY: bindable<boolean>(() => ({ defaultValue: false })),
       hovering: bindable<boolean>(() => ({ defaultValue: false })),
+      dragging: bindable<boolean>(() => ({ defaultValue: false })),
       touchModality: bindable<boolean>(() => ({ defaultValue: false })),
       atSides: bindable<ScrollRecord<boolean>>(() => ({
         defaultValue: { top: true, right: false, bottom: false, left: true },
@@ -359,7 +360,7 @@ export const machine = createMachine<ScrollAreaSchema>({
         }
       },
 
-      startDragging({ event, refs, scope }) {
+      startDragging({ event, refs, scope, context }) {
         refs.set("startX", event.point.x)
         refs.set("startY", event.point.y)
         refs.set("orientation", event.orientation)
@@ -369,6 +370,7 @@ export const machine = createMachine<ScrollAreaSchema>({
 
         refs.set("startScrollTop", viewportEl.scrollTop)
         refs.set("startScrollLeft", viewportEl.scrollLeft)
+        context.set("dragging", true)
       },
 
       setDraggingScroll({ event, refs, scope, context }) {
@@ -424,8 +426,9 @@ export const machine = createMachine<ScrollAreaSchema>({
         }
       },
 
-      stopDragging({ refs }) {
+      stopDragging({ refs, context }) {
         refs.set("orientation", null)
+        context.set("dragging", false)
       },
 
       clearTimeouts({ refs }) {

--- a/packages/machines/scroll-area/src/scroll-area.types.ts
+++ b/packages/machines/scroll-area/src/scroll-area.types.ts
@@ -42,6 +42,7 @@ export interface ScrollAreaContext {
   scrollingY: boolean
   hiddenState: ScrollbarHiddenState
   hovering: boolean
+  dragging: boolean
   touchModality: boolean
   atSides: ScrollRecord<boolean>
 }


### PR DESCRIPTION
## 📝 Description

First of all, thank you for releasing the new ScrollArea component — I’ve been happily using it in my project. 🎉
While integrating it, I noticed one small improvement that could make the developer experience even better.

This PR adds a data-dragging attribute to the scrollbar thumb, enabling developers to style the thumb differently when it is actively being dragged.
This allows us to replicate the familiar macOS scroll experience, where the thumb visually changes during drag for improved usability.


## ⛳️ Current behavior (updates)

Currently, the ScrollArea thumb only exposes a data-hover state.
There is no way to detect or differentiate when the thumb is being actively dragged, which limits the ability to reproduce native-like scroll behaviors.

## 🚀 New behavior

- Introduces a `data-dragging` attribute on the scrollbar and thumb.
- When the user starts dragging the thumb, data-dragging="true" is applied.
- Once the drag interaction ends, the attribute is removed.
- Developers can now implement macOS-like scroll behavior by styling the thumb across three states: default, hover, and dragging.

## 💣 Is this a breaking change (Yes/No):

No

