### PR TITLE
chore: correct place and code for marquee vue example

### DIFF
--- a/examples/nuxt-ts/app/pages/marquee.vue
+++ b/examples/nuxt-ts/app/pages/marquee.vue
@@ -7,11 +7,10 @@ const controls = useControls(marqueeControls)
 
 const service = useMachine(
   marquee.machine,
-  computed(() => ({
+  controls.mergeProps<marquee.Props>({
     id: useId(),
     spacing: "2rem",
-    ...controls.value.context,
-  })),
+  }),
 )
 
 const api = computed(() => marquee.connect(service, normalizeProps))
@@ -42,7 +41,10 @@ const api = computed(() => marquee.connect(service, normalizeProps))
     </div>
   </main>
 
-  <Toolbar :controls="controls.ui">
+  <Toolbar>
     <StateVisualizer :state="service" />
+    <template #controls>
+      <Controls :control="controls" />
+    </template>
   </Toolbar>
 </template>

--- a/examples/svelte-ts/package-map.json
+++ b/examples/svelte-ts/package-map.json
@@ -38,6 +38,7 @@
   "@zag-js/json-tree-utils": "../../packages/utilities/json-tree-utils/src",
   "@zag-js/listbox": "../../packages/machines/listbox/src",
   "@zag-js/live-region": "../../packages/utilities/live-region/src",
+  "@zag-js/marquee": "../../packages/machines/marquee/src",
   "@zag-js/menu": "../../packages/machines/menu/src",
   "@zag-js/navigation-menu": "../../packages/machines/navigation-menu/src",
   "@zag-js/number-input": "../../packages/machines/number-input/src",


### PR DESCRIPTION
- Moved `marquee.vue` to the correct directory.
- Corrected code for merging props and showing controls.