### PR TITLE
fix(number-input): avoid clamping empty value on blur

### DIFF
--- a/packages/machines/number-input/src/number-input.machine.ts
+++ b/packages/machines/number-input/src/number-input.machine.ts
@@ -181,7 +181,7 @@ export const machine = createMachine({
         },
         "INPUT.BLUR": [
           {
-            guard: and("clampValueOnBlur", not("isInRange")),
+            guard: and("clampValueOnBlur", not("isValueEmpty"), not("isInRange")),
             target: "idle",
             actions: ["setClampedValue", "clearHint", "invokeOnBlur", "invokeOnValueCommit"],
           },


### PR DESCRIPTION
Related to chakra-ui/chakra-ui#10820

## 📝 Description

This fixes an inconsistent blur behavior in `number-input` when the input is cleared and `min` is greater than `0`.

The original issue was reported in Chakra UI, but the underlying behavior comes from `@zag-js/number-input`.

## 🚛 Current behavior

When the input is cleared, the value becomes empty, but the blur logic can still enter the clamp path because it only checks:

```ts
and("clampValueOnBlur", not("isInRange"))