### PR TITLE
docs: use css variable for collapsed height in animations

### DIFF
--- a/website/data/components/collapsible.mdx
+++ b/website/data/components/collapsible.mdx
@@ -112,7 +112,7 @@ Use CSS animations to animate the collapsible when it expands and collapses. The
 ```css
 @keyframes expand {
   from {
-    height: 0;
+    height: var(--collapsed-height, 0);
   }
   to {
     height: var(--height);
@@ -124,7 +124,7 @@ Use CSS animations to animate the collapsible when it expands and collapses. The
     height: var(--height);
   }
   to {
-    height: 0;
+    height: var(--collapsed-height, 0);
   }
 }
 


### PR DESCRIPTION
## 📝 Description

Updates the collapsible animation code snippet to support the newly introduced collapsed height.
Falls back to 0.

## ⛳️ Current behavior (updates)

example is not working

## 🚀 New behavior

example is working

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
