### PR TITLE
fix(signature-pad): forward dir prop to visible parts

### DIFF
--- a/.changeset/signature-pad-dir.md
+++ b/.changeset/signature-pad-dir.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/signature-pad": patch
+---
+
+Forward the `dir` prop to visible signature pad parts.

--- a/packages/machines/signature-pad/src/signature-pad.connect.ts
+++ b/packages/machines/signature-pad/src/signature-pad.connect.ts
@@ -35,6 +35,7 @@ export function connect<T extends PropTypes>(
     getLabelProps() {
       return normalize.label({
         ...parts.label.attrs,
+        dir: prop("dir"),
         id: dom.getLabelId(scope),
         "data-disabled": dataAttr(disabled),
         "data-required": dataAttr(required),
@@ -51,6 +52,7 @@ export function connect<T extends PropTypes>(
     getRootProps() {
       return normalize.element({
         ...parts.root.attrs,
+        dir: prop("dir"),
         "data-disabled": dataAttr(disabled),
         id: dom.getRootId(scope),
       })
@@ -59,6 +61,7 @@ export function connect<T extends PropTypes>(
     getControlProps() {
       return normalize.element({
         ...parts.control.attrs,
+        dir: prop("dir"),
         tabIndex: disabled ? undefined : 0,
         id: dom.getControlId(scope),
         role: "application",
@@ -101,6 +104,7 @@ export function connect<T extends PropTypes>(
     getSegmentProps() {
       return normalize.svg({
         ...parts.segment.attrs,
+        ...(prop("dir") ? { dir: prop("dir") } : {}),
         style: {
           position: "absolute",
           top: 0,
@@ -116,6 +120,7 @@ export function connect<T extends PropTypes>(
     getSegmentPathProps(props) {
       return normalize.path({
         ...parts.segmentPath.attrs,
+        ...(prop("dir") ? { dir: prop("dir") } : {}),
         d: props.path,
       })
     },
@@ -123,6 +128,7 @@ export function connect<T extends PropTypes>(
     getGuideProps() {
       return normalize.element({
         ...parts.guide.attrs,
+        dir: prop("dir"),
         "data-disabled": dataAttr(disabled),
       })
     },
@@ -130,6 +136,7 @@ export function connect<T extends PropTypes>(
     getClearTriggerProps() {
       return normalize.button({
         ...parts.clearTrigger.attrs,
+        dir: prop("dir"),
         type: "button",
         "aria-label": translations.clearTrigger,
         hidden: !context.get("paths").length || drawing,


### PR DESCRIPTION
Closes #3158

## Description

This PR forwards the `dir` prop to the visible Signature Pad parts so RTL direction can be applied correctly.

## Changes

- Added `dir: prop("dir")` to visible Signature Pad parts
- Used spread syntax for SVG/path parts to keep the types valid

## Breaking change

No

## Notes

I could not run the local typecheck because the current pnpm version requires Node.js >= 22.13, while my local Node.js version is 20.19.5.