### PR TITLE
fix: add placement side data attributes

### DIFF
--- a/.changeset/select-trigger-data-side.md
+++ b/.changeset/select-trigger-data-side.md
@@ -1,5 +1,14 @@
 ---
+"@zag-js/cascade-select": patch
+"@zag-js/color-picker": patch
+"@zag-js/combobox": patch
+"@zag-js/date-picker": patch
+"@zag-js/hover-card": patch
+"@zag-js/menu": patch
+"@zag-js/popover": patch
 "@zag-js/select": patch
+"@zag-js/tooltip": patch
+"@zag-js/tour": patch
 ---
 
-Add `data-side` to the select trigger based on the current placement.
+Add `data-side` to placement-aware parts based on the current placement.

--- a/.changeset/select-trigger-data-side.md
+++ b/.changeset/select-trigger-data-side.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/select": patch
+---
+
+Add `data-side` to the select trigger based on the current placement.

--- a/packages/machines/cascade-select/src/cascade-select.connect.ts
+++ b/packages/machines/cascade-select/src/cascade-select.connect.ts
@@ -1,5 +1,5 @@
 import { ariaAttr, dataAttr, getEventKey, isEditableElement, isSelfTarget, isValidTabEvent } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { EventKeyMap, NormalizeProps, PropTypes } from "@zag-js/types"
 import type { Service } from "@zag-js/core"
 import { isEqual } from "@zag-js/utils"
@@ -20,6 +20,7 @@ export function connect<T extends PropTypes, V = TreeNode>(
   const highlightedIndexPath = context.get("highlightedIndexPath")
   const highlightedValue = context.get("highlightedValue")
   const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
   const disabled = prop("disabled") || context.get("fieldsetDisabled")
   const interactive = computed("isInteractive")
   const valueAsString = computed("valueAsString")
@@ -170,6 +171,7 @@ export function connect<T extends PropTypes, V = TreeNode>(
         "data-invalid": dataAttr(prop("invalid")),
         "data-focus": dataAttr(focused),
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         "data-placeholder-shown": dataAttr(!hasSelectedItems),
         disabled,
         onClick(event) {

--- a/packages/machines/color-picker/src/color-picker.connect.ts
+++ b/packages/machines/color-picker/src/color-picker.connect.ts
@@ -1,7 +1,7 @@
 import { getColorAreaGradient, normalizeColor } from "@zag-js/color-utils"
 import { getEventKey, getEventPoint, getEventStep, isLeftClick, isModifierKey } from "@zag-js/dom-query"
 import { dataAttr, query, visuallyHiddenStyle } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { NormalizeProps, PropTypes, EventKeyMap } from "@zag-js/types"
 import { parts } from "./color-picker.anatomy"
 import * as dom from "./color-picker.dom"
@@ -48,6 +48,7 @@ export function connect<T extends PropTypes>(
   }
 
   const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
   const popperStyles = getPlacementStyles({
     ...prop("positioning"),
     placement: currentPlacement,
@@ -159,6 +160,7 @@ export function connect<T extends PropTypes>(
         "data-readonly": dataAttr(readOnly),
         "data-invalid": dataAttr(invalid),
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         "aria-expanded": open,
         "data-state": open ? "open" : "closed",
         "data-focus": dataAttr(focused),
@@ -194,6 +196,7 @@ export function connect<T extends PropTypes>(
         role: prop("inline") ? undefined : "dialog",
         tabIndex: -1,
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         "data-state": open ? "open" : "closed",
         hidden: !open,
       })

--- a/packages/machines/combobox/src/combobox.connect.ts
+++ b/packages/machines/combobox/src/combobox.connect.ts
@@ -9,7 +9,7 @@ import {
   isLeftClick,
   isOpeningInNewTab,
 } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { EventKeyMap, NormalizeProps, PropTypes } from "@zag-js/types"
 import { ensure } from "@zag-js/utils"
 import { parts } from "./combobox.anatomy"
@@ -35,10 +35,12 @@ export function connect<T extends PropTypes, V extends CollectionItem>(
   const focused = state.hasTag("focused")
   const composite = prop("composite")
   const highlightedValue = context.get("highlightedValue")
+  const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
 
   const popperStyles = getPlacementStyles({
     ...prop("positioning"),
-    placement: context.get("currentPlacement"),
+    placement: currentPlacement,
   })
 
   function getItemState(props: ItemProps): ItemState {
@@ -334,7 +336,8 @@ export function connect<T extends PropTypes, V extends CollectionItem>(
         tabIndex: -1,
         hidden: !open,
         "data-state": open ? "open" : "closed",
-        "data-placement": context.get("currentPlacement"),
+        "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         "aria-labelledby": dom.getLabelId(scope),
         "aria-multiselectable": prop("multiple") && composite ? true : undefined,
         "data-empty": dataAttr(collection.size === 0),

--- a/packages/machines/date-picker/src/date-picker.connect.ts
+++ b/packages/machines/date-picker/src/date-picker.connect.ts
@@ -31,7 +31,7 @@ import {
   isValidCharacter,
 } from "@zag-js/date-utils"
 import { ariaAttr, dataAttr, getEventKey, getNativeEvent, isComposingEvent } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { EventKeyMap, NormalizeProps, PropTypes } from "@zag-js/types"
 import { chunk, isValueWithinRange } from "@zag-js/utils"
 import { parts } from "./date-picker.anatomy"
@@ -91,6 +91,7 @@ export function connect<T extends PropTypes>(
   const isMaxSelected = isMultiPicker && maxSelectedDates != null && selectedValue.length >= maxSelectedDates
 
   const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
   const popperStyles = getPlacementStyles({
     ...prop("positioning"),
     placement: currentPlacement,
@@ -458,6 +459,7 @@ export function connect<T extends PropTypes>(
         dir: prop("dir"),
         "data-state": open ? "open" : "closed",
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         "data-inline": dataAttr(prop("inline")),
         id: dom.getContentId(scope),
         tabIndex: -1,
@@ -856,6 +858,7 @@ export function connect<T extends PropTypes>(
         dir: prop("dir"),
         type: "button",
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         "aria-label": translations.trigger(open),
         "aria-controls": dom.getContentId(scope),
         "aria-expanded": open,

--- a/packages/machines/hover-card/src/hover-card.connect.ts
+++ b/packages/machines/hover-card/src/hover-card.connect.ts
@@ -1,5 +1,5 @@
 import { dataAttr } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { parts } from "./hover-card.anatomy"
 import * as dom from "./hover-card.dom"
@@ -10,10 +10,12 @@ export function connect<T extends PropTypes>(service: HoverCardService, normaliz
 
   const open = state.hasTag("open")
   const triggerValue = context.get("triggerValue")
+  const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
 
   const popperStyles = getPlacementStyles({
     ...prop("positioning"),
-    placement: context.get("currentPlacement"),
+    placement: currentPlacement,
   })
 
   return {
@@ -56,7 +58,8 @@ export function connect<T extends PropTypes>(service: HoverCardService, normaliz
       return normalize.element({
         ...parts.trigger.attrs,
         dir: prop("dir"),
-        "data-placement": context.get("currentPlacement"),
+        "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         id: dom.getTriggerId(scope, value),
         "data-ownedby": scope.id,
         "data-value": value,
@@ -109,7 +112,8 @@ export function connect<T extends PropTypes>(service: HoverCardService, normaliz
         hidden: !open,
         tabIndex: -1,
         "data-state": open ? "open" : "closed",
-        "data-placement": context.get("currentPlacement"),
+        "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         onPointerEnter(event) {
           if (event.pointerType === "touch") return
           if (prop("disabled")) return

--- a/packages/machines/menu/src/menu.connect.ts
+++ b/packages/machines/menu/src/menu.connect.ts
@@ -15,7 +15,7 @@ import {
   contains,
   isValidTabEvent,
 } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { EventKeyMap, NormalizeProps, PropTypes } from "@zag-js/types"
 import { cast, hasProp } from "@zag-js/utils"
 import { parts } from "./menu.anatomy"
@@ -41,6 +41,7 @@ export function connect<T extends PropTypes>(service: Service<MenuSchema>, norma
   const composite = prop("composite")
 
   const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
   const anchorPoint = context.get("anchorPoint")
   const highlightedValue = context.get("highlightedValue")
   const triggerValue = context.get("triggerValue")
@@ -213,7 +214,8 @@ export function connect<T extends PropTypes>(service: Service<MenuSchema>, norma
       const triggerId = dom.getTriggerId(scope, value)
       return normalize.button({
         ...(isSubmenu ? parts.triggerItem.attrs : parts.trigger.attrs),
-        "data-placement": context.get("currentPlacement"),
+        "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         type: "button",
         dir: prop("dir"),
         id: triggerId,
@@ -351,6 +353,7 @@ export function connect<T extends PropTypes>(service: Service<MenuSchema>, norma
           ? dom.getContextTriggerId(scope, triggerValue ?? undefined)
           : dom.getTriggerId(scope, triggerValue ?? undefined),
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         onPointerEnter(event) {
           if (event.pointerType !== "mouse") return
           send({ type: "MENU_POINTERENTER" })

--- a/packages/machines/popover/src/popover.connect.ts
+++ b/packages/machines/popover/src/popover.connect.ts
@@ -1,5 +1,5 @@
 import { ariaAttr, dataAttr, isLeftClick, isSafari } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { parts } from "./popover.anatomy"
 import * as dom from "./popover.dom"
@@ -11,6 +11,7 @@ export function connect<T extends PropTypes>(service: PopoverService, normalize:
   const open = state.matches("open")
 
   const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
   const portalled = computed("currentPortalled")
   const rendered = context.get("renderedElements")
   const triggerValue = context.get("triggerValue")
@@ -70,6 +71,7 @@ export function connect<T extends PropTypes>(service: PopoverService, normalize:
         dir: prop("dir"),
         type: "button",
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         id: dom.getTriggerId(scope, value),
         "data-ownedby": scope.id,
         "data-value": value,
@@ -126,6 +128,7 @@ export function connect<T extends PropTypes>(service: PopoverService, normalize:
         "aria-labelledby": rendered.title ? dom.getTitleId(scope) : undefined,
         "aria-describedby": rendered.description ? dom.getDescriptionId(scope) : undefined,
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
       })
     },
 

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -411,6 +411,7 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
         ...parts.content.attrs,
         "data-state": open ? "open" : "closed",
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         "data-activedescendant": ariaActiveDescendant,
         "aria-activedescendant": composite ? ariaActiveDescendant : undefined,
         "aria-multiselectable": prop("multiple") && composite ? true : undefined,

--- a/packages/machines/select/src/select.connect.ts
+++ b/packages/machines/select/src/select.connect.ts
@@ -12,7 +12,7 @@ import {
   isValidTabEvent,
   visuallyHiddenStyle,
 } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { EventKeyMap, NormalizeProps, PropTypes } from "@zag-js/types"
 import { ensure } from "@zag-js/utils"
 import { parts } from "./select.anatomy"
@@ -40,6 +40,7 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
   const highlightedItem = context.get("highlightedItem")
   const selectedItems = computed("selectedItems")
   const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
 
   const isTypingAhead = computed("isTypingAhead")
   const interactive = computed("isInteractive")
@@ -181,6 +182,7 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
         "data-invalid": dataAttr(invalid),
         "data-readonly": dataAttr(readOnly),
         "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         "data-placeholder-shown": dataAttr(!computed("hasSelectedItems")),
         onClick(event) {
           if (!interactive) return

--- a/packages/machines/tooltip/src/tooltip.connect.ts
+++ b/packages/machines/tooltip/src/tooltip.connect.ts
@@ -1,7 +1,7 @@
 import type { Service } from "@zag-js/core"
 import { dataAttr, isLeftClick } from "@zag-js/dom-query"
 import { isFocusVisible } from "@zag-js/focus-visible"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { parts } from "./tooltip.anatomy"
 import * as dom from "./tooltip.dom"
@@ -18,6 +18,8 @@ export function connect<P extends PropTypes>(
 
   const open = state.matches("open", "closing")
   const triggerValue = context.get("triggerValue")
+  const currentPlacement = context.get("currentPlacement")
+  const currentPlacementSide = currentPlacement ? getPlacementSide(currentPlacement) : undefined
 
   const contentId = dom.getContentId(scope)
 
@@ -25,7 +27,7 @@ export function connect<P extends PropTypes>(
 
   const popperStyles = getPlacementStyles({
     ...prop("positioning"),
-    placement: context.get("currentPlacement"),
+    placement: currentPlacement,
   })
 
   return {
@@ -157,7 +159,8 @@ export function connect<P extends PropTypes>(
         "data-instant": dataAttr(instant),
         role: hasAriaLabel ? undefined : "tooltip",
         id: hasAriaLabel ? undefined : contentId,
-        "data-placement": context.get("currentPlacement"),
+        "data-placement": currentPlacement,
+        "data-side": currentPlacementSide,
         onPointerEnter() {
           send({ type: "content.pointer.move" })
         },

--- a/packages/machines/tour/src/tour.connect.ts
+++ b/packages/machines/tour/src/tour.connect.ts
@@ -1,6 +1,6 @@
 import { mergeProps } from "@zag-js/core"
 import { dataAttr } from "@zag-js/dom-query"
-import { getPlacementStyles } from "@zag-js/popper"
+import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { toPx } from "@zag-js/utils"
 import { parts } from "./tour.anatomy"
@@ -25,6 +25,7 @@ export function connect<T extends PropTypes>(service: TourService, normalize: No
   const lastStep = computed("isLastStep")
 
   const placement = context.get("currentPlacement")
+  const placementSide = isTooltipPlacement(placement) ? getPlacementSide(placement) : undefined
   const targetRect = context.get("targetRect")
 
   const popperStyles = getPlacementStyles({
@@ -159,6 +160,7 @@ export function connect<T extends PropTypes>(service: TourService, normalize: No
         id: dom.getPositionerId(scope),
         "data-type": step?.type,
         "data-placement": placement,
+        "data-side": placementSide,
         style: {
           "--tour-layer": 2,
           ...(step?.type === "tooltip" && popperStyles.floating),
@@ -198,6 +200,7 @@ export function connect<T extends PropTypes>(service: TourService, normalize: No
         "data-state": open ? "open" : "closed",
         "data-type": step?.type,
         "data-placement": placement,
+        "data-side": placementSide,
         "data-step": step?.id,
         "aria-labelledby": dom.getTitleId(scope),
         "aria-describedby": dom.getDescriptionId(scope),
@@ -227,6 +230,7 @@ export function connect<T extends PropTypes>(service: TourService, normalize: No
         ...parts.title.attrs,
         id: dom.getTitleId(scope),
         "data-placement": hasTarget ? placement : "center",
+        "data-side": hasTarget ? placementSide : undefined,
       })
     },
 
@@ -235,6 +239,7 @@ export function connect<T extends PropTypes>(service: TourService, normalize: No
         ...parts.description.attrs,
         id: dom.getDescriptionId(scope),
         "data-placement": hasTarget ? placement : "center",
+        "data-side": hasTarget ? placementSide : undefined,
       })
     },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## 📝 Description

Add placement side data attributes to placement-aware machine parts.

## ⛳️ Current behavior (updates)

Several components expose the full current placement through `data-placement`, but do not expose the placement side separately.

## 🚀 New behavior

Placement-aware parts now include `data-side` derived from the current placement, keeping the side value in sync with flipped placements. Tour omits `data-side` for centered steps.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Includes patch changesets for the affected packages.

Validated with:

- `pnpm --filter @zag-js/cascade-select --filter @zag-js/color-picker --filter @zag-js/combobox --filter @zag-js/date-picker --filter @zag-js/hover-card --filter @zag-js/menu --filter @zag-js/popover --filter @zag-js/select --filter @zag-js/tooltip --filter @zag-js/tour typecheck`
- `pnpm --filter @zag-js/cascade-select --filter @zag-js/color-picker --filter @zag-js/combobox --filter @zag-js/date-picker --filter @zag-js/hover-card --filter @zag-js/menu --filter @zag-js/popover --filter @zag-js/select --filter @zag-js/tooltip --filter @zag-js/tour lint`
- `pnpm --filter @zag-js/cascade-select --filter @zag-js/color-picker --filter @zag-js/combobox --filter @zag-js/date-picker --filter @zag-js/hover-card --filter @zag-js/menu --filter @zag-js/popover --filter @zag-js/select --filter @zag-js/tooltip --filter @zag-js/tour build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abbb54be-bec4-43dd-8ff2-f7a164960f38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abbb54be-bec4-43dd-8ff2-f7a164960f38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

