### PR TITLE
chore: add AGENTS.md with cloud-specific development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Zag.js is a pnpm monorepo (~96 workspace packages) with no external service dependencies (no databases, Docker, APIs). All development is purely frontend/library work.
+
+### Key commands
+
+See `CLAUDE.md` and `.claude/docs/commands.md` for the full reference. Summary:
+
+| Task | Command |
+|---|---|
+| Install deps | `pnpm install` |
+| Build all packages | `pnpm build` |
+| Lint | `pnpm lint` |
+| Unit tests (JS/core) | `pnpm test-js --run` |
+| Unit tests (React) | `pnpm test-react --run` |
+| Unit tests (all) | `pnpm test` |
+| Start React dev server | `pnpm start-react` (port 3000) |
+| E2E tests (React) | `pnpm e2e-react` |
+| Typecheck | `pnpm typecheck` |
+
+### Non-obvious caveats
+
+- **Build before dev server**: `pnpm build` must complete before running any example dev servers or E2E tests, since workspace packages use `workspace:*` references and need compiled `dist/` output.
+- **Build is slow**: The full `pnpm build` takes ~2 minutes across all packages. It only needs to run once unless package source changes.
+- **Node version**: `.nvmrc` specifies Node 24, but Node 22 (pre-installed) works fine. The engine constraint is `>=18.0.0`.
+- **pnpm version**: `packageManager` field specifies `pnpm@10.33.0`. Corepack or the pre-installed pnpm handles this.
+- **Husky hooks**: Pre-commit runs `lint-staged` (prettier on changed files). Commit-msg runs `commitlint` enforcing conventional commits. Both are non-blocking for development.
+- **E2E tests**: Playwright auto-starts the appropriate dev server. Set `FRAMEWORK` env var to target a specific framework (default: `react`). Playwright browsers must be installed first via `pnpm exec playwright install`.
+- **No secrets required**: No environment variables, API keys, or external services are needed for development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agent sessions.

## ⛳️ Current behavior (updates)

No `AGENTS.md` exists. Cloud agents must re-discover development caveats each session.

## 🚀 New behavior

Cloud agents can reference `AGENTS.md` for non-obvious development caveats including:
- Build-before-dev requirement
- Node version compatibility notes
- Key commands reference table
- E2E test setup notes (Playwright browser install, FRAMEWORK env var)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Development environment validated:
- `pnpm install` - all 96 workspace packages resolved
- `pnpm build` - all packages built successfully
- `pnpm lint` - passes clean
- `pnpm test-react --run` - 36/36 tests pass
- `pnpm start-react` - Next.js dev server on port 3000
- Interactive demo of Accordion and Dialog components confirmed working

[zag_react_demo_accordion_dialog.mp4](https://cursor.com/agents/bc-20c7668e-f772-4126-a3dd-54fa0e551f99/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzag_react_demo_accordion_dialog.mp4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20c7668e-f772-4126-a3dd-54fa0e551f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20c7668e-f772-4126-a3dd-54fa0e551f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

