### PR TITLE
fix(bottom-sheet): controlled props

### DIFF
--- a/.changeset/floppy-waves-speak.md
+++ b/.changeset/floppy-waves-speak.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/bottom-sheet": patch
+---
+
+Fix the issue where controlled props are not working in the bottom sheet

--- a/packages/machines/bottom-sheet/src/bottom-sheet.machine.ts
+++ b/packages/machines/bottom-sheet/src/bottom-sheet.machine.ts
@@ -74,7 +74,7 @@ export const machine = createMachine<BottomSheetSchema>({
     },
   },
 
-  watch({ track, context }) {
+  watch({ track, context, prop, action }) {
     track([() => context.get("activeSnapPoint"), () => context.get("contentHeight")], () => {
       const activeSnapPoint = context.get("activeSnapPoint")
       const contentHeight = context.get("contentHeight")
@@ -82,6 +82,9 @@ export const machine = createMachine<BottomSheetSchema>({
 
       const resolvedActiveSnapPoint = resolveSnapPoint(activeSnapPoint, contentHeight)
       context.set("resolvedActiveSnapPoint", resolvedActiveSnapPoint)
+    })
+    track([() => prop("open")], () => {
+      action(["toggleVisibility"])
     })
   },
 
@@ -108,6 +111,9 @@ export const machine = createMachine<BottomSheetSchema>({
         "trackContentHeight",
       ],
       on: {
+        "CONTROLLED.CLOSE": {
+          target: "closed",
+        },
         POINTER_DOWN: [
           {
             actions: ["setPointerStart"],
@@ -180,6 +186,9 @@ export const machine = createMachine<BottomSheetSchema>({
     closed: {
       tags: ["closed"],
       on: {
+        "CONTROLLED.OPEN": {
+          target: "open",
+        },
         OPEN: [
           {
             guard: "isOpenControlled",
@@ -329,6 +338,10 @@ export const machine = createMachine<BottomSheetSchema>({
         context.set("lastPoint", null)
         context.set("lastTimestamp", null)
         context.set("velocity", null)
+      },
+
+      toggleVisibility({ event, send, prop }) {
+        send({ type: prop("open") ? "CONTROLLED.OPEN" : "CONTROLLED.CLOSE", previousEvent: event })
       },
     },
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fix the issue where controlled props are not working in the bottom sheet.

## ⛳️ Current behavior (updates)

The open state of the bottom sheet can't be controlled using the `open` prop.

## 🚀 New behavior

The open state of the bottom sheet can be controlled using the `open` prop.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information
