### PR TITLE
fix(select): adds missing aria-required to trigger props

### DIFF
--- a/.changeset/tidy-dingos-deny.md
+++ b/.changeset/tidy-dingos-deny.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/select": patch
+---
+
+Fix accessibility violation where the required state was not set correctly to on the trigger.

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -171,6 +171,7 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
         "aria-haspopup": "listbox",
         "data-state": open ? "open" : "closed",
         "aria-invalid": invalid,
+        "aria-required": required,
         "aria-labelledby": dom.getLabelId(scope),
         ...parts.trigger.attrs,
         "data-disabled": dataAttr(disabled),

--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -166,6 +166,7 @@ export const toastControls = defineControls({
 export const selectControls = defineControls({
   multiple: { type: "boolean", defaultValue: false },
   disabled: { type: "boolean", defaultValue: false },
+  required: { type: "boolean", defaultValue: false },
   loopFocus: { type: "boolean", defaultValue: true },
   readOnly: { type: "boolean", defaultValue: false },
   deselectable: { type: "boolean", defaultValue: false },


### PR DESCRIPTION
Closes #2785

## 📝 Description

This PR adds accessibility support for the required state in the Zag.js Select component by ensuring it is reflected in the accessibility tree.

## ⛳️ Current behavior (updates)

Currently, when the required property is set on the Select component, it has no effect on the accessibility tree. Assistive technologies do not detect the component as required, which can lead to accessibility issues and non-compliance with WCAG guidelines.

## 🚀 New behavior

The getTriggerProps function now sets aria-required="true" when the required property is present. This ensures that the required state is properly exposed to assistive technologies, similar to how aria-invalid is handled.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
<img width="2032" height="1161" alt="Bildschirmfoto 2025-10-17 um 16 32 17" src="https://github.com/user-attachments/assets/a28c7a3a-43dd-41c8-88f9-989fa9a17fcd" />
<img width="2032" height="1161" alt="Bildschirmfoto 2025-10-17 um 16 32 22" src="https://github.com/user-attachments/assets/5c976ba0-6ad4-4053-bd72-f108b8380a42" />

