### PR TITLE
fix(pin-input): focus first empty slot on empty-field click

### DIFF
--- a/packages/machines/pin-input/src/pin-input.machine.ts
+++ b/packages/machines/pin-input/src/pin-input.machine.ts
@@ -189,8 +189,19 @@ export const machine = createMachine({
       clearFocusedIndex({ context }) {
         context.set("focusedIndex", -1)
       },
-      setFocusedIndex({ context, event }) {
-        context.set("focusedIndex", event.index)
+      setFocusedIndex({ context, event, computed }) {
+        const value = computed("_value")
+        const clickedIndex = event.index
+
+        // If user taps an empty slot, move focus to the first empty slot.
+        // This keeps keyboard entry starting from the earliest missing value.
+        if (value[clickedIndex] === "") {
+          const firstEmptyIndex = value.findIndex((item) => item === "")
+          context.set("focusedIndex", firstEmptyIndex === -1 ? clickedIndex : firstEmptyIndex)
+          return
+        }
+
+        context.set("focusedIndex", clickedIndex)
       },
       setValue({ context, event }) {
         const value = fill(event.value, context.get("count"))


### PR DESCRIPTION
Closes #2999

## 📝 Description

- update `setFocusedIndex` to route focus to the first empty pin slot when the clicked input is empty
- keep existing behavior for clicks on already-filled inputs

## ⛳️ Current behavior (updates)

- clicking an empty slot focuses that exact slot, even when earlier slots are still empty
- this can make keyboard entry start from the middle and leave earlier cells unfilled

## 🚀 New behavior

- clicking any empty slot now moves focus to the first empty slot in the group
- clicking a filled slot still focuses the clicked slot

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Validated locally with:
- `pnpm --filter @zag-js/pin-input lint`
- `pnpm --filter @zag-js/pin-input typecheck`