### PR TITLE
feat(menu): support modal behavior

### DIFF
--- a/packages/machines/menu/package.json
+++ b/packages/machines/menu/package.json
@@ -27,13 +27,16 @@
   },
   "dependencies": {
     "@zag-js/anatomy": "workspace:*",
+    "@zag-js/aria-hidden": "workspace:*",
     "@zag-js/core": "workspace:*",
-    "@zag-js/dom-query": "workspace:*",
-    "@zag-js/rect-utils": "workspace:*",
-    "@zag-js/utils": "workspace:*",
     "@zag-js/dismissable": "workspace:*",
+    "@zag-js/dom-query": "workspace:*",
+    "@zag-js/focus-trap": "workspace:*",
     "@zag-js/popper": "workspace:*",
-    "@zag-js/types": "workspace:*"
+    "@zag-js/rect-utils": "workspace:*",
+    "@zag-js/remove-scroll": "workspace:*",
+    "@zag-js/types": "workspace:*",
+    "@zag-js/utils": "workspace:*"
   },
   "devDependencies": {
     "clean-package": "2.2.0"

--- a/packages/machines/menu/src/menu.connect.ts
+++ b/packages/machines/menu/src/menu.connect.ts
@@ -299,6 +299,7 @@ export function connect<T extends PropTypes>(service: Service<MenuSchema>, norma
         ...parts.content.attrs,
         id: dom.getContentId(scope),
         "aria-label": prop("aria-label"),
+        "aria-modal": ariaAttr(prop("modal")),
         hidden: !open,
         "data-state": open ? "open" : "closed",
         role: composite ? "menu" : "dialog",

--- a/packages/machines/menu/src/menu.props.ts
+++ b/packages/machines/menu/src/menu.props.ts
@@ -15,6 +15,7 @@ export const props = createProps<MenuProps>()([
   "id",
   "ids",
   "loopFocus",
+  "modal",
   "navigate",
   "onEscapeKeyDown",
   "onFocusOutside",

--- a/packages/machines/menu/src/menu.types.ts
+++ b/packages/machines/menu/src/menu.types.ts
@@ -91,6 +91,16 @@ export interface MenuProps extends DirectionProperty, CommonProperties, Dismissa
    */
   closeOnSelect?: boolean | undefined
   /**
+   * Whether the menu should be modal. When set to `true`:
+   * - interaction with outside elements will be disabled
+   * - only menu content will be visible to screen readers
+   * - scrolling is blocked
+   * - focus is trapped within the menu
+   *
+   * @default false
+   */
+  modal?: boolean | undefined
+  /**
    * The accessibility label for the menu
    */
   "aria-label"?: string | undefined
@@ -123,7 +133,7 @@ export interface MenuProps extends DirectionProperty, CommonProperties, Dismissa
   navigate?: ((details: NavigateDetails) => void) | null | undefined
 }
 
-type PropsWithDefault = "closeOnSelect" | "typeahead" | "composite" | "positioning" | "loopFocus"
+type PropsWithDefault = "closeOnSelect" | "typeahead" | "composite" | "positioning" | "loopFocus" | "modal"
 
 export interface MenuSchema {
   props: RequiredBy<MenuProps, PropsWithDefault>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2555,6 +2555,9 @@ importers:
       '@zag-js/anatomy':
         specifier: workspace:*
         version: link:../../anatomy
+      '@zag-js/aria-hidden':
+        specifier: workspace:*
+        version: link:../../utilities/aria-hidden
       '@zag-js/core':
         specifier: workspace:*
         version: link:../../core
@@ -2564,12 +2567,18 @@ importers:
       '@zag-js/dom-query':
         specifier: workspace:*
         version: link:../../utilities/dom-query
+      '@zag-js/focus-trap':
+        specifier: workspace:*
+        version: link:../../utilities/focus-trap
       '@zag-js/popper':
         specifier: workspace:*
         version: link:../../utilities/popper
       '@zag-js/rect-utils':
         specifier: workspace:*
         version: link:../../utilities/rect
+      '@zag-js/remove-scroll':
+        specifier: workspace:*
+        version: link:../../utilities/remove-scroll
       '@zag-js/types':
         specifier: workspace:*
         version: link:../../types

--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -60,6 +60,7 @@ export const editableControls = defineControls({
 export const menuControls = defineControls({
   closeOnSelect: { type: "boolean", defaultValue: true },
   loopFocus: { type: "boolean", defaultValue: false },
+  modal: { type: "boolean", defaultValue: false },
 })
 
 export const hoverCardControls = defineControls({


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Addresses: https://github.com/chakra-ui/zag/discussions/1722, https://github.com/chakra-ui/ark/issues/2874

## 📝 Description

Adds support for modal behavior for `menu`.

## ⛳️ Current behavior (updates)

`Menu` doesn't support modality.

## 🚀 New behavior

The `modal` property can be set to `true` for `menu`, meaning that it will:

- trap focus within its content
- block scrolling on the body
- disable pointer interactions outside the popover
- hide content behind the popover from screen readers

## 💣 Is this a breaking change (Yes/No):

No, the property is set to `false` by default, mirroring the behavior before the change.

## 📝 Additional Information

The change is largely based on how modality is implemented in the `popover`.