### PR TITLE
test: extend e2e tests for date input granularity

### DIFF
--- a/e2e/date-input.e2e.ts
+++ b/e2e/date-input.e2e.ts
@@ -223,9 +223,52 @@ test.describe("date-input [single]", () => {
     await I.seeSegmentFocused("month")
   })
 
+  test("[input] year granularity", async () => {
+    await I.clickControls()
+    await I.controls.select("granularity", "year")
+
+    // Month (and finer) segments should not be present
+    await I.seeSegmentNotPresent("month")
+    await I.seeSegmentNotPresent("day")
+    await I.seeSegmentNotPresent("minute")
+    await I.seeSegmentNotPresent("seconds")
+
+    // Year segment should be present and focusable
+    await I.focusSegment("year")
+    await I.seeSegmentFocused("year")
+    await I.seeSegmentIsPlaceholder("year")
+
+    // ArrowUp should initialize year from placeholder
+    await I.pressKey("ArrowUp")
+    await I.seeSegmentIsNotPlaceholder("year")
+  })
+
+  test("[input] month granularity", async () => {
+    await I.clickControls()
+    await I.controls.select("granularity", "month")
+
+    // Day (and finer) segments should not be present
+    await I.seeSegmentNotPresent("day")
+    await I.seeSegmentNotPresent("minute")
+    await I.seeSegmentNotPresent("seconds")
+
+    // Month segment should be present and focusable
+    await I.focusSegment("month")
+    await I.seeSegmentFocused("month")
+    await I.seeSegmentIsPlaceholder("month")
+
+    // ArrowUp should initialize month from placeholder
+    await I.pressKey("ArrowUp")
+    await I.seeSegmentIsNotPlaceholder("month")
+  })
+
   test("[input] hour granularity", async () => {
     await I.clickControls()
     await I.controls.select("granularity", "hour")
+
+    // Minute and second segments should not be present
+    await I.seeSegmentNotPresent("minute")
+    await I.seeSegmentNotPresent("seconds")
 
     // Hour segment should be present and focusable
     await I.focusSegment("hour")
@@ -240,6 +283,9 @@ test.describe("date-input [single]", () => {
   test("[input] minute granularity", async () => {
     await I.clickControls()
     await I.controls.select("granularity", "minute")
+
+    // Second segment should not be present
+    await I.seeSegmentNotPresent("second")
 
     // Minute segment should be present and focusable
     await I.focusSegment("minute")

--- a/e2e/models/date-input.model.ts
+++ b/e2e/models/date-input.model.ts
@@ -102,6 +102,10 @@ export class DateInputModel extends Model {
     return expect(this.getSegmentNth(type, index)).toHaveAttribute("data-placeholder-shown", "")
   }
 
+  seeSegmentNotPresent(type: string) {
+    return expect(this.getSegment(type)).not.toBeAttached()
+  }
+
   seeSelectedValue(value: string) {
     return expect(this.output).toContainText(`Selected: ${value || "-"}`)
   }

--- a/shared/src/controls.ts
+++ b/shared/src/controls.ts
@@ -231,7 +231,7 @@ export const dateInputControls = defineControls({
   },
   granularity: {
     type: "select",
-    options: ["day", "hour", "minute", "second"] as const,
+    options: ["year", "month", "day", "hour", "minute", "second"] as const,
     defaultValue: "day",
   },
   placeholderValue: {


### PR DESCRIPTION
## 📝 Description

According to the TS types, the date input (which is an awesome addition by the way!) supports `"month"` and `"year"` granularities, which are not available in the shared controls yet and do not seem implemented in general. If those are not planned, feel free to close this and update the types. Otherwise, this PR adds
- (failing) tests for the `"month"` and `"year"` granularities
- assertions about segments that should not be present in existing granularity tests

## ⛳️ Current behavior (updates)

`"month"` and `"year"` granularities do not work in date input, are not included in shared controls, and do not have tests. 

## 🚀 New behavior

Shared controls are updated and (failing) tests are there.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
