### PR TITLE
fix(tabs,radio-group): no longer show `indicator` prematurely

### DIFF
--- a/.changeset/cyan-wolves-travel.md
+++ b/.changeset/cyan-wolves-travel.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/radio-group": patch
+"@zag-js/tabs": patch
+---
+
+bugfix: `tabs` and `radio-group` machine no longer show the `indicator` prematurely

--- a/packages/machines/radio-group/src/radio-group.connect.ts
+++ b/packages/machines/radio-group/src/radio-group.connect.ts
@@ -196,11 +196,12 @@ export function connect<T extends PropTypes>(
 
     getIndicatorProps() {
       const rect = context.get("indicatorRect")
+      const rectIsEmpty = rect == null || (rect.width === 0 && rect.height === 0 && rect.x === 0 && rect.y === 0)
       return normalize.element({
         id: dom.getIndicatorId(scope),
         ...parts.indicator.attrs,
         dir: prop("dir"),
-        hidden: context.get("value") == null || rect == null,
+        hidden: context.get("value") == null || rectIsEmpty,
         "data-disabled": dataAttr(groupDisabled),
         "data-orientation": prop("orientation"),
         style: {

--- a/packages/machines/tabs/src/tabs.connect.ts
+++ b/packages/machines/tabs/src/tabs.connect.ts
@@ -192,12 +192,13 @@ export function connect<T extends PropTypes>(service: Service<TabsSchema>, norma
 
     getIndicatorProps() {
       const rect = context.get("indicatorRect")
+      const rectIsEmpty = rect == null || (rect.width === 0 && rect.height === 0 && rect.x === 0 && rect.y === 0)
       return normalize.element({
         id: dom.getIndicatorId(scope),
         ...parts.indicator.attrs,
         dir: prop("dir"),
         "data-orientation": prop("orientation"),
-        hidden: rect == null,
+        hidden: rectIsEmpty,
         style: {
           "--transition-property": "left, right, top, bottom, width, height",
           "--left": toPx(rect?.x),


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/skeletonlabs/skeleton/issues/4065

## 📝 Description

Fixes the `indicator` from being shown whilst its dimensions are not calculated yet

## ⛳️ Current behavior (updates)

See the Skeleton ticket, the segmented control indicator is shown when the height, width, x and y are `0`, then the animation causes it to swoop from 0x0x0x0 to its actual location, this looks buggy/broken.

## 🚀 New behavior

Now the indicator is shown (using `hidden`) only once the indicatorRect is actually available, by checking wether it's `null` or if all width/height/x/y are set to `0`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
