### PR TITLE
docs: fixed SegmentedControl stackblitz link

### DIFF
--- a/website/lib/normalize.ts
+++ b/website/lib/normalize.ts
@@ -5,6 +5,7 @@ const nameMap: Record<string, string> = {
   "progress-circular": "progress",
   "range-slider": "slider",
   "timer-countdown": "timer",
+  "segmented-control": "radio-group",
 }
 
 export function normalizeComponentName(component: string) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

currently stackblitz link on https://zagjs.com/components/react/segmented-control is broken:

```
@zag-js/segmented-control is not in the npm registry, or you have no permission to fetch it.
```

because the actual package name is `@zag-js/radio-group`. this change should fix it, although i haven't tested

## ⛳️ Current behavior (updates)

stackblitz example doesn't work

## 🚀 New behavior

it works

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
