### PR TITLE
feat(slider): add `splitMarkerProps` helper

### DIFF
--- a/.changeset/rude-kings-listen.md
+++ b/.changeset/rude-kings-listen.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/slider": minor
+---
+
+feat: Add `splitMarkerProps` helper

--- a/packages/machines/slider/src/slider.props.ts
+++ b/packages/machines/slider/src/slider.props.ts
@@ -1,6 +1,6 @@
 import { createProps } from "@zag-js/types"
 import { createSplitProps } from "@zag-js/utils"
-import { type ThumbProps, type SliderProps, type MarkerProps } from "./slider.types"
+import type { ThumbProps, SliderProps, MarkerProps } from "./slider.types"
 
 export const props = createProps<SliderProps>()([
   "aria-label",

--- a/packages/machines/slider/src/slider.props.ts
+++ b/packages/machines/slider/src/slider.props.ts
@@ -1,6 +1,6 @@
 import { createProps } from "@zag-js/types"
 import { createSplitProps } from "@zag-js/utils"
-import type { ThumbProps, SliderProps } from "./slider.types"
+import { type ThumbProps, type SliderProps, type MarkerProps } from "./slider.types"
 
 export const props = createProps<SliderProps>()([
   "aria-label",
@@ -35,3 +35,5 @@ export const splitProps = createSplitProps<Partial<SliderProps>>(props)
 
 export const thumbProps = createProps<ThumbProps>()(["index", "name"])
 export const splitThumbProps = createSplitProps<ThumbProps>(thumbProps)
+export const markerProps = createProps<MarkerProps>()(["value"])
+export const splitMarkerProps = createSplitProps<MarkerProps>(markerProps)


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2725

## 📝 Description

Adds the `splitMarkerProps` utility

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Incremental feature, no behaviour will change

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Users can split marker props now.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
