### PR TITLE
fix(vanilla): allow undefined and null computed values

### DIFF
--- a/.changeset/sweet-mugs-work.md
+++ b/.changeset/sweet-mugs-work.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/vanilla": patch
+---
+
+Machine: Do not use `{}` instead of `undefined` and `null` computed value (fixes `accept="[object Object]"` in File
+Upload with `accept: undefined`)

--- a/packages/frameworks/vanilla/src/machine.ts
+++ b/packages/frameworks/vanilla/src/machine.ts
@@ -26,7 +26,7 @@ import {
   resolveStateValue,
 } from "@zag-js/core"
 import { subscribe } from "@zag-js/store"
-import { compact, identity, isEqual, isFunction, isString, runIfFn, toArray, warn } from "@zag-js/utils"
+import { compact, ensure, identity, isEqual, isFunction, isString, runIfFn, toArray, warn } from "@zag-js/utils"
 import { bindable } from "./bindable"
 import { createRefs } from "./refs"
 import { mergeMachineProps } from "./merge-machine-props"
@@ -136,16 +136,15 @@ export class VanillaMachine<T extends MachineSchema> {
     this.context = ctx
 
     const computed: ComputedFn<T> = (key) => {
-      return (
-        machine.computed?.[key]({
-          context: ctx as any,
-          event: this.getEvent(),
-          prop,
-          refs: this.refs,
-          scope: this.scope,
-          computed: computed as any,
-        }) ?? ({} as any)
-      )
+      ensure(machine.computed, () => `[zag-js] No computed object found on machine`)
+      return machine.computed[key]({
+        context: ctx as any,
+        event: this.getEvent(),
+        prop,
+        refs: this.refs,
+        scope: this.scope,
+        computed: computed as any,
+      })
     }
     this.computed = computed
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

To prevent working with undefined `machine.computed`, the machine adds fallback computed value `?? ({} as any)`.
This changes also valid `undefined` and `null` computed values to `{}`.
Found in File Upload hidden input, where property `accept: undefined` produces invalid HTML attribute `accept="[object Object]"`

## ⛳️ Current behavior (updates)

File Upload hidden input with `accept: undefined` property is rendered as `<input accept="[object Object]" />` 

## 🚀 New behavior

`undefined` and `null` computed values are treated as normal values.

File Upload hidden input with `accept: undefined` is rendered without `accept` attribute

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing users. -->

## 📝 Additional Information

When `machine.computed` is `undefined`, an error is throw (instead of silently using `{}` as fallback).
This is consistent with other frameworks and is not expected to cause issues in production thanks to Typescript checks.