### PR TITLE
fix(pin-input): skip INPUT.CHANGE when value is unchanged in native i…

### DIFF
--- a/.changeset/pin-input-same-value-fix.md
+++ b/.changeset/pin-input-same-value-fix.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/pin-input": patch
+---
+
+Fix crash when typing the same character in a completed pin input on frameworks that use native `input` event (Svelte, Vue, etc.)

--- a/packages/machines/pin-input/src/pin-input.connect.ts
+++ b/packages/machines/pin-input/src/pin-input.connect.ts
@@ -186,6 +186,7 @@ export function connect<T extends PropTypes>(
             send({ type: "INPUT.BACKSPACE" })
             return
           }
+          if (value === computed("focusedValue")) return
 
           send({ type: "INPUT.CHANGE", value, index })
         },


### PR DESCRIPTION
skip INPUT.CHANGE when value is unchanged in native input event