### PR TITLE
fix: date picker select sync

### DIFF
--- a/.changeset/fix-date-picker-improvements.md
+++ b/.changeset/fix-date-picker-improvements.md
@@ -1,0 +1,9 @@
+---
+"@zag-js/date-picker": patch
+---
+
+- Fix keyboard navigation issue where pressing HOME key in month view would incorrectly jump to an invalid date instead
+  of January, potentially causing date selection errors.
+
+- Clear hover state immediately when completing range selection instead of waiting for pointer to leave the calendar
+  area.

--- a/.changeset/sync-month-select-on-start-value.md
+++ b/.changeset/sync-month-select-on-start-value.md
@@ -1,0 +1,9 @@
+---
+"@zag-js/date-picker": patch
+---
+
+fix(date-picker): ensure Month/Year select labels update under min/max constraints
+
+- Sync Month/Year `<select>` values when `startValue` changes so the labels reflect the visible month/year even if `focusedValue` doesn't change.
+- Add `hash` for `startValue` to enable efficient watcher updates.
+- Remove duplicate select sync from `focusedValue` watcher (syncs now only on `startValue`).

--- a/.changeset/sync-month-select-on-start-value.md
+++ b/.changeset/sync-month-select-on-start-value.md
@@ -7,3 +7,5 @@ fix(date-picker): ensure Month/Year select labels update under min/max constrain
 - Sync Month/Year `<select>` values when `startValue` changes so the labels reflect the visible month/year even if `focusedValue` doesn't change.
 - Add `hash` for `startValue` to enable efficient watcher updates.
 - Remove duplicate select sync from `focusedValue` watcher (syncs now only on `startValue`).
+- Expose `disabled` on `api.getMonths()` and `api.getYears()` results to indicate options out of range for current constraints.
+- Update Next.js examples to apply `disabled` on `<option>`.

--- a/examples/next-ts/pages/date-picker-inline.tsx
+++ b/examples/next-ts/pages/date-picker-inline.tsx
@@ -37,7 +37,7 @@ export default function Page() {
           <div style={{ marginBottom: "20px" }}>
             <select {...api.getMonthSelectProps()}>
               {api.getMonths().map((month, i) => (
-                <option key={i} value={month.value}>
+                <option key={i} value={month.value} disabled={month.disabled}>
                   {month.label}
                 </option>
               ))}
@@ -45,7 +45,7 @@ export default function Page() {
 
             <select {...api.getYearSelectProps()}>
               {api.getYears().map((year, i) => (
-                <option key={i} value={year.value}>
+                <option key={i} value={year.value} disabled={year.disabled}>
                   {year.label}
                 </option>
               ))}

--- a/examples/next-ts/pages/date-picker-min-max.tsx
+++ b/examples/next-ts/pages/date-picker-min-max.tsx
@@ -5,89 +5,89 @@ import { StateVisualizer } from "../components/state-visualizer"
 import { Toolbar } from "../components/toolbar"
 
 export default function Page() {
-	const service = useMachine(datePicker.machine, {
-		id: useId(),
-		locale: "en",
-		selectionMode: "single",
-		min: datePicker.parse("2024-07-01"),
-		max: datePicker.parse("2024-09-30"),
-	})
+  const service = useMachine(datePicker.machine, {
+    id: useId(),
+    locale: "en",
+    selectionMode: "single",
+    min: datePicker.parse("2025-07-01"),
+    max: datePicker.parse("2025-09-30"),
+  })
 
-	const api = datePicker.connect(service, normalizeProps)
+  const api = datePicker.connect(service, normalizeProps)
 
-	return (
-		<>
-			<main className="date-picker">
-				<p>{`Visible range: ${api.visibleRangeText.formatted}`}</p>
+  return (
+    <>
+      <main className="date-picker">
+        <p>{`Visible range: ${api.visibleRangeText.formatted}`}</p>
 
-				<output className="date-output">
-					<div>Selected: {api.valueAsString ?? "-"}</div>
-					<div>Focused: {api.focusedValueAsString}</div>
-				</output>
+        <output className="date-output">
+          <div>Selected: {api.valueAsString ?? "-"}</div>
+          <div>Focused: {api.focusedValueAsString}</div>
+        </output>
 
-				<div {...api.getControlProps()}>
-					<input {...api.getInputProps()} />
-					<button {...api.getClearTriggerProps()}>❌</button>
-					<button {...api.getTriggerProps()}>🗓</button>
-				</div>
+        <div {...api.getControlProps()}>
+          <input {...api.getInputProps()} />
+          <button {...api.getClearTriggerProps()}>❌</button>
+          <button {...api.getTriggerProps()}>🗓</button>
+        </div>
 
-				<div {...api.getPositionerProps()}>
-					<div {...api.getContentProps()}>
-						<div style={{ marginBottom: "20px" }}>
-							<select {...api.getMonthSelectProps()}>
-								{api.getMonths().map((month, i) => (
-									<option key={i} value={month.value} disabled={month.disabled}>
-										{month.label}
-									</option>
-								))}
-							</select>
+        <div {...api.getPositionerProps()}>
+          <div {...api.getContentProps()}>
+            <div style={{ marginBottom: "20px" }}>
+              <select {...api.getMonthSelectProps()}>
+                {api.getMonths().map((month, i) => (
+                  <option key={i} value={month.value} disabled={month.disabled}>
+                    {month.label}
+                  </option>
+                ))}
+              </select>
 
-							<select {...api.getYearSelectProps()}>
-								{api.getYears().map((year, i) => (
-									<option key={i} value={year.value} disabled={year.disabled}>
-										{year.label}
-									</option>
-								))}
-							</select>
-						</div>
+              <select {...api.getYearSelectProps()}>
+                {api.getYears().map((year, i) => (
+                  <option key={i} value={year.value} disabled={year.disabled}>
+                    {year.label}
+                  </option>
+                ))}
+              </select>
+            </div>
 
-						<div hidden={api.view !== "day"}>
-							<div {...api.getViewControlProps({ view: "year" })}>
-								<button {...api.getPrevTriggerProps()}>Prev</button>
-								<button {...api.getViewTriggerProps()}>{api.visibleRangeText.start}</button>
-								<button {...api.getNextTriggerProps()}>Next</button>
-							</div>
+            <div hidden={api.view !== "day"}>
+              <div {...api.getViewControlProps({ view: "year" })}>
+                <button {...api.getPrevTriggerProps()}>Prev</button>
+                <button {...api.getViewTriggerProps()}>{api.visibleRangeText.start}</button>
+                <button {...api.getNextTriggerProps()}>Next</button>
+              </div>
 
-							<table {...api.getTableProps({ view: "day" })}>
-								<thead {...api.getTableHeaderProps({ view: "day" })}>
-									<tr {...api.getTableRowProps({ view: "day" })}>
-										{api.weekDays.map((day, i) => (
-											<th scope="col" key={i} aria-label={day.long}>
-												{day.narrow}
-											</th>
-										))}
-									</tr>
-								</thead>
-								<tbody {...api.getTableBodyProps({ view: "day" })}>
-									{api.weeks.map((week, i) => (
-										<tr key={i} {...api.getTableRowProps({ view: "day" })}>
-											{week.map((value, i) => (
-												<td key={i} {...api.getDayTableCellProps({ value })}>
-													<div {...api.getDayTableCellTriggerProps({ value })}>{value.day}</div>
-												</td>
-											))}
-										</tr>
-									))}
-								</tbody>
-							</table>
-						</div>
-					</div>
-				</div>
-			</main>
+              <table {...api.getTableProps({ view: "day" })}>
+                <thead {...api.getTableHeaderProps({ view: "day" })}>
+                  <tr {...api.getTableRowProps({ view: "day" })}>
+                    {api.weekDays.map((day, i) => (
+                      <th scope="col" key={i} aria-label={day.long}>
+                        {day.narrow}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody {...api.getTableBodyProps({ view: "day" })}>
+                  {api.weeks.map((week, i) => (
+                    <tr key={i} {...api.getTableRowProps({ view: "day" })}>
+                      {week.map((value, i) => (
+                        <td key={i} {...api.getDayTableCellProps({ value })}>
+                          <div {...api.getDayTableCellTriggerProps({ value })}>{value.day}</div>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </main>
 
-			<Toolbar viz>
-				<StateVisualizer state={service} omit={["weeks"]} />
-			</Toolbar>
-		</>
-	)
+      <Toolbar viz>
+        <StateVisualizer state={service} omit={["weeks"]} />
+      </Toolbar>
+    </>
+  )
 }

--- a/examples/next-ts/pages/date-picker-min-max.tsx
+++ b/examples/next-ts/pages/date-picker-min-max.tsx
@@ -36,7 +36,7 @@ export default function Page() {
 						<div style={{ marginBottom: "20px" }}>
 							<select {...api.getMonthSelectProps()}>
 								{api.getMonths().map((month, i) => (
-									<option key={i} value={month.value}>
+									<option key={i} value={month.value} disabled={month.disabled}>
 										{month.label}
 									</option>
 								))}
@@ -44,7 +44,7 @@ export default function Page() {
 
 							<select {...api.getYearSelectProps()}>
 								{api.getYears().map((year, i) => (
-									<option key={i} value={year.value}>
+									<option key={i} value={year.value} disabled={year.disabled}>
 										{year.label}
 									</option>
 								))}

--- a/examples/next-ts/pages/date-picker-min-max.tsx
+++ b/examples/next-ts/pages/date-picker-min-max.tsx
@@ -1,0 +1,93 @@
+import * as datePicker from "@zag-js/date-picker"
+import { normalizeProps, useMachine } from "@zag-js/react"
+import { useId } from "react"
+import { StateVisualizer } from "../components/state-visualizer"
+import { Toolbar } from "../components/toolbar"
+
+export default function Page() {
+	const service = useMachine(datePicker.machine, {
+		id: useId(),
+		locale: "en",
+		selectionMode: "single",
+		min: datePicker.parse("2024-07-01"),
+		max: datePicker.parse("2024-09-30"),
+	})
+
+	const api = datePicker.connect(service, normalizeProps)
+
+	return (
+		<>
+			<main className="date-picker">
+				<p>{`Visible range: ${api.visibleRangeText.formatted}`}</p>
+
+				<output className="date-output">
+					<div>Selected: {api.valueAsString ?? "-"}</div>
+					<div>Focused: {api.focusedValueAsString}</div>
+				</output>
+
+				<div {...api.getControlProps()}>
+					<input {...api.getInputProps()} />
+					<button {...api.getClearTriggerProps()}>❌</button>
+					<button {...api.getTriggerProps()}>🗓</button>
+				</div>
+
+				<div {...api.getPositionerProps()}>
+					<div {...api.getContentProps()}>
+						<div style={{ marginBottom: "20px" }}>
+							<select {...api.getMonthSelectProps()}>
+								{api.getMonths().map((month, i) => (
+									<option key={i} value={month.value}>
+										{month.label}
+									</option>
+								))}
+							</select>
+
+							<select {...api.getYearSelectProps()}>
+								{api.getYears().map((year, i) => (
+									<option key={i} value={year.value}>
+										{year.label}
+									</option>
+								))}
+							</select>
+						</div>
+
+						<div hidden={api.view !== "day"}>
+							<div {...api.getViewControlProps({ view: "year" })}>
+								<button {...api.getPrevTriggerProps()}>Prev</button>
+								<button {...api.getViewTriggerProps()}>{api.visibleRangeText.start}</button>
+								<button {...api.getNextTriggerProps()}>Next</button>
+							</div>
+
+							<table {...api.getTableProps({ view: "day" })}>
+								<thead {...api.getTableHeaderProps({ view: "day" })}>
+									<tr {...api.getTableRowProps({ view: "day" })}>
+										{api.weekDays.map((day, i) => (
+											<th scope="col" key={i} aria-label={day.long}>
+												{day.narrow}
+											</th>
+										))}
+									</tr>
+								</thead>
+								<tbody {...api.getTableBodyProps({ view: "day" })}>
+									{api.weeks.map((week, i) => (
+										<tr key={i} {...api.getTableRowProps({ view: "day" })}>
+											{week.map((value, i) => (
+												<td key={i} {...api.getDayTableCellProps({ value })}>
+													<div {...api.getDayTableCellTriggerProps({ value })}>{value.day}</div>
+												</td>
+											))}
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</main>
+
+			<Toolbar viz>
+				<StateVisualizer state={service} omit={["weeks"]} />
+			</Toolbar>
+		</>
+	)
+}

--- a/examples/next-ts/pages/date-picker-month-range.tsx
+++ b/examples/next-ts/pages/date-picker-month-range.tsx
@@ -67,7 +67,7 @@ export default function Page() {
             <div style={{ marginBottom: "20px" }}>
               <select {...api.getMonthSelectProps()}>
                 {api.getMonths().map((month, i) => (
-                  <option key={i} value={month.value}>
+                  <option key={i} value={month.value} disabled={month.disabled}>
                     {month.label}
                   </option>
                 ))}
@@ -75,7 +75,7 @@ export default function Page() {
 
               <select {...api.getYearSelectProps()}>
                 {api.getYears().map((year, i) => (
-                  <option key={i} value={year.value}>
+                  <option key={i} value={year.value} disabled={year.disabled}>
                     {year.label}
                   </option>
                 ))}

--- a/examples/next-ts/pages/date-picker-multi.tsx
+++ b/examples/next-ts/pages/date-picker-multi.tsx
@@ -41,7 +41,7 @@ export default function Page() {
             <div style={{ marginBottom: "20px" }}>
               <select {...api.getMonthSelectProps()}>
                 {api.getMonths().map((month, i) => (
-                  <option key={i} value={month.value}>
+                  <option key={i} value={month.value} disabled={month.disabled}>
                     {month.label}
                   </option>
                 ))}
@@ -49,7 +49,7 @@ export default function Page() {
 
               <select {...api.getYearSelectProps()}>
                 {api.getYears().map((year, i) => (
-                  <option key={i} value={year.value}>
+                  <option key={i} value={year.value} disabled={year.disabled}>
                     {year.label}
                   </option>
                 ))}

--- a/examples/next-ts/pages/date-picker-range.tsx
+++ b/examples/next-ts/pages/date-picker-range.tsx
@@ -47,7 +47,7 @@ export default function Page() {
             <div style={{ marginBottom: "20px" }}>
               <select {...api.getMonthSelectProps()}>
                 {api.getMonths().map((month, i) => (
-                  <option key={i} value={i + 1}>
+                  <option key={i} value={i + 1} disabled={month.disabled}>
                     {month.label}
                   </option>
                 ))}
@@ -55,7 +55,7 @@ export default function Page() {
 
               <select {...api.getYearSelectProps()}>
                 {api.getYears().map((year, i) => (
-                  <option key={i} value={year.value}>
+                  <option key={i} value={year.value} disabled={year.disabled}>
                     {year.label}
                   </option>
                 ))}

--- a/examples/next-ts/pages/date-picker-year-range.tsx
+++ b/examples/next-ts/pages/date-picker-year-range.tsx
@@ -66,7 +66,7 @@ export default function Page() {
             <div style={{ marginBottom: "20px" }}>
               <select {...api.getMonthSelectProps()}>
                 {api.getMonths().map((month, i) => (
-                  <option key={i} value={month.value}>
+                  <option key={i} value={month.value} disabled={month.disabled}>
                     {month.label}
                   </option>
                 ))}
@@ -74,7 +74,7 @@ export default function Page() {
 
               <select {...api.getYearSelectProps()}>
                 {api.getYears().map((year, i) => (
-                  <option key={i} value={year.value}>
+                  <option key={i} value={year.value} disabled={year.disabled}>
                     {year.label}
                   </option>
                 ))}

--- a/examples/next-ts/pages/date-picker.tsx
+++ b/examples/next-ts/pages/date-picker.tsx
@@ -41,7 +41,7 @@ export default function Page() {
             <div style={{ marginBottom: "20px" }}>
               <select {...api.getMonthSelectProps()}>
                 {api.getMonths().map((month, i) => (
-                  <option key={i} value={month.value}>
+                  <option key={i} value={month.value} disabled={month.disabled}>
                     {month.label}
                   </option>
                 ))}
@@ -49,7 +49,7 @@ export default function Page() {
 
               <select {...api.getYearSelectProps()}>
                 {api.getYears().map((year, i) => (
-                  <option key={i} value={year.value}>
+                  <option key={i} value={year.value} disabled={year.disabled}>
                     {year.label}
                   </option>
                 ))}

--- a/packages/machines/date-picker/src/date-picker.connect.ts
+++ b/packages/machines/date-picker/src/date-picker.connect.ts
@@ -88,12 +88,17 @@ export function connect<T extends PropTypes>(
 
   function getMonths(props: { format?: "short" | "long" | undefined } = {}) {
     const { format } = props
-    return getMonthNames(locale, format).map((label, index) => ({ label, value: index + 1 }))
+    return getMonthNames(locale, format).map((label, index) => {
+      const value = index + 1
+      const dateValue = focusedValue.set({ month: value })
+      const disabled = isDateOutsideRange(dateValue, min, max)
+      return { label, value, disabled }
+    })
   }
 
   function getYears() {
     const range = getYearsRange({ from: min?.year ?? 1900, to: max?.year ?? 2100 })
-    return range.map((year) => ({ label: year.toString(), value: year }))
+    return range.map((year) => ({ label: year.toString(), value: year, disabled: !isValueWithinRange(year, min?.year ?? 0, max?.year ?? 9999) }))
   }
 
   function getDecadeYears(year?: number) {

--- a/packages/machines/date-picker/src/date-picker.connect.ts
+++ b/packages/machines/date-picker/src/date-picker.connect.ts
@@ -98,7 +98,11 @@ export function connect<T extends PropTypes>(
 
   function getYears() {
     const range = getYearsRange({ from: min?.year ?? 1900, to: max?.year ?? 2100 })
-    return range.map((year) => ({ label: year.toString(), value: year, disabled: !isValueWithinRange(year, min?.year ?? 0, max?.year ?? 9999) }))
+    return range.map((year) => ({
+      label: year.toString(),
+      value: year,
+      disabled: !isValueWithinRange(year, min?.year, max?.year),
+    }))
   }
 
   function getDecadeYears(year?: number) {
@@ -126,7 +130,7 @@ export function connect<T extends PropTypes>(
 
     const cellState = {
       focused: focusedValue.year === props.value,
-      selectable: isValueWithinRange(value, min?.year ?? 0, max?.year ?? 9999),
+      selectable: isValueWithinRange(value, min?.year, max?.year),
       selected: !!selectedValue.find((date) => date.year === value),
       valueText: value.toString(),
       inRange:

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -218,6 +218,11 @@ export const machine = createMachine<DatePickerSchema>({
       ])
     })
 
+    // Ensure the month/year select reflect the actual visible start value
+    track([() => context.hash("startValue")], () => {
+      action(["syncMonthSelectElement", "syncYearSelectElement"])
+    })
+
     track([() => context.get("inputValue")], () => {
       action(["syncInputValue"])
     })

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -167,6 +167,7 @@ export const machine = createMachine<DatePickerSchema>({
         return {
           defaultValue: alignDate(focusedValue, "start", { months: prop("numOfMonths") }, prop("locale")),
           isEqual: isDateEqual,
+          hash: (v) => v.toString(),
         }
       }),
       currentPlacement: bindable<Placement | undefined>(() => ({

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -407,7 +407,14 @@ export const machine = createMachine<DatePickerSchema>({
           // === Grouped transitions (based on `closeOnSelect` and `isOpenControlled`) ===
           {
             guard: and("isRangePicker", "isSelectingEndDate", "closeOnSelect", "isOpenControlled"),
-            actions: ["setFocusedDate", "setSelectedDate", "setActiveIndexToStart", "invokeOnClose", "setRestoreFocus"],
+            actions: [
+              "setFocusedDate",
+              "setSelectedDate",
+              "setActiveIndexToStart",
+              "clearHoveredDate",
+              "invokeOnClose",
+              "setRestoreFocus",
+            ],
           },
           {
             guard: and("isRangePicker", "isSelectingEndDate", "closeOnSelect"),
@@ -416,6 +423,7 @@ export const machine = createMachine<DatePickerSchema>({
               "setFocusedDate",
               "setSelectedDate",
               "setActiveIndexToStart",
+              "clearHoveredDate",
               "invokeOnClose",
               "focusInputElement",
             ],
@@ -484,16 +492,22 @@ export const machine = createMachine<DatePickerSchema>({
           // === Grouped transitions (based on `closeOnSelect` and `isOpenControlled`) ===
           {
             guard: and("isRangePicker", "isSelectingEndDate", "closeOnSelect", "isOpenControlled"),
-            actions: ["setSelectedDate", "setActiveIndexToStart", "invokeOnClose"],
+            actions: ["setSelectedDate", "setActiveIndexToStart", "clearHoveredDate", "invokeOnClose"],
           },
           {
             guard: and("isRangePicker", "isSelectingEndDate", "closeOnSelect"),
             target: "focused",
-            actions: ["setSelectedDate", "setActiveIndexToStart", "invokeOnClose", "focusInputElement"],
+            actions: [
+              "setSelectedDate",
+              "setActiveIndexToStart",
+              "clearHoveredDate",
+              "invokeOnClose",
+              "focusInputElement",
+            ],
           },
           {
             guard: and("isRangePicker", "isSelectingEndDate"),
-            actions: ["setSelectedDate", "setActiveIndexToStart"],
+            actions: ["setSelectedDate", "setActiveIndexToStart", "clearHoveredDate"],
           },
           // ===
           {

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -212,8 +212,6 @@ export const machine = createMachine<DatePickerSchema>({
     track([() => context.hash("focusedValue")], () => {
       action([
         "setStartValue",
-        "syncMonthSelectElement",
-        "syncYearSelectElement",
         "focusActiveCellIfNeeded",
         "setHoveredValueIfKeyboard",
       ])

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -210,11 +210,7 @@ export const machine = createMachine<DatePickerSchema>({
     })
 
     track([() => context.hash("focusedValue")], () => {
-      action([
-        "setStartValue",
-        "focusActiveCellIfNeeded",
-        "setHoveredValueIfKeyboard",
-      ])
+      action(["setStartValue", "focusActiveCellIfNeeded", "setHoveredValueIfKeyboard"])
     })
 
     // Ensure the month/year select reflect the actual visible start value
@@ -953,7 +949,7 @@ export const machine = createMachine<DatePickerSchema>({
       },
       focusFirstMonth(params) {
         const { context } = params
-        const nextValue = context.get("focusedValue").set({ month: 0 })
+        const nextValue = context.get("focusedValue").set({ month: 1 })
         setFocusedValue(params, nextValue)
       },
       focusLastMonth(params) {

--- a/packages/machines/date-picker/src/date-picker.types.ts
+++ b/packages/machines/date-picker/src/date-picker.types.ts
@@ -467,6 +467,7 @@ export interface MonthGridProps {
 export interface Cell {
   label: string
   value: number
+  disabled?: boolean | undefined
 }
 
 export type MonthGridValue = Cell[][]

--- a/packages/utilities/core/src/number.ts
+++ b/packages/utilities/core/src/number.ts
@@ -11,7 +11,12 @@ export const getMaxValueAtIndex = (i: number, v: number[], vmax: number) => (i =
 
 export const isValueAtMax = (v: number, vmax: number) => nan(v) >= vmax
 export const isValueAtMin = (v: number, vmin: number) => nan(v) <= vmin
-export const isValueWithinRange = (v: number, vmin: number, vmax: number) => nan(v) >= vmin && nan(v) <= vmax
+export const isValueWithinRange = (v: number, vmin: number | null | undefined, vmax: number | null | undefined) => {
+  const value = nan(v)
+  const minCheck = vmin == null || value >= vmin
+  const maxCheck = vmax == null || value <= vmax
+  return minCheck && maxCheck
+}
 
 export const roundValue = (v: number, vmin: number, step: number) => round((nan(v) - vmin) / step) * step + vmin
 export const clampValue = (v: number, vmin: number, vmax: number) => min(max(nan(v), vmin), vmax)

--- a/starters/react/components/date-range-picker.tsx
+++ b/starters/react/components/date-range-picker.tsx
@@ -1,5 +1,4 @@
 import * as datePicker from "@zag-js/date-picker"
-import { getYearsRange } from "@zag-js/date-utils"
 import { normalizeProps, useMachine } from "@zag-js/react"
 import { useId } from "react"
 
@@ -44,16 +43,16 @@ export function DateRangePicker(props: Props) {
           <div style={{ marginBottom: "20px" }}>
             <select {...api.getMonthSelectProps()}>
               {api.getMonths().map((month, i) => (
-                <option key={i} value={i + 1}>
+                <option key={i} value={i + 1} disabled={month.disabled}>
                   {month.label}
                 </option>
               ))}
             </select>
 
             <select {...api.getYearSelectProps()}>
-              {getYearsRange({ from: 1_800, to: 2_300 }).map((year, i) => (
-                <option key={i} value={year}>
-                  {year}
+              {api.getYears().map((year, i) => (
+                <option key={i} value={year.value} disabled={year.disabled}>
+                  {year.label}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2655
Closes #2660

## 📝 Description

Fixes an issue where the MonthSelect and YearSelect labels in the date picker did not update when the visible month/year changed due to `min`/`max` date constraints.

## ⛳️ Current behavior (updates)

When `min` or `max` date constraints prevent `focusedValue` from changing (e.g., trying to navigate past the max month), the `MonthSelect` and `YearSelect` labels would not update to reflect the actual `startValue` (the visible month/year), leading to a desynchronized display.

## 🚀 New behavior

The `MonthSelect` and `YearSelect` elements now explicitly synchronize with the `startValue` (the currently displayed month/year) whenever `startValue` changes. This ensures the labels always reflect the visible month/year, even when navigation is constrained.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This change adds a `track` listener in `date-picker.machine.ts` to watch for `startValue` changes and trigger the `syncMonthSelectElement` and `syncYearSelectElement` actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd1df449-7b54-41e7-a7a5-bc06eeda710f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd1df449-7b54-41e7-a7a5-bc06eeda710f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

