### PR TITLE
fix: Splitter cursor styles in shadow root

### DIFF
--- a/.changeset/cute-socks-laugh.md
+++ b/.changeset/cute-socks-laugh.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/splitter": patch
+---
+
+Fix global cursor styles when splitter is used in a shadow root

--- a/packages/machines/splitter/src/splitter.dom.ts
+++ b/packages/machines/splitter/src/splitter.dom.ts
@@ -26,8 +26,12 @@ export const getResizeTriggerEls = (ctx: Scope) => {
   return queryAll(getRootEl(ctx), `[role=separator][data-ownedby='${CSS.escape(getRootId(ctx))}']`)
 }
 
+export const getGlobalCursorEl = (ctx: Scope) => {
+  return ctx.getDoc().getElementById(getGlobalCursorId(ctx))
+}
+
 export const setupGlobalCursor = (ctx: Scope, state: CursorState, x: boolean, nonce?: string) => {
-  const styleEl = ctx.getById(getGlobalCursorId(ctx))
+  const styleEl = getGlobalCursorEl(ctx)
   const textContent = `* { cursor: ${getCursor(state, x)} !important; }`
   if (styleEl) {
     styleEl.textContent = textContent
@@ -41,6 +45,6 @@ export const setupGlobalCursor = (ctx: Scope, state: CursorState, x: boolean, no
 }
 
 export const removeGlobalCursor = (ctx: Scope) => {
-  const styleEl = ctx.getById(getGlobalCursorId(ctx))
+  const styleEl = getGlobalCursorEl(ctx)
   styleEl?.remove()
 }


### PR DESCRIPTION
## 📝 Description

The splitter registers a global style element to change the user's cursor.
When in a shadow root, that style element is currently repeated hundrends of times (one style element per tick/mouse event) and never cleaned up, causing the cursor to be stuck in its altered style.

## ⛳️ Current behavior (updates)

The splitter fails to find its style element when inside the shadow root.
This is caused by _adding_ the style element to `document.head` but _looking for it_ in the shadow root (via `ctx.getById()`).

## 🚀 New behavior

The lookup now happens on `ctx.getDoc()` instead.
This way, the style element is found and both updated and removed correctly.

## 💣 Is this a breaking change (Yes/No):

No

