### PR TITLE
feat(datepicker): added onPageChange callback

### DIFF
--- a/.xstate/date-picker.js
+++ b/.xstate/date-picker.js
@@ -105,21 +105,21 @@ const fetchMachine = createMachine({
     }],
     "GOTO.NEXT": [{
       cond: "isYearView",
-      actions: ["focusNextDecade", "announceVisibleRange"]
+      actions: ["focusNextDecade", "announceVisibleRange", "invokeOnPageChange"]
     }, {
       cond: "isMonthView",
-      actions: ["focusNextYear", "announceVisibleRange"]
+      actions: ["focusNextYear", "announceVisibleRange", "invokeOnPageChange"]
     }, {
-      actions: ["focusNextPage"]
+      actions: ["focusNextPage", "invokeOnPageChange"]
     }],
     "GOTO.PREV": [{
       cond: "isYearView",
-      actions: ["focusPreviousDecade", "announceVisibleRange"]
+      actions: ["focusPreviousDecade", "announceVisibleRange", "invokeOnPageChange"]
     }, {
       cond: "isMonthView",
-      actions: ["focusPreviousYear", "announceVisibleRange"]
+      actions: ["focusPreviousYear", "announceVisibleRange", "invokeOnPageChange"]
     }, {
-      actions: ["focusPreviousPage"]
+      actions: ["focusPreviousPage", "invokeOnPageChange"]
     }]
   },
   on: {

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -191,27 +191,27 @@ export function machine(userContext: UserDefinedContext) {
         "GOTO.NEXT": [
           {
             guard: "isYearView",
-            actions: ["focusNextDecade", "announceVisibleRange"],
+            actions: ["focusNextDecade", "announceVisibleRange", "invokeOnPageChange"],
           },
           {
             guard: "isMonthView",
-            actions: ["focusNextYear", "announceVisibleRange"],
+            actions: ["focusNextYear", "announceVisibleRange", "invokeOnPageChange"],
           },
           {
-            actions: ["focusNextPage"],
+            actions: ["focusNextPage", "invokeOnPageChange"],
           },
         ],
         "GOTO.PREV": [
           {
             guard: "isYearView",
-            actions: ["focusPreviousDecade", "announceVisibleRange"],
+            actions: ["focusPreviousDecade", "announceVisibleRange", "invokeOnPageChange"],
           },
           {
             guard: "isMonthView",
-            actions: ["focusPreviousYear", "announceVisibleRange"],
+            actions: ["focusPreviousYear", "announceVisibleRange", "invokeOnPageChange"],
           },
           {
-            actions: ["focusPreviousPage"],
+            actions: ["focusPreviousPage", "invokeOnPageChange"],
           },
         ],
       },
@@ -933,6 +933,14 @@ export function machine(userContext: UserDefinedContext) {
         },
         invokeOnClose(ctx) {
           ctx.onOpenChange?.({ open: false })
+        },
+        invokeOnPageChange(ctx, evt) {
+          const direction = evt.type === "GOTO.NEXT" ? "next" : "prev"
+          ctx.onPageChange?.({
+            direction,
+            view: ctx.view,
+            visibleRange: ctx.visibleRange,
+          })
         },
         toggleVisibility(ctx, evt, { send }) {
           send({ type: ctx.open ? "CONTROLLED.OPEN" : "CONTROLLED.CLOSE", previousEvent: evt })

--- a/packages/machines/date-picker/src/date-picker.props.ts
+++ b/packages/machines/date-picker/src/date-picker.props.ts
@@ -30,6 +30,7 @@ export const props = createProps<UserDefinedContext>()([
   "numOfMonths",
   "onFocusChange",
   "onOpenChange",
+  "onPageChange",
   "onValueChange",
   "onViewChange",
   "open",

--- a/packages/machines/date-picker/src/date-picker.types.ts
+++ b/packages/machines/date-picker/src/date-picker.types.ts
@@ -34,6 +34,12 @@ export interface ViewChangeDetails {
   view: DateView
 }
 
+export interface PageChangeDetails {
+  direction: "next" | "prev"
+  view: DateView
+  visibleRange: { start: DateValue; end: DateValue }
+}
+
 export interface OpenChangeDetails {
   open: boolean
 }
@@ -165,6 +171,10 @@ interface PublicContext extends DirectionProperty, CommonProperties {
    * Function called when the focused date changes.
    */
   onFocusChange?: ((details: FocusChangeDetails) => void) | undefined
+  /**
+   * Function called when the page changes (next/prev navigation).
+   */
+  onPageChange?: ((details: PageChangeDetails) => void) | undefined
   /**
    * Function called when the view changes.
    */

--- a/packages/machines/date-picker/src/index.ts
+++ b/packages/machines/date-picker/src/index.ts
@@ -26,6 +26,7 @@ export type {
   LocaleDetails,
   MonthGridProps,
   OpenChangeDetails,
+  PageChangeDetails,
   PositioningOptions,
   PresetTriggerProps,
   SelectionMode,


### PR DESCRIPTION
## 📝 Description
Added `onPageChange` callback to datepicker api. Useful to determine the current month after clicking next/previous trigger and, for example, load events or different data based on the current calendar page/month.

## ⛳️ Current behavior (updates)
N/A

## 🚀 New behavior
Triggers `onPageChange` callback on clicking next/previous trigger

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
N/A
