### PR TITLE
fix(preact): avoid bundling @zag-js/utils and remove unused proxy-compare

### DIFF
--- a/.changeset/strange-spiders-bow.md
+++ b/.changeset/strange-spiders-bow.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/preact": patch
+---
+
+Avoid bundling @zag-js/utils and remove unused proxy-compare

--- a/packages/frameworks/preact/package.json
+++ b/packages/frameworks/preact/package.json
@@ -28,10 +28,9 @@
     "@zag-js/core": "workspace:*",
     "@zag-js/store": "workspace:*",
     "@zag-js/types": "workspace:*",
-    "proxy-compare": "3.0.1"
+    "@zag-js/utils": "workspace:*"
   },
   "devDependencies": {
-    "@zag-js/utils": "workspace:*",
     "@testing-library/preact": "^3.2.4",
     "preact": "10.29.0",
     "clean-package": "2.2.0"


### PR DESCRIPTION
This PR fixes the Preact package by avoiding the bundling of @zag-js/utils and removing the unused proxy-compare dependency.