### PR TITLE
formatByte: Add unit system property

### DIFF
--- a/.changeset/little-eyes-dress.md
+++ b/.changeset/little-eyes-dress.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/i18n-utils": patch
+---
+
+- **formatBytes**: Support `unitSystem` property to allow changing between decimal (1000 bytes) and binary (1024 bytes)
+  systems.

--- a/packages/utilities/i18n-utils/src/format-bytes.ts
+++ b/packages/utilities/i18n-utils/src/format-bytes.ts
@@ -4,6 +4,8 @@ const bitPrefixes = ["", "kilo", "mega", "giga", "tera"]
 const bytePrefixes = ["", "kilo", "mega", "giga", "tera", "peta"]
 
 export interface FormatBytesOptions {
+  precision?: number | undefined
+  definition?: "binary" | "decimal" | undefined
   unit?: "bit" | "byte" | undefined
   unitDisplay?: "long" | "short" | "narrow" | undefined
 }
@@ -12,7 +14,9 @@ export const formatBytes = (bytes: number, locale = "en-US", options: FormatByte
   if (isNaN(bytes)) return ""
   if (bytes === 0) return "0 B"
 
-  const { unit = "byte", unitDisplay = "short" } = options
+  const { definition = "decimal", precision = 3, unit = "byte", unitDisplay = "short" } = options
+
+  const factor = definition === "binary" ? 1024 : 1000
 
   const prefix = unit === "bit" ? bitPrefixes : bytePrefixes
   const index = Math.max(0, Math.min(Math.floor(Math.log10(bytes) / 3), prefix.length - 1))
@@ -20,7 +24,7 @@ export const formatBytes = (bytes: number, locale = "en-US", options: FormatByte
   const _unit = prefix[index] + unit
   const _unitDisplay = unitDisplay || "short"
 
-  const v = parseFloat((bytes / Math.pow(1000, index)).toPrecision(3))
+  const v = parseFloat((bytes / Math.pow(factor, index)).toPrecision(precision))
 
   return formatNumber(v, locale, {
     style: "unit",

--- a/packages/utilities/i18n-utils/src/format-bytes.ts
+++ b/packages/utilities/i18n-utils/src/format-bytes.ts
@@ -4,31 +4,51 @@ const bitPrefixes = ["", "kilo", "mega", "giga", "tera"]
 const bytePrefixes = ["", "kilo", "mega", "giga", "tera", "peta"]
 
 export interface FormatBytesOptions {
+  /**
+   * The number of significant digits to include in the formatted output.
+   * @default 3
+   */
   precision?: number | undefined
-  definition?: "binary" | "decimal" | undefined
+  /**
+   * The unit system to use for calculations.
+   * - "binary": Uses 1024 as the base (e.g., 1 KiB = 1024 bytes)
+   * - "decimal": Uses 1000 as the base (e.g., 1 KB = 1000 bytes)
+   * @default "decimal"
+   */
+  unitSystem?: "binary" | "decimal" | undefined
+  /**
+   * The type of unit to format the value as.
+   * - "bit": Format as bits (b)
+   * - "byte": Format as bytes (B)
+   * @default "byte"
+   */
   unit?: "bit" | "byte" | undefined
+  /**
+   * The display style for the unit.
+   * - "long": Full unit name (e.g., "kilobytes")
+   * - "short": Abbreviated unit (e.g., "KB")
+   * - "narrow": Compact unit (e.g., "K")
+   * @default "short"
+   */
   unitDisplay?: "long" | "short" | "narrow" | undefined
 }
 
 export const formatBytes = (bytes: number, locale = "en-US", options: FormatBytesOptions = {}) => {
-  if (isNaN(bytes)) return ""
+  if (Number.isNaN(bytes)) return ""
   if (bytes === 0) return "0 B"
 
-  const { definition = "decimal", precision = 3, unit = "byte", unitDisplay = "short" } = options
+  const { unitSystem = "decimal", precision = 3, unit = "byte", unitDisplay = "short" } = options
 
-  const factor = definition === "binary" ? 1024 : 1000
+  const factor = unitSystem === "binary" ? 1024 : 1000
 
   const prefix = unit === "bit" ? bitPrefixes : bytePrefixes
   const index = Math.max(0, Math.min(Math.floor(Math.log10(bytes) / 3), prefix.length - 1))
-
-  const _unit = prefix[index] + unit
-  const _unitDisplay = unitDisplay || "short"
 
   const v = parseFloat((bytes / Math.pow(factor, index)).toPrecision(precision))
 
   return formatNumber(v, locale, {
     style: "unit",
-    unit: _unit,
-    unitDisplay: _unitDisplay,
+    unit: prefix[index] + unit,
+    unitDisplay,
   })
 }

--- a/packages/utilities/i18n-utils/tests/format-byte.test.ts
+++ b/packages/utilities/i18n-utils/tests/format-byte.test.ts
@@ -44,36 +44,36 @@ describe("formatBytes", () => {
 
   describe("binary definition", () => {
     test("should format bytes correctly", () => {
-      const options: FormatBytesOptions = { definition: "binary", unit: "byte", unitDisplay: "short" }
+      const options: FormatBytesOptions = { unitSystem: "binary", unit: "byte", unitDisplay: "short" }
       const result = formatBytes(1536, "en-US", options)
       expect(result).toMatchInlineSnapshot(`"1.5 kB"`)
     })
 
     test("should format bits correctly", () => {
-      const options: FormatBytesOptions = { definition: "binary", unit: "bit", unitDisplay: "short" }
+      const options: FormatBytesOptions = { unitSystem: "binary", unit: "bit", unitDisplay: "short" }
       const result = formatBytes(1536, "en-US", options)
       expect(result).toMatchInlineSnapshot(`"1.5 kb"`)
     })
 
     test("should handle large byte values", () => {
-      const options: FormatBytesOptions = { definition: "binary", unit: "byte", unitDisplay: "short" }
+      const options: FormatBytesOptions = { unitSystem: "binary", unit: "byte", unitDisplay: "short" }
       const result = formatBytes(1610612736, "en-US", options)
       expect(result).toMatchInlineSnapshot(`"1.5 GB"`)
     })
 
     test("sink", () => {
-      expect(formatBytes(1024, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 kB"`)
-      expect(formatBytes(1048576, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 MB"`)
-      expect(formatBytes(1075200, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1.03 MB"`)
-      expect(formatBytes(1073741824, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 GB"`)
-      expect(formatBytes(1148903751, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1.07 GB"`)
-      expect(formatBytes(1099511627776, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 TB"`)
-      expect(formatBytes(1209462790553, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1.1 TB"`)
-      expect(formatBytes(1022, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"0.998 kB"`)
-      expect(formatBytes(1018, "en-US", { definition: "binary", precision: 2 })).toMatchInlineSnapshot(`"0.99 kB"`)
-      expect(formatBytes(1048575, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 MB"`)
-      expect(formatBytes(1073741823, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 GB"`)
-      expect(formatBytes(1099511627775, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 TB"`)
+      expect(formatBytes(1024, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1 kB"`)
+      expect(formatBytes(1048576, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1 MB"`)
+      expect(formatBytes(1075200, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1.03 MB"`)
+      expect(formatBytes(1073741824, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1 GB"`)
+      expect(formatBytes(1148903751, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1.07 GB"`)
+      expect(formatBytes(1099511627776, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1 TB"`)
+      expect(formatBytes(1209462790553, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1.1 TB"`)
+      expect(formatBytes(1022, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"0.998 kB"`)
+      expect(formatBytes(1018, "en-US", { unitSystem: "binary", precision: 2 })).toMatchInlineSnapshot(`"0.99 kB"`)
+      expect(formatBytes(1048575, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1 MB"`)
+      expect(formatBytes(1073741823, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1 GB"`)
+      expect(formatBytes(1099511627775, "en-US", { unitSystem: "binary" })).toMatchInlineSnapshot(`"1 TB"`)
     })
   })
 })

--- a/packages/utilities/i18n-utils/tests/format-byte.test.ts
+++ b/packages/utilities/i18n-utils/tests/format-byte.test.ts
@@ -1,42 +1,79 @@
 import { formatBytes, type FormatBytesOptions } from "../src"
 
 describe("formatBytes", () => {
-  test("should return empty string for NaN", () => {
-    const result = formatBytes(NaN)
-    expect(result).toMatchInlineSnapshot(`""`)
+  describe("decimal definition", () => {
+    test("should return empty string for NaN", () => {
+      const result = formatBytes(NaN)
+      expect(result).toMatchInlineSnapshot(`""`)
+    })
+
+    test("should return '0 B' for 0 bytes", () => {
+      const result = formatBytes(0)
+      expect(result).toMatchInlineSnapshot(`"0 B"`)
+    })
+
+    test("should format bytes correctly", () => {
+      const options: FormatBytesOptions = { unit: "byte", unitDisplay: "short" }
+      const result = formatBytes(1500, "en-US", options)
+      expect(result).toMatchInlineSnapshot(`"1.5 kB"`)
+    })
+
+    test("should format bits correctly", () => {
+      const options: FormatBytesOptions = { unit: "bit", unitDisplay: "short" }
+      const result = formatBytes(1500, "en-US", options)
+      expect(result).toMatchInlineSnapshot(`"1.5 kb"`)
+    })
+
+    test("should handle large byte values", () => {
+      const options: FormatBytesOptions = { unit: "byte", unitDisplay: "short" }
+      const result = formatBytes(1500000000, "en-US", options)
+      expect(result).toMatchInlineSnapshot(`"1.5 GB"`)
+    })
+
+    test("sink", () => {
+      expect(formatBytes(1024)).toMatchInlineSnapshot(`"1.02 kB"`)
+      expect(formatBytes(1048576)).toMatchInlineSnapshot(`"1.05 MB"`)
+      expect(formatBytes(1073741824)).toMatchInlineSnapshot(`"1.07 GB"`)
+      expect(formatBytes(1099511627776)).toMatchInlineSnapshot(`"1.1 TB"`)
+      expect(formatBytes(1023)).toMatchInlineSnapshot(`"1.02 kB"`)
+      expect(formatBytes(1048575)).toMatchInlineSnapshot(`"1.05 MB"`)
+      expect(formatBytes(1073741823)).toMatchInlineSnapshot(`"1.07 GB"`)
+      expect(formatBytes(1099511627775)).toMatchInlineSnapshot(`"1.1 TB"`)
+    })
   })
 
-  test("should return '0 B' for 0 bytes", () => {
-    const result = formatBytes(0)
-    expect(result).toMatchInlineSnapshot(`"0 B"`)
-  })
+  describe("binary definition", () => {
+    test("should format bytes correctly", () => {
+      const options: FormatBytesOptions = { definition: "binary", unit: "byte", unitDisplay: "short" }
+      const result = formatBytes(1536, "en-US", options)
+      expect(result).toMatchInlineSnapshot(`"1.5 kB"`)
+    })
 
-  test("should format bytes correctly", () => {
-    const options: FormatBytesOptions = { unit: "byte", unitDisplay: "short" }
-    const result = formatBytes(1500, "en-US", options)
-    expect(result).toMatchInlineSnapshot(`"1.5 kB"`)
-  })
+    test("should format bits correctly", () => {
+      const options: FormatBytesOptions = { definition: "binary", unit: "bit", unitDisplay: "short" }
+      const result = formatBytes(1536, "en-US", options)
+      expect(result).toMatchInlineSnapshot(`"1.5 kb"`)
+    })
 
-  test("should format bits correctly", () => {
-    const options: FormatBytesOptions = { unit: "bit", unitDisplay: "short" }
-    const result = formatBytes(1500, "en-US", options)
-    expect(result).toMatchInlineSnapshot(`"1.5 kb"`)
-  })
+    test("should handle large byte values", () => {
+      const options: FormatBytesOptions = { definition: "binary", unit: "byte", unitDisplay: "short" }
+      const result = formatBytes(1610612736, "en-US", options)
+      expect(result).toMatchInlineSnapshot(`"1.5 GB"`)
+    })
 
-  test("should handle large byte values", () => {
-    const options: FormatBytesOptions = { unit: "byte", unitDisplay: "short" }
-    const result = formatBytes(1500000000, "en-US", options)
-    expect(result).toMatchInlineSnapshot(`"1.5 GB"`)
-  })
-
-  test("sink", () => {
-    expect(formatBytes(1024)).toMatchInlineSnapshot(`"1.02 kB"`)
-    expect(formatBytes(1048576)).toMatchInlineSnapshot(`"1.05 MB"`)
-    expect(formatBytes(1073741824)).toMatchInlineSnapshot(`"1.07 GB"`)
-    expect(formatBytes(1099511627776)).toMatchInlineSnapshot(`"1.1 TB"`)
-    expect(formatBytes(1023)).toMatchInlineSnapshot(`"1.02 kB"`)
-    expect(formatBytes(1048575)).toMatchInlineSnapshot(`"1.05 MB"`)
-    expect(formatBytes(1073741823)).toMatchInlineSnapshot(`"1.07 GB"`)
-    expect(formatBytes(1099511627775)).toMatchInlineSnapshot(`"1.1 TB"`)
+    test("sink", () => {
+      expect(formatBytes(1024, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 kB"`)
+      expect(formatBytes(1048576, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 MB"`)
+      expect(formatBytes(1075200, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1.03 MB"`)
+      expect(formatBytes(1073741824, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 GB"`)
+      expect(formatBytes(1148903751, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1.07 GB"`)
+      expect(formatBytes(1099511627776, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 TB"`)
+      expect(formatBytes(1209462790553, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1.1 TB"`)
+      expect(formatBytes(1022, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"0.998 kB"`)
+      expect(formatBytes(1018, "en-US", { definition: "binary", precision: 2 })).toMatchInlineSnapshot(`"0.99 kB"`)
+      expect(formatBytes(1048575, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 MB"`)
+      expect(formatBytes(1073741823, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 GB"`)
+      expect(formatBytes(1099511627775, "en-US", { definition: "binary" })).toMatchInlineSnapshot(`"1 TB"`)
+    })
   })
 })


### PR DESCRIPTION
In computing, there are two competing definitions of what “kilo,” “mega,” “giga,” etc., mean when applied to bytes:

**Decimal** (SI definition)
1 kilobyte (KB) = 1000 bytes
1 megabyte (MB) = 1000² bytes
Common in disk storage, networking, and marketing.

**Binary** (IEC definition)

1 kibibyte (KiB) = 1024 bytes
1 mebibyte (MiB) = 1024² bytes
Used in memory, OS-level reporting, and low-level computing

I added `definition` so developers can choose between default `decimal` (1000) and `binary` (1024) unit systems, ensuring accurate and context-appropriate byte formatting.