### PR TITLE
fix: stop handled escape propagation

### DIFF
--- a/.changeset/quiet-pandas-escape.md
+++ b/.changeset/quiet-pandas-escape.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/dismissable": patch
+"@zag-js/floating-panel": patch
+---
+
+Prevent handled `Escape` key events from bubbling beyond dismissable layers and floating panels.

--- a/packages/machines/floating-panel/src/floating-panel.connect.ts
+++ b/packages/machines/floating-panel/src/floating-panel.connect.ts
@@ -121,7 +121,11 @@ export function connect<T extends PropTypes>(
         onKeyDown(event) {
           if (event.defaultPrevented) return
 
-          if (event.key === "Escape" && isTopmost) {
+          const isEscapeHandled = prop("closeOnEscape") || dragging || resizing
+
+          if (event.key === "Escape" && isTopmost && isEscapeHandled) {
+            event.preventDefault()
+            event.stopPropagation()
             send({ type: "ESCAPE" })
             return
           }

--- a/packages/machines/floating-panel/tests/floating-panel.connect.test.ts
+++ b/packages/machines/floating-panel/tests/floating-panel.connect.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { describe, expect, test, vi } from "vitest"
+import { connect } from "../src/floating-panel.connect"
+
+function setup(options: { closeOnEscape?: boolean; dragging?: boolean; resizing?: boolean; isTopmost?: boolean } = {}) {
+  const { closeOnEscape = true, dragging = false, resizing = false, isTopmost = true } = options
+  const send = vi.fn()
+  const api = connect(
+    {
+      state: {
+        hasTag: (tag: string) => tag === "open",
+        matches: (value: string) => {
+          if (value === "open.dragging") return dragging
+          if (value === "open.resizing") return resizing
+          return false
+        },
+      },
+      send,
+      scope: {},
+      prop: (key: string) => {
+        if (key === "closeOnEscape") return closeOnEscape
+        if (key === "gridSize") return 1
+        return undefined
+      },
+      computed: () => false,
+      context: {
+        get: (key: string) => {
+          if (key === "isTopmost") return isTopmost
+          if (key === "size") return { width: 100, height: 100 }
+          if (key === "position") return { x: 0, y: 0 }
+          return undefined
+        },
+      },
+    } as any,
+    {
+      button: (props: any) => props,
+      element: (props: any) => props,
+    } as any,
+  )
+
+  return { send, contentProps: api.getContentProps() as any }
+}
+
+describe("floating-panel connect", () => {
+  test("stops Escape propagation when closing the topmost panel", () => {
+    const { send, contentProps } = setup({ closeOnEscape: true })
+    const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+    const stopPropagation = vi.spyOn(event, "stopPropagation")
+
+    contentProps.onKeyDown(event)
+
+    expect(send).toHaveBeenCalledWith({ type: "ESCAPE" })
+    expect(event.defaultPrevented).toBe(true)
+    expect(stopPropagation).toHaveBeenCalledTimes(1)
+  })
+
+  test("stops Escape propagation when restoring a drag or resize", () => {
+    const { send, contentProps } = setup({ closeOnEscape: false, dragging: true })
+    const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+    const stopPropagation = vi.spyOn(event, "stopPropagation")
+
+    contentProps.onKeyDown(event)
+
+    expect(send).toHaveBeenCalledWith({ type: "ESCAPE" })
+    expect(event.defaultPrevented).toBe(true)
+    expect(stopPropagation).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not consume Escape when the idle panel will not close", () => {
+    const { send, contentProps } = setup({ closeOnEscape: false })
+    const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+    const stopPropagation = vi.spyOn(event, "stopPropagation")
+
+    contentProps.onKeyDown(event)
+
+    expect(send).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+    expect(stopPropagation).not.toHaveBeenCalled()
+  })
+})

--- a/packages/utilities/dismissable/src/dismissable-layer.ts
+++ b/packages/utilities/dismissable/src/dismissable-layer.ts
@@ -6,7 +6,7 @@ import {
   type PointerDownOutsideEvent,
 } from "@zag-js/interact-outside"
 import { isFunction, warn, type MaybeFunction } from "@zag-js/utils"
-import { trackEscapeKeydown } from "./escape-keydown"
+import { markEscapeKeydownHandled, trackEscapeKeydown } from "./escape-keydown"
 import { layerStack, type Layer, type LayerDismissEvent, type LayerStyleTarget, type LayerType } from "./layer-stack"
 import { assignPointerEventToLayers, clearPointerEvent, disablePointerEventsOutside } from "./pointer-event-outside"
 
@@ -132,8 +132,13 @@ function trackDismissableElementImpl(node: MaybeElement, options: DismissableEle
   function onEscapeKeyDown(event: KeyboardEvent) {
     if (!layerStack.isTopMost(node!)) return
     options.onEscapeKeyDown?.(event)
+    if (event.defaultPrevented) {
+      markEscapeKeydownHandled(event)
+      return
+    }
     if (!event.defaultPrevented && onDismiss) {
       event.preventDefault()
+      markEscapeKeydownHandled(event)
       onDismiss()
     }
   }

--- a/packages/utilities/dismissable/src/escape-keydown.ts
+++ b/packages/utilities/dismissable/src/escape-keydown.ts
@@ -1,11 +1,55 @@
 import { addDomEvent, getDocument } from "@zag-js/dom-query"
 
+const handledEvents = new WeakSet<KeyboardEvent>()
+const listeners = new WeakMap<Document, { count: number; cleanup: VoidFunction }>()
+
+function trackHandledEscapeKeydown(doc: Document) {
+  const listener = listeners.get(doc)
+  if (listener) {
+    listener.count++
+    return
+  }
+
+  const cleanup = addDomEvent(doc, "keydown", (event) => {
+    if (event.key !== "Escape") return
+    if (!handledEvents.has(event)) return
+    event.stopPropagation()
+  })
+
+  listeners.set(doc, { count: 1, cleanup })
+}
+
+function releaseHandledEscapeKeydown(doc: Document) {
+  const listener = listeners.get(doc)
+  if (!listener) return
+
+  listener.count--
+
+  queueMicrotask(() => {
+    if (listener.count > 0) return
+    listener.cleanup()
+    listeners.delete(doc)
+  })
+}
+
+export function markEscapeKeydownHandled(event: KeyboardEvent) {
+  handledEvents.add(event)
+}
+
 export function trackEscapeKeydown(node: HTMLElement, fn?: (event: KeyboardEvent) => void) {
+  const doc = getDocument(node)
+  trackHandledEscapeKeydown(doc)
+
   const handleKeyDown = (event: KeyboardEvent) => {
     if (event.key !== "Escape") return
     if (event.isComposing) return
     fn?.(event)
   }
 
-  return addDomEvent(getDocument(node), "keydown", handleKeyDown, { capture: true })
+  const cleanup = addDomEvent(doc, "keydown", handleKeyDown, { capture: true })
+
+  return () => {
+    cleanup()
+    releaseHandledEscapeKeydown(doc)
+  }
 }

--- a/packages/utilities/dismissable/tests/dismissable-layer.test.ts
+++ b/packages/utilities/dismissable/tests/dismissable-layer.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { trackDismissableElement } from "../src"
+import { layerStack } from "../src/layer-stack"
+
+function nextTick() {
+  return new Promise<void>((resolve) => queueMicrotask(resolve))
+}
+
+function resetStack() {
+  while (layerStack.count() > 0) {
+    const first = layerStack.layers[0]
+    if (first) layerStack.remove(first.node)
+  }
+}
+
+describe("trackDismissableElement", () => {
+  afterEach(async () => {
+    resetStack()
+    document.body.innerHTML = ""
+    await nextTick()
+  })
+
+  test("stops handled Escape events from reaching the window after dismissing", () => {
+    const layer = document.createElement("div")
+    const input = document.createElement("input")
+    layer.append(input)
+    document.body.append(layer)
+
+    const onInputKeyDown = vi.fn()
+    const onWindowKeyDown = vi.fn()
+
+    input.addEventListener("keydown", onInputKeyDown)
+    window.addEventListener("keydown", onWindowKeyDown)
+
+    let cleanup: VoidFunction | undefined
+    const onDismiss = vi.fn(() => cleanup?.())
+
+    cleanup = trackDismissableElement(layer, { onDismiss })
+
+    const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+    input.dispatchEvent(event)
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    expect(onInputKeyDown).toHaveBeenCalledTimes(1)
+    expect(onWindowKeyDown).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
+
+    window.removeEventListener("keydown", onWindowKeyDown)
+  })
+
+  test("stops prevented Escape events without dismissing", () => {
+    const layer = document.createElement("div")
+    const input = document.createElement("input")
+    layer.append(input)
+    document.body.append(layer)
+
+    const onInputKeyDown = vi.fn()
+    const onWindowKeyDown = vi.fn()
+    const onDismiss = vi.fn()
+
+    input.addEventListener("keydown", onInputKeyDown)
+    window.addEventListener("keydown", onWindowKeyDown)
+
+    const cleanup = trackDismissableElement(layer, {
+      onEscapeKeyDown: (event) => event.preventDefault(),
+      onDismiss,
+    })
+
+    const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+    input.dispatchEvent(event)
+
+    expect(onDismiss).not.toHaveBeenCalled()
+    expect(onInputKeyDown).toHaveBeenCalledTimes(1)
+    expect(onWindowKeyDown).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
+
+    cleanup?.()
+    window.removeEventListener("keydown", onWindowKeyDown)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## 📝 Description

Stop handled `Escape` keydown events from bubbling beyond dismissable layers and floating panels.

## ⛳️ Current behavior (updates)

Dismissable popups and floating panels could close or restore on `Escape` while allowing the key event to continue bubbling beyond the app.

## 🚀 New behavior

Handled `Escape` events are prevented and propagation is stopped after popup content handlers run, reducing browser-level side effects while preserving child key handlers.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Added focused unit coverage for dismissable layer and floating panel Escape handling.

Verification:
- `pnpm exec vitest packages/utilities/dismissable/tests/dismissable-layer.test.ts packages/utilities/dismissable/tests/layer-stack.test.ts packages/machines/floating-panel/tests/floating-panel.connect.test.ts --run`
- `pnpm --filter @zag-js/floating-panel typecheck`
- `pnpm exec eslint packages/utilities/dismissable/src/escape-keydown.ts packages/utilities/dismissable/src/dismissable-layer.ts packages/utilities/dismissable/tests/dismissable-layer.test.ts packages/machines/floating-panel/src/floating-panel.connect.ts packages/machines/floating-panel/tests/floating-panel.connect.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-005919af-beda-44cf-9e16-04fcdf9a2c4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-005919af-beda-44cf-9e16-04fcdf9a2c4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

