### PR TITLE
fix(date-utils): fix CalendarDateTime handling in isDateEqual

### DIFF
--- a/packages/utilities/date-utils/src/assertion.ts
+++ b/packages/utilities/date-utils/src/assertion.ts
@@ -1,9 +1,9 @@
-import { isSameDay } from "@internationalized/date"
+import { isSameDay, toCalendarDateTime } from "@internationalized/date"
 import type { DateAvailableFn, DateValue } from "./types"
 
 export function isDateEqual(dateA: DateValue | null | undefined, dateB?: DateValue | null) {
   if (dateA == null || dateB == null) return dateA === dateB
-  return isSameDay(dateA, dateB)
+  return toCalendarDateTime(dateA).compare(dateB) === 0
 }
 
 export function isDateUnavailable(

--- a/packages/utilities/date-utils/tests/assertion.test.ts
+++ b/packages/utilities/date-utils/tests/assertion.test.ts
@@ -1,18 +1,56 @@
-import { parseDate } from "@internationalized/date"
+import { CalendarDate, CalendarDateTime, parseDate, ZonedDateTime } from "@internationalized/date"
 import { describe, expect, test } from "vitest"
 import { isDateEqual } from "../src"
 
 describe("Date utilities / Assertion", () => {
-  test("isEqual / truthy", () => {
+  test("isEqual / CalendarDate / truthy", () => {
     const dateA = parseDate("2024-03-15")
     const dateB = parseDate("2024-03-15")
     expect(isDateEqual(dateA, dateB)).toBe(true)
   })
 
-  test("isEqual / falsy", () => {
+  test("isEqual / CalendarDate / falsy", () => {
     const dateA = parseDate("2024-04-15")
     const dateB = parseDate("2024-03-15")
+    expect(isDateEqual(dateA, dateB)).toBe(true)
+  })
+
+  test("isEqual / CalendarDateTime / truthy", () => {
+    const dateA = new CalendarDateTime(2024, 3, 15, 0, 0, 0)
+    const dateB = new CalendarDateTime(2024, 3, 15, 0, 0, 0)
+    expect(isDateEqual(dateA, dateB)).toBe(true)
+  })
+
+  test("isEqual / CalendarDateTime / falsy", () => {
+    const dateA = new CalendarDateTime(2024, 3, 15, 0, 0, 0)
+    const dateB = new CalendarDateTime(2024, 3, 15, 0, 0, 1)
     expect(isDateEqual(dateA, dateB)).toBe(false)
+  })
+
+  test("isEqual / ZonedCalendarDate / truthy", () => {
+    const dateA = new ZonedDateTime(2024, 3, 15, "UTC", 0, 0, 0)
+    const dateB = new ZonedDateTime(2024, 3, 15, "UTC+1", 0, 0, 0)
+    expect(isDateEqual(dateA, dateB)).toBe(true)
+  })
+
+  test("isEqual / ZonedCalendarDate / falsy", () => {
+    const dateA = new ZonedDateTime(2024, 3, 15, "UTC", 0, 0, 0)
+    const dateB = new ZonedDateTime(2024, 3, 15, "UTC+1", 0, 0, 1)
+    expect(isDateEqual(dateA, dateB)).toBe(false)
+  })
+
+  test("isEqual / CalendarDate with CalendarDateTime / truthy", () => {
+    const dateA = new CalendarDate(2024, 3, 15)
+    const dateB = new CalendarDateTime(2024, 3, 15, 0, 0, 0)
+    expect(isDateEqual(dateA, dateB)).toBe(true)
+    expect(isDateEqual(dateB, dateA)).toBe(true)
+  })
+
+  test("isEqual / CalendarDate with CalendarDateTime / falsy", () => {
+    const dateA = new CalendarDate(2024, 3, 15)
+    const dateB = new CalendarDateTime(2024, 3, 15, 0, 0, 1)
+    expect(isDateEqual(dateA, dateB)).toBe(false)
+    expect(isDateEqual(dateB, dateA)).toBe(false)
   })
 
   test("isEqual / both null", () => {


### PR DESCRIPTION
## 📝 Description

`isDateEqual` from `@zag-js/date-utils` accepts two `DateValue`s, i.e. `CalendarDate | CalendarDateTime | ZonedDateTime` from `@internationalized/date`. The time components of `CalendarDateTime` and `ZonedDateTime` are currently ignored in the comparison. This PR fixes that.

## ⛳️ Current behavior (updates)

`isDateEqual` from `@zag-js/date-utils` ignores the time components of `CalendarDateTime` and `ZonedDateTime` values. This prevents the `onValueChange` callback to be invoked on time changes in the date input machine:

https://github.com/chakra-ui/zag/blob/b5fe9903f3168746b2c5d5dd2bd38edad0c51043/packages/machines/date-input/src/date-input.machine.ts#L115

The current implementation of `isDateEqual` uses `isSameDay` for the comparison.

## 🚀 New behavior

The comparison is performed by `toCalendarDateTime(dateA).compare(dateB) === 0`. While this does consider the time portion of `CalendarDateTime` and `ZonedDateTime` values, it ignores the time zone of `ZonedDateTime`s. I couldn't find a use case for this in the code base yet, but let me know if this is a concern. Cheers!

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

At a first glance, the tests at `packages/utilities/date-utils/tests/` do not seem to be included in any existing pnpm script and/or workflow. Am I wrong?