### PR TITLE
fix(combobox): handle Enter correctly when item highlighted

### DIFF
--- a/e2e/combobox.e2e.ts
+++ b/e2e/combobox.e2e.ts
@@ -378,6 +378,7 @@ test.describe("combobox / form", () => {
 
   test("[keyboard / no highlight] Enter submits form when no item is highlighted", async () => {
     await I.controls.select("inputBehavior", "none")
+    await I.controls.bool("allowCustomValue", true)
 
     await I.focusInput()
     await I.type("z")

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -241,7 +241,7 @@ export function connect<T extends PropTypes, V extends CollectionItem>(
               // Allow submission when alwaysSubmitOnEnter is true
               const alwaysSubmit = prop("alwaysSubmitOnEnter")
 
-              if (open && !submittable && !alwaysSubmit && hasHighlight) {
+              if (open && !alwaysSubmit && (hasHighlight || !submittable)) {
                 event.preventDefault()
               }
 


### PR DESCRIPTION
## 📝 Description
See below

## ⛳️ Current behavior (updates)

1. use a opening Combobox with `allowCustomValue` with a collection
2. type something
3. select an item with Enter key
4. **default behavior triggered** (but if you select an item by clicking, default behavior won't be triggered)

## 🚀 New behavior

1-3: the same
4. **default behavior won't be triggered**

## 💣 Is this a breaking change (Yes/No):

No

