### PR TITLE
fix(floating-panel): resizable and draggable are now respected

### DIFF
--- a/.changeset/three-lines-end.md
+++ b/.changeset/three-lines-end.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/floating-panel": patch
+---
+
+bugfix: `draggable` and `resizable` were not respected when set to `false`

--- a/packages/machines/floating-panel/src/floating-panel.machine.ts
+++ b/packages/machines/floating-panel/src/floating-panel.machine.ts
@@ -104,8 +104,8 @@ export const machine = createMachine<FloatingPanelSchema>({
     isMaximized: ({ context }) => context.get("stage") === "maximized",
     isMinimized: ({ context }) => context.get("stage") === "minimized",
     isStaged: ({ context }) => context.get("stage") !== "default",
-    canResize: ({ context, prop }) => (prop("resizable") || !prop("disabled")) && context.get("stage") === "default",
-    canDrag: ({ prop, computed }) => (prop("draggable") || !prop("disabled")) && !computed("isMaximized"),
+    canResize: ({ context, prop }) => prop("resizable") && !prop("disabled") && context.get("stage") === "default",
+    canDrag: ({ prop, computed }) => prop("draggable") && !prop("disabled") && !computed("isMaximized"),
   },
 
   watch({ track, context, action, prop }) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2860

## 📝 Description

Rewires the `canDrag` and `canResize` logic slightly to ensure `draggable` and `resizable` are equally important as the other conditions.

## ⛳️ Current behavior (updates)

`canResize` will be set to true even when `resizable` is set to false

## 🚀 New behavior

`canResize` will be set to false even when `resizable` is set to false

## 💣 Is this a breaking change (Yes/No):

No, unless people are depending on the previously broken logic.

## 📝 Additional Information
