### PR TITLE
Fix onChange event for readOnly inputs

### DIFF
--- a/packages/machines/radio-group/src/radio-group.machine.ts
+++ b/packages/machines/radio-group/src/radio-group.machine.ts
@@ -78,10 +78,11 @@ export const machine = createMachine<RadioGroupSchema>({
   on: {
     SET_VALUE: [
       {
-        guard: not("isTrusted"),
+        guard: [not("isTrusted"), not("isReadOnly")],
         actions: ["setValue", "dispatchChangeEvent"],
       },
       {
+        guard: not("isReadOnly"),
         actions: ["setValue"],
       },
     ],
@@ -103,6 +104,7 @@ export const machine = createMachine<RadioGroupSchema>({
   implementations: {
     guards: {
       isTrusted: ({ event }) => !!event.isTrusted,
+      isReadOnly: ({ prop }) => !!prop("readOnly"),
     },
 
     effects: {
@@ -122,7 +124,8 @@ export const machine = createMachine<RadioGroupSchema>({
     },
 
     actions: {
-      setValue({ context, event }) {
+      setValue({ context, event, prop }) {
+        if (prop("readOnly")) return
         context.set("value", event.value)
       },
       setHovered({ context, event }) {


### PR DESCRIPTION
```
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #

## 📝 Description

Fixes an issue where the `onChange` event (via `onValueChange`) was incorrectly triggered in the radio group machine even when the `readOnly` prop was set to `true`.

## ⛳️ Current behavior (updates)

When the `readOnly` prop was `true`, programmatic calls to `setValue` or `clearValue` would still update the radio group's value and trigger the `onValueChange` callback. The `SET_VALUE` event handler in the state machine did not check for the `readOnly` state.

## 🚀 New behavior

- The `SET_VALUE` event handler in the radio group machine now includes an `isReadOnly` guard.
- The `setValue` action itself also includes a defensive check for `readOnly`.
- When `readOnly` is `true`, both programmatic value changes and the associated `onValueChange` callback are prevented.
- The radio group's value will not change, and `onValueChange` will not be dispatched when `readOnly` is active.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This ensures that the `readOnly` prop functions as expected, preventing any value modifications and change events when enabled.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-9c2fa1dc-e076-4a51-981b-900f05e475f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c2fa1dc-e076-4a51-981b-900f05e475f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

