### PR TITLE
fix: scrollarea hover in portals

### DIFF
--- a/.changeset/quiet-scrollarea-hover.md
+++ b/.changeset/quiet-scrollarea-hover.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/scroll-area": patch
+---
+
+Prevent hover state from clearing when pointer moves into descendants or portals by guarding `onPointerLeave` with `contains` from `@zag-js/dom-query`. This avoids unintended scrollbar hide/show when interacting with sibling portals.

--- a/packages/machines/scroll-area/src/scroll-area.connect.ts
+++ b/packages/machines/scroll-area/src/scroll-area.connect.ts
@@ -1,4 +1,4 @@
-import { dataAttr, getEventPoint } from "@zag-js/dom-query"
+import { contains, dataAttr, getEventPoint } from "@zag-js/dom-query"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { toPx } from "@zag-js/utils"
 import { parts } from "./scroll-area.anatomy"
@@ -66,7 +66,8 @@ export function connect<T extends PropTypes>(
         onPointerDown({ pointerType }) {
           send({ type: "root.pointerdown", pointerType })
         },
-        onPointerLeave() {
+        onPointerLeave(event) {
+          if (contains(event.currentTarget, event.relatedTarget)) return
           send({ type: "root.pointerleave" })
         },
         style: {

--- a/packages/machines/scroll-area/src/scroll-area.connect.ts
+++ b/packages/machines/scroll-area/src/scroll-area.connect.ts
@@ -58,9 +58,11 @@ export function connect<T extends PropTypes>(
         "data-overflow-x": dataAttr(!hiddenState.scrollbarXHidden),
         "data-overflow-y": dataAttr(!hiddenState.scrollbarYHidden),
         onPointerEnter(event) {
+          if (!contains(event.currentTarget, event.target)) return
           send({ type: "root.pointerenter", pointerType: event.pointerType })
         },
         onPointerMove(event) {
+          if (!contains(event.currentTarget, event.target)) return
           send({ type: "root.pointerenter", pointerType: event.pointerType })
         },
         onPointerDown({ pointerType }) {

--- a/packages/machines/scroll-area/src/scroll-area.connect.ts
+++ b/packages/machines/scroll-area/src/scroll-area.connect.ts
@@ -1,4 +1,4 @@
-import { contains, dataAttr, getEventPoint } from "@zag-js/dom-query"
+import { contains, dataAttr, getEventPoint, getEventTarget } from "@zag-js/dom-query"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { toPx } from "@zag-js/utils"
 import { parts } from "./scroll-area.anatomy"
@@ -58,11 +58,13 @@ export function connect<T extends PropTypes>(
         "data-overflow-x": dataAttr(!hiddenState.scrollbarXHidden),
         "data-overflow-y": dataAttr(!hiddenState.scrollbarYHidden),
         onPointerEnter(event) {
-          if (!contains(event.currentTarget, event.target)) return
+          const target = getEventTarget(event)
+          if (!contains(event.currentTarget, target)) return
           send({ type: "root.pointerenter", pointerType: event.pointerType })
         },
         onPointerMove(event) {
-          if (!contains(event.currentTarget, event.target)) return
+          const target = getEventTarget(event)
+          if (!contains(event.currentTarget, target)) return
           send({ type: "root.pointerenter", pointerType: event.pointerType })
         },
         onPointerDown({ pointerType }) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # N/A

## 📝 Description

Prevents the `ScrollArea`'s hover state from clearing prematurely when the pointer moves from the scroll area root into a descendant element or a sibling portal.

## ⛳️ Current behavior (updates)

The `ScrollArea`'s `onPointerLeave` handler would trigger when the pointer moved from the root element into a child element or a sibling portal, causing the hover state to reset (e.g., scrollbars to hide).

## 🚀 New behavior

The `onPointerLeave` handler now uses a `contains` check to ensure the `root.pointerleave` event is only dispatched when the pointer truly leaves the scroll area's root element and its descendants. This maintains the hover state correctly when interacting with nested elements or sibling portals.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

---
<a href="https://cursor.com/background-agent?bcId=bc-f89dc297-6bce-40aa-99e9-4e51e4a3db56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f89dc297-6bce-40aa-99e9-4e51e4a3db56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

