### PR TITLE
fix(dismissable): prevent parent layer close after nested dismiss

### DIFF
--- a/packages/utilities/dismissable/src/layer-stack.ts
+++ b/packages/utilities/dismissable/src/layer-stack.ts
@@ -1,4 +1,4 @@
-import { contains, nextTick } from "@zag-js/dom-query"
+import { contains } from "@zag-js/dom-query"
 
 export type LayerType = "dialog" | "popover" | "menu" | "listbox" | (string & {})
 
@@ -103,7 +103,7 @@ export const layerStack = {
 
     // Schedule cleanup after two frames to ensure it outlasts any deferred
     // focusin handlers (which also use requestAnimationFrame)
-    nextTick(() => this.recentlyRemoved.delete(node))
+    requestAnimationFrame(() => this.recentlyRemoved.delete(node))
 
     // dismiss nested layers
     if (index < this.count() - 1) {


### PR DESCRIPTION
Fixes chakra-ui/chakra-ui#10770

## Description

This fixes a timing issue in the dismissable layer stack when a nested overlay closes inside a parent overlay.

Previously, the `recentlyRemoved` guard was cleared in a microtask using `nextTick`. In cases where a child overlay restores focus on the next animation frame, the parent layer could incorrectly treat that restored focus as an outside interaction and dismiss itself.

## Current behavior

When a nested child overlay (such as a popover or toggletip) closes inside a dialog, the parent layer may close during the child’s focus restoration cycle.

## New behavior

The cleanup now runs in `requestAnimationFrame`, which keeps the `recentlyRemoved` guard active long enough for the child overlay’s focus restoration to complete.

This ensures the parent layer remains open when a nested child overlay closes.

## Is this a breaking change

No

## Additional information

This was traced from the Chakra UI issue where closing a ToggleTip inside an open Dialog also caused the Dialog to close.
