### PR TITLE
fix(floating-panel): remove `sync: true` from size/position bindables

### DIFF
--- a/packages/machines/floating-panel/src/floating-panel.machine.ts
+++ b/packages/machines/floating-panel/src/floating-panel.machine.ts
@@ -59,7 +59,6 @@ export const machine = createMachine<FloatingPanelSchema>({
         defaultValue: prop("defaultSize"),
         value: prop("size"),
         isEqual: isSizeEqual,
-        sync: true,
         hash(v) {
           return `W:${v.width} H:${v.height}`
         },
@@ -71,7 +70,6 @@ export const machine = createMachine<FloatingPanelSchema>({
         defaultValue: prop("defaultPosition"),
         value: prop("position"),
         isEqual: isPointEqual,
-        sync: true,
         hash(v) {
           return `X:${v.x} Y:${v.y}`
         },


### PR DESCRIPTION
## Summary

Remove `sync: true` from the `size` and `position` bindables in the floating-panel machine to fix intermittent "Maximum update depth exceeded" errors in React.

Fixes #3005

## Problem

`sync: true` causes the React adapter's `useBindable` to wrap `setState` in `flushSync`. During drag-resize, the `setSize` action calls `context.set("size")` and `context.set("position")` — both triggering `flushSync`. This forces React to synchronously commit renders. If the panel's content contains `ResizeObserver` callbacks that trigger state updates (common with chart libraries, auto-sizing components, etc.), those fire within the same synchronous frame, causing a cascading render loop.

## Why removing `sync: true` is safe

1. **`setSizeStyle` already uses `queueMicrotask`** — the CSS custom property update for width/height is already asynchronous, so `flushSync` doesn't actually make the visual update any faster
2. **React 18+ automatically batches** state updates within event handlers and commits at the end of the handler, still within the same animation frame
3. **`setSize` computes from `prevSize`/`prevPosition`** (snapshots taken at drag start), not from `context.get("size")`, so there is no stale-value drift from batched updates
4. **React 17 / legacy mode** — native event handlers (which `trackPointerMove` uses via `document.addEventListener`) are already not batched, so `flushSync` is redundant there too

The visual difference is imperceptible — both paths result in the CSS custom properties being updated and painted in the same frame.

## Change

Two lines removed from `packages/machines/floating-panel/src/floating-panel.machine.ts`:

```diff
 size: bindable<Size>(() => ({
   defaultValue: prop("defaultSize"),
   value: prop("size"),
   isEqual: isSizeEqual,
-  sync: true,
   hash(v) { ... },
   onChange(value) { ... },
 })),
 position: bindable<Point>(() => ({
   defaultValue: prop("defaultPosition"),
   value: prop("position"),
   isEqual: isPointEqual,
-  sync: true,
   hash(v) { ... },
   onChange(value) { ... },
 })),
```