### PR TITLE
fix(popper): forward positioning.boundary to size middleware

### DIFF
--- a/.changeset/popper-size-middleware-boundary.md
+++ b/.changeset/popper-size-middleware-boundary.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/popper": patch
+---
+
+Forward `positioning.boundary` to the `size` middleware. Previously, `boundary` was honored by `flip`, `shift`, and `hide` middleware but not by `size`, so `--available-width` and `--available-height` were always computed against `clippingAncestors` (effectively the viewport for portaled popovers) regardless of the configured boundary. Consumers can now constrain the floating element's width and height to a specific boundary element, in addition to its position.
+
+Uses the function/derivable form so `size` re-resolves the boundary on every position tick — matching the pattern recently adopted by `flip`, `shift`, and `hide` for late-mounted boundary elements.

--- a/packages/utilities/popper/src/get-placement.ts
+++ b/packages/utilities/popper/src/get-placement.ts
@@ -115,33 +115,37 @@ function getSizeMiddleware(opts: Options) {
   let lastAvailableWidth: number | undefined
   let lastAvailableHeight: number | undefined
 
-  return size({
-    padding: opts.overflowPadding,
-    apply({ elements, rects, availableHeight, availableWidth }) {
-      const floating = elements.floating
+  return size(() => {
+    const boundary = resolveBoundaryOption(opts.boundary)
+    return {
+      ...(boundary ? { boundary } : undefined),
+      padding: opts.overflowPadding,
+      apply({ elements, rects, availableHeight, availableWidth }) {
+        const floating = elements.floating
 
-      const referenceWidth = Math.round(rects.reference.width)
-      const referenceHeight = Math.round(rects.reference.height)
-      availableWidth = Math.floor(availableWidth)
-      availableHeight = Math.floor(availableHeight)
+        const referenceWidth = Math.round(rects.reference.width)
+        const referenceHeight = Math.round(rects.reference.height)
+        availableWidth = Math.floor(availableWidth)
+        availableHeight = Math.floor(availableHeight)
 
-      if (!isApproximatelyEqual(lastReferenceWidth, referenceWidth)) {
-        floating.style.setProperty("--reference-width", `${referenceWidth}px`)
-        lastReferenceWidth = referenceWidth
-      }
-      if (!isApproximatelyEqual(lastReferenceHeight, referenceHeight)) {
-        floating.style.setProperty("--reference-height", `${referenceHeight}px`)
-        lastReferenceHeight = referenceHeight
-      }
-      if (!isApproximatelyEqual(lastAvailableWidth, availableWidth)) {
-        floating.style.setProperty("--available-width", `${availableWidth}px`)
-        lastAvailableWidth = availableWidth
-      }
-      if (!isApproximatelyEqual(lastAvailableHeight, availableHeight)) {
-        floating.style.setProperty("--available-height", `${availableHeight}px`)
-        lastAvailableHeight = availableHeight
-      }
-    },
+        if (!isApproximatelyEqual(lastReferenceWidth, referenceWidth)) {
+          floating.style.setProperty("--reference-width", `${referenceWidth}px`)
+          lastReferenceWidth = referenceWidth
+        }
+        if (!isApproximatelyEqual(lastReferenceHeight, referenceHeight)) {
+          floating.style.setProperty("--reference-height", `${referenceHeight}px`)
+          lastReferenceHeight = referenceHeight
+        }
+        if (!isApproximatelyEqual(lastAvailableWidth, availableWidth)) {
+          floating.style.setProperty("--available-width", `${availableWidth}px`)
+          lastAvailableWidth = availableWidth
+        }
+        if (!isApproximatelyEqual(lastAvailableHeight, availableHeight)) {
+          floating.style.setProperty("--available-height", `${availableHeight}px`)
+          lastAvailableHeight = availableHeight
+        }
+      },
+    }
   })
 }
 


### PR DESCRIPTION
## Summary

`positioning.boundary` is honored by the `flip`, `shift`, and `hide` middleware in `get-placement.ts`, but not by `size`. As a result, `--available-width` / `--available-height` (which consumers of `getPlacement` use to cap the floating element's `max-width` / `max-height`) always tracked `clippingAncestors`, effectively the viewport when the floating element is portaled to body.

That meant callers could position a popover within a custom boundary but couldn't constrain its width/height to that boundary, which is usually what you want when the boundary represents a layout column or scroll container.

## Change

Pass `boundary` (resolved via the existing `resolveBoundaryOption`) to the `size` middleware, matching the pattern already used by `getFlipMiddleware` / `getShiftMiddleware` / `hideWhenDetachedMiddleware`. Behavior is unchanged when `positioning.boundary` is unset.

Uses the function/derivable form `size(() => { ... })` so the boundary re-resolves on every position tick — aligning with the late-mounted boundary fix that recently landed for `flip`, `shift`, and `hide` (commit `0973473`). A function-form `boundary: () => element` now picks up its element once it mounts, for `size` too.

```ts
function getSizeMiddleware(opts: Options) {
  // ... unchanged setup ...
  return size(() => {
    const boundary = resolveBoundaryOption(opts.boundary)
    return {
      ...(boundary ? { boundary } : undefined),
      padding: opts.overflowPadding,
      apply({ /* ... */ }) { /* ... unchanged ... */ },
    }
  })
}
```

## Repro / verification

Set `positioning={{ boundary: () => columnEl }}` on `Popover.Root` (or any consumer of `getPlacement`) where `columnEl` is narrower than the viewport. Before this change, `--available-width` matches the viewport. After, it matches the column's clip rect,  the popover's `max-width: var(--available-width)` finally wraps text inside the boundary.

Verified end-to-end in a downstream consumer (Ark UI Popover via our own package) by patching `node_modules/@zag-js/popper/dist/get-placement.{js,mjs}` with the same change. `--available-width` correctly reflects the boundary element's width after the patch; popover content wraps inside the column instead of bleeding into adjacent columns.

## Risk

Very low. Behavior is identical for any caller that doesn't set `positioning.boundary`. Callers that do set it now get sized output that matches their already-positioned output (likely what they were trying to achieve in the first place).