### PR TITLE
fix: correct pin input filled state

### DIFF
--- a/.changeset/gentle-pins-float.md
+++ b/.changeset/gentle-pins-float.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/pin-input": patch
+---
+
+Fix initial `data-filled` state for empty pin input fields.

--- a/e2e/pin-input.e2e.ts
+++ b/e2e/pin-input.e2e.ts
@@ -9,6 +9,12 @@ test.describe("pin input", () => {
     await I.goto()
   })
 
+  test("data-filled: should not be set on empty inputs on first render", async () => {
+    await I.dontSeeInputHasAttribute(1, "data-filled")
+    await I.dontSeeInputHasAttribute(2, "data-filled")
+    await I.dontSeeInputHasAttribute(3, "data-filled")
+  })
+
   test("on type: should move focus to the next input", async () => {
     await I.fillInput(1, "1")
     await I.seeInputIsFocused(2)
@@ -404,6 +410,12 @@ test.describe("pin input / controlled", () => {
   test.beforeEach(async ({ page }) => {
     I = new PinInputModel(page)
     await I.goto("/pin-input/controlled")
+  })
+
+  test("data-filled: should not be set on empty inputs on first render", async () => {
+    await I.dontSeeInputHasAttribute(1, "data-filled")
+    await I.dontSeeInputHasAttribute(2, "data-filled")
+    await I.dontSeeInputHasAttribute(3, "data-filled")
   })
 
   test("should update inputs when value is set externally", async () => {

--- a/packages/machines/pin-input/src/pin-input.connect.ts
+++ b/packages/machines/pin-input/src/pin-input.connect.ts
@@ -113,6 +113,7 @@ export function connect<T extends PropTypes>(
     getInputProps(props) {
       const { index } = props
       const inputType = prop("type") === "numeric" ? "tel" : "text"
+      const value = computed("_value")
       const valueLength = computed("valueLength")
       const tabbableIndex =
         focusedIndex !== -1 ? focusedIndex : Math.min(computed("filledValueLength"), valueLength - 1)
@@ -123,7 +124,7 @@ export function connect<T extends PropTypes>(
         tabIndex: index === tabbableIndex ? 0 : -1,
         "data-disabled": dataAttr(disabled),
         "data-complete": dataAttr(complete),
-        "data-filled": dataAttr(context.get("value")[index] !== ""),
+        "data-filled": dataAttr(value[index] !== ""),
         id: dom.getInputId(scope, index.toString()),
         "data-index": index,
         "data-ownedby": dom.getRootId(scope),
@@ -133,7 +134,7 @@ export function connect<T extends PropTypes>(
         "data-invalid": dataAttr(invalid),
         enterKeyHint: index === valueLength - 1 ? "done" : "next",
         type: prop("mask") ? "password" : inputType,
-        defaultValue: context.get("value")[index] || "",
+        defaultValue: value[index] || "",
         readOnly,
         autoCapitalize: "none",
         autoComplete: prop("otp") ? "one-time-code" : "off",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3156

## 📝 Description

Fix pin input slots incorrectly receiving `data-filled` on the first render when their value has not been initialized yet.

## ⛳️ Current behavior (updates)

Empty pin input slots could read from the raw value array before it was normalized, so `undefined !== ""` marked every slot as filled on initial render.

## 🚀 New behavior

Input props use the normalized computed value for both `data-filled` and the initial input value, so only slots with actual values receive `data-filled`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Added Playwright coverage for uncontrolled and controlled initial empty states.

## ✅ Tests

- `pnpm build`
- `pnpm e2e-react e2e/pin-input.e2e.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-176e601c-3b17-4148-bed2-98fe0cef8500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-176e601c-3b17-4148-bed2-98fe0cef8500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

