### PR TITLE
fix(navigation-menu): drop default aria-label

### DIFF
--- a/.changeset/small-knives-hear.md
+++ b/.changeset/small-knives-hear.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/navigation-menu": patch
+---
+
+Remove agressive and redundant default aria-label

--- a/packages/machines/navigation-menu/src/navigation-menu.connect.ts
+++ b/packages/machines/navigation-menu/src/navigation-menu.connect.ts
@@ -66,7 +66,7 @@ export function connect<T extends PropTypes>(
       return normalize.element({
         ...parts.root.attrs,
         id: dom.getRootId(scope),
-        "aria-label": translations.rootLabel,
+        "aria-label": translations?.rootLabel ? translations.rootLabel : undefined,
         "data-orientation": prop("orientation"),
         dir: prop("dir"),
         style: {

--- a/packages/machines/navigation-menu/src/navigation-menu.connect.ts
+++ b/packages/machines/navigation-menu/src/navigation-menu.connect.ts
@@ -66,7 +66,7 @@ export function connect<T extends PropTypes>(
       return normalize.element({
         ...parts.root.attrs,
         id: dom.getRootId(scope),
-        "aria-label": translations?.rootLabel ? translations.rootLabel : undefined,
+        "aria-label": translations?.rootLabel,
         "data-orientation": prop("orientation"),
         dir: prop("dir"),
         style: {

--- a/packages/machines/navigation-menu/src/navigation-menu.machine.ts
+++ b/packages/machines/navigation-menu/src/navigation-menu.machine.ts
@@ -25,10 +25,6 @@ export const machine = createMachine({
       orientation: "horizontal",
       defaultValue: "",
       ...props,
-      translations: {
-        rootLabel: "Main Navigation",
-        ...props.translations,
-      },
     }
   },
 

--- a/packages/machines/navigation-menu/src/navigation-menu.types.ts
+++ b/packages/machines/navigation-menu/src/navigation-menu.types.ts
@@ -82,7 +82,7 @@ export interface NavigationMenuProps extends DirectionProperty, CommonProperties
   disablePointerLeaveClose?: boolean | undefined
 }
 
-type PropsWithDefault = "openDelay" | "closeDelay" | "dir" | "id" | "orientation" | "translations"
+type PropsWithDefault = "openDelay" | "closeDelay" | "dir" | "id" | "orientation"
 
 export interface NavigationMenuSchema {
   props: RequiredBy<NavigationMenuProps, PropsWithDefault>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Removes the default `aria-label` from the `navigation-menu` machine. As it caused redundant announcement and was a little agressive.

## ⛳️ Current behavior (updates)

- `aria-label="Main Navigation"` does not really work on a plain `div`. Role `navigation` is not forced.
- Normally users should use a `nav` or `role="navigation"` themself and this would result in duplicate announcement of the word "Navigation" because it is triggered by the role and the label
- The `aria-label` is not needed when theres only one navigation on the page and users with a non english site would then need to override the label because of this

## 🚀 New behavior

- Doesnt set a default label at all
- Matches consistency and expectaions across the machine since we also dont force the `nav`/`role="navigation"` or `ul`/`li` semantics

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->
No
- users with a single instance will get the same semantic/a11y behavior
- users with more instances would previously got a broken a11y behavior because of duplicate nav labels

## 📝 Additional Information
Maybe its worth adding a note in the docs for the semantic elements for some parts:
- root -> `<nav>`
- list -> `<ul>`
- item -> `<li>`

And the indicator element should be moved out of the ul if possible i guess since it would result in invalid html