### PR TITLE
fix: trigger elements in shadow root

### DIFF
--- a/.changeset/clear-queens-lose.md
+++ b/.changeset/clear-queens-lose.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/core": patch
+---
+
+Change return type of Scope.getRootNode() from Node to Element to support querySelector / querySelectorAll.

--- a/.changeset/flat-taxes-clap.md
+++ b/.changeset/flat-taxes-clap.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/dom-query": patch
+---
+
+Accept ShadowRoot as argument for query and queryAll.

--- a/.changeset/pretty-candies-hunt.md
+++ b/.changeset/pretty-candies-hunt.md
@@ -1,0 +1,10 @@
+---
+"@zag-js/hover-card": patch
+"@zag-js/popover": patch
+"@zag-js/tooltip": patch
+"@zag-js/dialog": patch
+"@zag-js/drawer": patch
+"@zag-js/menu": patch
+---
+
+Fix trigger element lookups in shadow root.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,7 +78,7 @@ export interface BindableFn {
 export interface Scope {
   id?: string | undefined
   ids?: Record<string, any> | undefined
-  getRootNode: () => ShadowRoot | Document | Node
+  getRootNode: () => ShadowRoot | Document | Element
   getById: <T extends Element = HTMLElement>(id: string) => T | null
   getActiveElement: () => HTMLElement | null
   isActiveElement: (elem: HTMLElement | null) => boolean

--- a/packages/machines/dialog/src/dialog.dom.ts
+++ b/packages/machines/dialog/src/dialog.dom.ts
@@ -25,7 +25,7 @@ export const getDescriptionEl = (ctx: Scope) => ctx.getById(getDescriptionId(ctx
 export const getCloseTriggerEl = (ctx: Scope) => ctx.getById(getCloseTriggerId(ctx))
 
 export const getTriggerEls = (ctx: Scope) =>
-  queryAll(ctx.getDoc(), `[data-scope="dialog"][data-part="trigger"][data-ownedby="${ctx.id}"]`)
+  queryAll(ctx.getRootNode(), `[data-scope="dialog"][data-part="trigger"][data-ownedby="${ctx.id}"]`)
 
 export const getActiveTriggerEl = (ctx: Scope, value: string | null): HTMLElement | null => {
   return value == null ? getTriggerEls(ctx)[0] : ctx.getById(getTriggerId(ctx, value))

--- a/packages/machines/drawer/src/drawer.dom.ts
+++ b/packages/machines/drawer/src/drawer.dom.ts
@@ -13,7 +13,7 @@ export const getTriggerId = (ctx: Scope, value?: string) => {
 }
 
 export const getTriggerEls = (ctx: Scope): HTMLElement[] =>
-  queryAll<HTMLElement>(ctx.getDoc(), `[data-scope="drawer"][data-part="trigger"][data-ownedby="${ctx.id}"]`)
+  queryAll<HTMLElement>(ctx.getRootNode(), `[data-scope="drawer"][data-part="trigger"][data-ownedby="${ctx.id}"]`)
 
 export const getActiveTriggerEl = (ctx: Scope, value: string | null): HTMLElement | null => {
   if (value == null) return getTriggerEl(ctx) ?? getTriggerEls(ctx)[0]

--- a/packages/machines/hover-card/src/hover-card.dom.ts
+++ b/packages/machines/hover-card/src/hover-card.dom.ts
@@ -16,7 +16,10 @@ export const getContentEl = (scope: Scope) => scope.getById(getContentId(scope))
 export const getPositionerEl = (scope: Scope) => scope.getById(getPositionerId(scope))
 
 export const getTriggerEls = (scope: Scope): HTMLElement[] =>
-  queryAll<HTMLElement>(scope.getDoc(), `[data-scope="hover-card"][data-part="trigger"][data-ownedby="${scope.id}"]`)
+  queryAll<HTMLElement>(
+    scope.getRootNode(),
+    `[data-scope="hover-card"][data-part="trigger"][data-ownedby="${scope.id}"]`,
+  )
 
 export const getActiveTriggerEl = (scope: Scope, value: string | null): HTMLElement | null => {
   return value == null ? getTriggerEls(scope)[0] : scope.getById(getTriggerId(scope, value))

--- a/packages/machines/menu/src/menu.dom.ts
+++ b/packages/machines/menu/src/menu.dom.ts
@@ -33,10 +33,10 @@ export const getArrowEl = (ctx: Scope) => ctx.getById(getArrowId(ctx))
 export const getContextTriggerEl = (ctx: Scope) => ctx.getById(getContextTriggerId(ctx))
 
 export const getTriggerEls = (ctx: Scope): HTMLElement[] =>
-  queryAll<HTMLElement>(ctx.getDoc(), `[data-scope="menu"][data-part="trigger"][data-ownedby="${ctx.id}"]`)
+  queryAll<HTMLElement>(ctx.getRootNode(), `[data-scope="menu"][data-part="trigger"][data-ownedby="${ctx.id}"]`)
 
 export const getContextTriggerEls = (ctx: Scope): HTMLElement[] =>
-  queryAll<HTMLElement>(ctx.getDoc(), `[data-scope="menu"][data-part="context-trigger"][data-ownedby="${ctx.id}"]`)
+  queryAll<HTMLElement>(ctx.getRootNode(), `[data-scope="menu"][data-part="context-trigger"][data-ownedby="${ctx.id}"]`)
 
 export const getActiveTriggerEl = (ctx: Scope, value: string | null): HTMLElement | null => {
   // When value is null, use ID-based lookup (works for submenus with trigger-item)

--- a/packages/machines/popover/src/popover.dom.ts
+++ b/packages/machines/popover/src/popover.dom.ts
@@ -19,7 +19,7 @@ export const getCloseTriggerId = (scope: Scope) => scope.ids?.closeTrigger ?? `p
 export const getAnchorEl = (scope: Scope) => scope.getById(getAnchorId(scope))
 
 export const getTriggerEls = (scope: Scope): HTMLElement[] =>
-  queryAll<HTMLElement>(scope.getDoc(), `[data-scope="popover"][data-part="trigger"][data-ownedby="${scope.id}"]`)
+  queryAll<HTMLElement>(scope.getRootNode(), `[data-scope="popover"][data-part="trigger"][data-ownedby="${scope.id}"]`)
 
 export const getActiveTriggerEl = (scope: Scope, value: string | null): HTMLElement | null => {
   return value == null ? getTriggerEls(scope)[0] : scope.getById(getTriggerId(scope, value))

--- a/packages/machines/tooltip/src/tooltip.dom.ts
+++ b/packages/machines/tooltip/src/tooltip.dom.ts
@@ -23,7 +23,7 @@ export const getPositionerEl = (scope: Scope) => scope.getById(getPositionerId(s
 export const getArrowEl = (scope: Scope) => scope.getById(getArrowId(scope))
 
 export const getTriggerEls = (scope: Scope): HTMLElement[] =>
-  queryAll<HTMLElement>(scope.getDoc(), `[data-scope="tooltip"][data-part="trigger"][data-ownedby="${scope.id}"]`)
+  queryAll<HTMLElement>(scope.getRootNode(), `[data-scope="tooltip"][data-part="trigger"][data-ownedby="${scope.id}"]`)
 
 export const getActiveTriggerEl = (scope: Scope, value: string | null): HTMLElement | null => {
   return value == null ? getTriggerEls(scope)[0] : scope.getById(getTriggerId(scope, value))

--- a/packages/utilities/dom-query/src/query.ts
+++ b/packages/utilities/dom-query/src/query.ts
@@ -1,4 +1,4 @@
-type Root = Document | Element | null | undefined
+type Root = Document | ShadowRoot | Element | null | undefined
 
 export function queryAll<T extends Element = HTMLElement>(root: Root, selector: string) {
   return Array.from(root?.querySelectorAll<T>(selector) ?? [])


### PR DESCRIPTION
Fixes an issue with trigger elements in shadow roots.

## 📝 Description

This PR fixes an issue that was accidentally introduced by #2929.
The functions that lookup the trigger elements use `getDoc().querySelectorAll` instead of `getRootNode().querySelectorAll`, which causes them to return `undefined` / `[]` when the trigger elements are inside a shadow root.

The most obvious problem is broken positioning (e.g. tooltips appear in the top left corner).
But this breaks more subtle features as well.

## ⛳️ Current behavior (updates)

Trigger elements associated with tooltip, popover, etc. are not found correctly.

## 🚀 New behavior

Trigger elements are found using the shadow root as lookup context.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->

In order to fix the current approach I had to change the type signature of `getRootNode()`.

```diff
- getRootNode: () => ShadowRoot | Document | Node
+ getRootNode: () => ShadowRoot | Document | Element
```

It could previously return a `Node` (which does _not_ provide the querySelector[All] methods).
I changed it to `Element`, which is probably the most obvious type to use.
Alternatively, one could use `ParentNode` for a slightly less impactful change.

Note that this type change may also impact ArcUI and Chakra, see https://github.com/chakra-ui/ark/blob/9df02ce6aef50f9bcd86926d602306e84a082667/packages/react/src/providers/environment/use-environment-context.ts#L5 for example. But I would argue that the original `Node` type did not make much sense here.


