### PR TITLE
fix: handle custom trigger elements correctly

### DIFF
--- a/packages/machines/dialog/src/dialog.dom.ts
+++ b/packages/machines/dialog/src/dialog.dom.ts
@@ -28,5 +28,8 @@ export const getTriggerEls = (ctx: Scope) =>
   queryAll(ctx.getDoc(), `[data-scope="dialog"][data-part="trigger"][data-ownedby="${ctx.id}"]`)
 
 export const getActiveTriggerEl = (ctx: Scope, value: string | null): HTMLElement | null => {
-  return value == null ? getTriggerEls(ctx)[0] : ctx.getById(getTriggerId(ctx, value))
+  if (value == null) {
+    return getTriggerEl(ctx) ?? getTriggerEls(ctx)[0]
+  }
+  return ctx.getById(getTriggerId(ctx, value))
 }

--- a/packages/machines/dialog/src/dialog.machine.ts
+++ b/packages/machines/dialog/src/dialog.machine.ts
@@ -133,7 +133,7 @@ export const machine = createMachine<DialogSchema>({
           defer: true,
           pointerBlocking: prop("modal"),
           layerStyleTargets: [() => dom.getBackdropEl(scope), () => dom.getPositionerEl(scope)],
-          exclude: dom.getTriggerEls(scope),
+          exclude: [dom.getTriggerEl(scope), ...dom.getTriggerEls(scope)].filter(Boolean) as HTMLElement[],
           onInteractOutside(event) {
             prop("onInteractOutside")?.(event)
             if (!prop("closeOnInteractOutside")) {

--- a/packages/machines/drawer/src/drawer.machine.ts
+++ b/packages/machines/drawer/src/drawer.machine.ts
@@ -689,7 +689,7 @@ export const machine = createMachine<DrawerSchema>({
           defer: true,
           pointerBlocking: prop("modal"),
           layerStyleTargets: [() => dom.getBackdropEl(scope), () => dom.getPositionerEl(scope)],
-          exclude: [dom.getTriggerEl(scope)],
+          exclude: [dom.getTriggerEl(scope), ...dom.getTriggerEls(scope)].filter(Boolean) as HTMLElement[],
           onInteractOutside(event) {
             prop("onInteractOutside")?.(event)
             if (!prop("closeOnInteractOutside")) {

--- a/packages/machines/hover-card/src/hover-card.dom.ts
+++ b/packages/machines/hover-card/src/hover-card.dom.ts
@@ -19,5 +19,8 @@ export const getTriggerEls = (scope: Scope): HTMLElement[] =>
   queryAll<HTMLElement>(scope.getDoc(), `[data-scope="hover-card"][data-part="trigger"][data-ownedby="${scope.id}"]`)
 
 export const getActiveTriggerEl = (scope: Scope, value: string | null): HTMLElement | null => {
-  return value == null ? getTriggerEls(scope)[0] : scope.getById(getTriggerId(scope, value))
+  if (value == null) {
+    return getTriggerEl(scope) ?? getTriggerEls(scope)[0]
+  }
+  return scope.getById(getTriggerId(scope, value))
 }

--- a/packages/machines/hover-card/src/hover-card.machine.ts
+++ b/packages/machines/hover-card/src/hover-card.machine.ts
@@ -271,7 +271,7 @@ export const machine = createMachine<HoverCardSchema>({
         return trackDismissableElement(getContentEl, {
           type: "popover",
           defer: true,
-          exclude: dom.getTriggerEls(scope),
+          exclude: [dom.getTriggerEl(scope), ...dom.getTriggerEls(scope)].filter(Boolean) as HTMLElement[],
           onDismiss() {
             send({ type: "CLOSE", src: "interact-outside" })
           },

--- a/packages/machines/popover/src/popover.dom.ts
+++ b/packages/machines/popover/src/popover.dom.ts
@@ -18,11 +18,16 @@ export const getCloseTriggerId = (scope: Scope) => scope.ids?.closeTrigger ?? `p
 
 export const getAnchorEl = (scope: Scope) => scope.getById(getAnchorId(scope))
 
+export const getTriggerEl = (scope: Scope) => scope.getById(getTriggerId(scope))
+
 export const getTriggerEls = (scope: Scope): HTMLElement[] =>
   queryAll<HTMLElement>(scope.getDoc(), `[data-scope="popover"][data-part="trigger"][data-ownedby="${scope.id}"]`)
 
 export const getActiveTriggerEl = (scope: Scope, value: string | null): HTMLElement | null => {
-  return value == null ? getTriggerEls(scope)[0] : scope.getById(getTriggerId(scope, value))
+  if (value == null) {
+    return getTriggerEl(scope) ?? getTriggerEls(scope)[0]
+  }
+  return scope.getById(getTriggerId(scope, value))
 }
 export const getContentEl = (scope: Scope) => scope.getById(getContentId(scope))
 export const getPositionerEl = (scope: Scope) => scope.getById(getPositionerId(scope))

--- a/packages/machines/popover/src/popover.machine.ts
+++ b/packages/machines/popover/src/popover.machine.ts
@@ -169,7 +169,7 @@ export const machine = createMachine<PopoverSchema>({
         return trackDismissableElement(getContentEl, {
           type: "popover",
           pointerBlocking: prop("modal"),
-          exclude: dom.getTriggerEls(scope),
+          exclude: [dom.getTriggerEl(scope), ...dom.getTriggerEls(scope)].filter(Boolean) as HTMLElement[],
           defer: true,
           onEscapeKeyDown(event) {
             prop("onEscapeKeyDown")?.(event)

--- a/packages/machines/tooltip/src/tooltip.dom.ts
+++ b/packages/machines/tooltip/src/tooltip.dom.ts
@@ -26,5 +26,8 @@ export const getTriggerEls = (scope: Scope): HTMLElement[] =>
   queryAll<HTMLElement>(scope.getDoc(), `[data-scope="tooltip"][data-part="trigger"][data-ownedby="${scope.id}"]`)
 
 export const getActiveTriggerEl = (scope: Scope, value: string | null): HTMLElement | null => {
-  return value == null ? getTriggerEls(scope)[0] : scope.getById(getTriggerId(scope, value))
+  if (value == null) {
+    return getTriggerEl(scope) ?? getTriggerEls(scope)[0]
+  }
+  return scope.getById(getTriggerId(scope, value))
 }


### PR DESCRIPTION
Trigger elements are currently not handled correctly when the `triggerId` is explicitly defined.

This is currently necessary for dom elements that are, for example, both a tooltip trigger and a menu trigger (see [Docs](https://chakra-ui.com/docs/components/tooltip#with-menutrigger) for Chakra).

Note that _menus_ work fine at this time, but the same approach for Popover + Tooltip (and probably other combinations) does not:

```tsx
 <Popover.Root ids={{ trigger: triggerId }}>
   <Tooltip ids={{ trigger: triggerId }} content={...}>
     <Popover.Trigger asChild>
        ...
```

This pattern worked with previous versions of zag-js, but it is currently broken.

## 📝 Description

Custom trigger elements are currently not handled well with respect to "interact outside" behavior and positioning.


## ⛳️ Current behavior (updates)

- A click on the trigger counts as "outside", so clicking the trigger closes and immediately reopens a popover.
- The trigger is not used for positioning, because `getActiveTriggerEl` no longer returns it. `getTriggerEls` will not return the actual trigger because, in this example, the tooltip "wins" and overrides the popover attributes. This makes popovers be positioned at the top left corner of the screen.

## 🚀 New behavior

- Clicks on the explicit trigger are excluded from outside click detection
- The popover is correctly positioned at the explicit trigger element


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The changes to the popover package have been verified manually.
I've used Claude and [this prior commit](https://github.com/chakra-ui/zag/commit/4ff1736) as a reference to update the other components as well. I _believe_ that they may be affected too. But I'm not sure!