### PR TITLE
fix(listbox): update `splitProps` to avoid partial

### DIFF
--- a/packages/machines/listbox/src/listbox.props.ts
+++ b/packages/machines/listbox/src/listbox.props.ts
@@ -25,7 +25,7 @@ export const props = createProps<ListboxProps>()([
   "typeahead",
   "value",
 ])
-export const splitProps = createSplitProps<Partial<ListboxProps>>(props)
+export const splitProps = createSplitProps<ListboxProps>(props)
 
 export const itemProps = createProps<ItemProps>()(["item", "highlightOnHover"])
 export const splitItemProps = createSplitProps<ItemProps>(itemProps)


### PR DESCRIPTION
Closes #2745

## 📝 Description

This PR fixes a TypeScript typing issue in the `Listbox` machine where the `splitProps` function incorrectly returns `Partial<ListboxProps>` instead of `ListboxProps`. This change corrects the type parameter to ensure proper type inference and eliminates the need for manual type assertions.

## ⛳️ Current behavior (updates)

The `splitProps` function was defined with `Partial<ListboxProps>` as the type parameter, which made all properties optional in the returned props object. This caused TypeScript typing issues where users had to use workaround type assertions.

## 🚀 New behavior

The `splitProps` function now correctly returns typed props where required properties remain required and optional properties remain optional, matching the original `ListboxProps` interface definition.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This fix aligns the `Listbox` machine with the correct usage pattern found in other machines and matches the intended behavior of the `createSplitProps` utility function.

#### Before

```typescript
// ❌ Using Partial<ListboxProps> makes all properties optional
export const splitProps = createSplitProps<Partial<ListboxProps>>(props)
```

#### After

```typescript
// ✅ Using ListboxProps preserves required/optional property types
export const splitProps = createSplitProps<ListboxProps>(props)
```