### PR TITLE
feat: add chat virtualizer options

### DIFF
--- a/.changeset/virtualizer-chat-options.md
+++ b/.changeset/virtualizer-chat-options.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/virtualizer": minor
+---
+
+Add chat-oriented list virtualizer options and helpers: `anchorTo`, `followOnAppend`, `scrollEndThreshold`,
+`scrollToEnd()`, `getDistanceFromEnd()`, and `isAtEnd()`.

--- a/e2e/virtualizer.e2e.ts
+++ b/e2e/virtualizer.e2e.ts
@@ -97,9 +97,7 @@ test.describe("virtualizer examples", () => {
 
     await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
 
-    const pinnedScrollTop = await transcript.evaluate((el) => (el as HTMLElement).scrollTop)
     await page.getByRole("button", { name: "Append message" }).click()
-    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeGreaterThan(pinnedScrollTop)
     await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
 
     await transcript.evaluate((el) => {

--- a/e2e/virtualizer.e2e.ts
+++ b/e2e/virtualizer.e2e.ts
@@ -9,6 +9,7 @@ const virtualizerRoutes = [
   "/virtualizer/scroll-padding",
   "/virtualizer/sticky",
   "/virtualizer/infinite-scroll",
+  "/virtualizer/chat",
   "/virtualizer/window",
 ] as const
 
@@ -82,4 +83,37 @@ test.describe("virtualizer examples", () => {
       await I.checkAccessibility("main")
     })
   }
+
+  test("chat example follows appended messages only when pinned", async ({ page }) => {
+    await page.goto("/virtualizer/chat")
+    await page.waitForSelector("main", { state: "visible" })
+
+    const transcript = page.getByLabel("Chat transcript")
+    const distanceFromEnd = () =>
+      transcript.evaluate((el) => {
+        const element = el as HTMLElement
+        return element.scrollHeight - element.clientHeight - element.scrollTop
+      })
+
+    await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
+
+    const pinnedScrollTop = await transcript.evaluate((el) => (el as HTMLElement).scrollTop)
+    await page.getByRole("button", { name: "Append message" }).click()
+    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeGreaterThan(pinnedScrollTop)
+    await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
+
+    await transcript.evaluate((el) => {
+      const element = el as HTMLElement
+      element.scrollTop = 0
+      element.dispatchEvent(new Event("scroll", { bubbles: true }))
+    })
+    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeLessThan(2)
+
+    await page.getByRole("button", { name: "Append message" }).click()
+    await page.waitForTimeout(100)
+    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeLessThan(2)
+
+    await page.getByRole("button", { name: "Jump to latest" }).click()
+    await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
+  })
 })

--- a/e2e/virtualizer.e2e.ts
+++ b/e2e/virtualizer.e2e.ts
@@ -141,16 +141,37 @@ test.describe("virtualizer examples", () => {
     await page.waitForSelector("main", { state: "visible" })
 
     const transcript = page.getByLabel("Chat transcript")
+    const distanceFromEnd = () =>
+      transcript.evaluate((el) => {
+        const element = el as HTMLElement
+        return element.scrollHeight - element.clientHeight - element.scrollTop
+      })
+    const visibleMessages = () =>
+      transcript.evaluate((el) => {
+        const container = el as HTMLElement
+        const containerRect = container.getBoundingClientRect()
+        return Array.from(container.querySelectorAll<HTMLElement>("[data-index]"))
+          .filter((item) => {
+            const rect = item.getBoundingClientRect()
+            return rect.bottom > containerRect.top && rect.top < containerRect.bottom
+          })
+          .map((item) => item.textContent?.trim() ?? "")
+      })
+
     await expect
       .poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop), { timeout: 5000 })
       .toBeGreaterThan(0)
+    await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
 
-    const beforeText = await transcript.locator("[data-index]").first().textContent()
     await page.getByRole("button", { name: "Load older messages" }).click()
 
     await expect(page.getByText("Messages: 48")).toBeVisible({ timeout: 5000 })
-    await expect(transcript.locator("[data-index]").first()).toContainText(beforeText?.trim() || /message/)
-    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeGreaterThan(100)
+    await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
+    await expect
+      .poll(visibleMessages)
+      .toContainEqual(
+        "AssistantAssistant message 35. This message is intentionally longer so the example exercises dynamic row measurement and anchor correction.",
+      )
   })
 
   test("chat example keeps streamed output pinned when at latest", async ({ page }) => {

--- a/e2e/virtualizer.e2e.ts
+++ b/e2e/virtualizer.e2e.ts
@@ -136,6 +136,23 @@ test.describe("virtualizer examples", () => {
     await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeGreaterThan(100)
   })
 
+  test("chat example load older button preserves a valid virtual window", async ({ page }) => {
+    await page.goto("/virtualizer/chat")
+    await page.waitForSelector("main", { state: "visible" })
+
+    const transcript = page.getByLabel("Chat transcript")
+    await expect
+      .poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop), { timeout: 5000 })
+      .toBeGreaterThan(0)
+
+    const beforeText = await transcript.locator("[data-index]").first().textContent()
+    await page.getByRole("button", { name: "Load older messages" }).click()
+
+    await expect(page.getByText("Messages: 48")).toBeVisible({ timeout: 5000 })
+    await expect(transcript.locator("[data-index]").first()).toContainText(beforeText?.trim() || /message/)
+    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeGreaterThan(100)
+  })
+
   test("chat example keeps streamed output pinned when at latest", async ({ page }) => {
     await page.goto("/virtualizer/chat")
     await page.waitForSelector("main", { state: "visible" })

--- a/e2e/virtualizer.e2e.ts
+++ b/e2e/virtualizer.e2e.ts
@@ -102,16 +102,60 @@ test.describe("virtualizer examples", () => {
 
     await transcript.evaluate((el) => {
       const element = el as HTMLElement
-      element.scrollTop = 0
+      element.scrollTop = 240
       element.dispatchEvent(new Event("scroll", { bubbles: true }))
     })
-    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeLessThan(2)
+    const readingHistoryOffset = await transcript.evaluate((el) => (el as HTMLElement).scrollTop)
+    expect(readingHistoryOffset).toBeGreaterThan(100)
 
     await page.getByRole("button", { name: "Append message" }).click()
     await page.waitForTimeout(100)
-    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeLessThan(2)
+    await expect
+      .poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop))
+      .toBeLessThanOrEqual(readingHistoryOffset + 2)
 
     await page.getByRole("button", { name: "Jump to latest" }).click()
+    await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
+  })
+
+  test("chat example auto-loads older messages without losing the visible item", async ({ page }) => {
+    await page.goto("/virtualizer/chat")
+    await page.waitForSelector("main", { state: "visible" })
+
+    const transcript = page.getByLabel("Chat transcript")
+
+    await transcript.evaluate((el) => {
+      const element = el as HTMLElement
+      element.scrollTop = 0
+      element.dispatchEvent(new Event("scroll", { bubbles: true }))
+    })
+
+    await expect(page.getByText("Loading...")).toBeVisible()
+    await expect(page.getByText("Messages: 48")).toBeVisible({ timeout: 5000 })
+    await expect(transcript.getByText(/message 0\./)).toBeVisible()
+    await expect.poll(() => transcript.evaluate((el) => (el as HTMLElement).scrollTop)).toBeGreaterThan(100)
+  })
+
+  test("chat example keeps streamed output pinned when at latest", async ({ page }) => {
+    await page.goto("/virtualizer/chat")
+    await page.waitForSelector("main", { state: "visible" })
+
+    const transcript = page.getByLabel("Chat transcript")
+    const distanceFromEnd = () =>
+      transcript.evaluate((el) => {
+        const element = el as HTMLElement
+        return element.scrollHeight - element.clientHeight - element.scrollTop
+      })
+
+    await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
+
+    await page.getByRole("button", { name: "Stream reply" }).click()
+    await expect(page.getByRole("button", { name: "Streaming..." })).toBeDisabled()
+    await expect(page.getByText(/viewport remains pinned only when you are already at the latest message/)).toBeVisible(
+      {
+        timeout: 5000,
+      },
+    )
     await expect.poll(distanceFromEnd, { timeout: 5000 }).toBeLessThan(2)
   })
 })

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -196,10 +196,14 @@ export default function Page() {
   }, [])
 
   const appendMessage = useCallback(() => {
+    const shouldFollow = virtualizer.isAtEnd()
     const nextIndex = nextMessageIndexRef.current
     nextMessageIndexRef.current += 1
     setMessages((current) => [...current, makeMessage(nextIndex)])
-  }, [])
+    if (shouldFollow) {
+      requestAnimationFrame(scrollToLatestSettled)
+    }
+  }, [scrollToLatestSettled, virtualizer])
 
   const streamReply = useCallback(() => {
     if (streamTimerRef.current != null) return
@@ -276,6 +280,7 @@ export default function Page() {
         style={{
           ...virtualizer.getContainerStyle(),
           height: 460,
+          width: "100%",
           border: "1px solid #cbd5e1",
           borderRadius: 12,
           marginTop: 16,

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -81,9 +81,10 @@ export default function Page() {
 
   useEffect(() => {
     if (didInitialScrollRef.current) return
-    didInitialScrollRef.current = true
 
     const frame = requestAnimationFrame(() => {
+      if (didInitialScrollRef.current) return
+      didInitialScrollRef.current = true
       virtualizer.scrollToEnd()
     })
 

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -122,6 +122,7 @@ export default function Page() {
   const prependHistory = useCallback(() => {
     if (loadingHistoryRef.current) return
 
+    const shouldFollow = virtualizer.isAtEnd()
     loadingHistoryRef.current = true
     setIsLoadingHistory(true)
 
@@ -137,11 +138,14 @@ export default function Page() {
       messageIndexByIdRef.current = getMessageIndexById(nextMessages)
       virtualizer.prependItems(HISTORY_PAGE_SIZE)
       setMessageSnapshot(nextMessages)
+      if (shouldFollow) {
+        requestAnimationFrame(scrollToLatestSettled)
+      }
 
       loadingHistoryRef.current = false
       setIsLoadingHistory(false)
     }, 200)
-  }, [virtualizer])
+  }, [scrollToLatestSettled, virtualizer])
 
   const handleTranscriptScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -93,6 +93,21 @@ export default function Page() {
     [virtualizer],
   )
 
+  const scrollToLatestSettled = useCallback(() => {
+    let attempts = 0
+
+    const scroll = () => {
+      scrollToLatest()
+      attempts += 1
+
+      if (attempts < 4) {
+        requestAnimationFrame(scroll)
+      }
+    }
+
+    scroll()
+  }, [scrollToLatest])
+
   useEffect(() => {
     virtualizer.updateOptions({
       count: messages.length,
@@ -222,7 +237,7 @@ export default function Page() {
         <button type="button" onClick={streamReply} disabled={isStreaming}>
           {isStreaming ? "Streaming..." : "Stream reply"}
         </button>
-        <button type="button" onClick={() => scrollToLatest()} disabled={isAtEnd}>
+        <button type="button" onClick={scrollToLatestSettled} disabled={isAtEnd}>
           Jump to latest
         </button>
       </div>

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -45,7 +45,7 @@ export default function Page() {
   const messagesRef = useRef(initialMessages)
   const messageIndexByIdRef = useRef(getMessageIndexById(initialMessages))
 
-  const [messages, setMessages] = useState(initialMessages)
+  const [, setMessageSnapshot] = useState(initialMessages)
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
   const [isStreaming, setIsStreaming] = useState(false)
 
@@ -57,7 +57,7 @@ export default function Page() {
   )
 
   const { virtualizer, ref } = useListVirtualizer({
-    count: messages.length,
+    count: messagesRef.current.length,
     estimatedSize,
     indexToKey,
     keyToIndex,
@@ -116,7 +116,7 @@ export default function Page() {
   const syncMessages = useCallback((nextMessages: ChatMessage[]) => {
     messagesRef.current = nextMessages
     messageIndexByIdRef.current = getMessageIndexById(nextMessages)
-    setMessages(nextMessages)
+    setMessageSnapshot(nextMessages)
   }, [])
 
   const prependHistory = useCallback(() => {
@@ -136,7 +136,7 @@ export default function Page() {
       messagesRef.current = nextMessages
       messageIndexByIdRef.current = getMessageIndexById(nextMessages)
       virtualizer.prependItems(HISTORY_PAGE_SIZE)
-      setMessages(nextMessages)
+      setMessageSnapshot(nextMessages)
 
       loadingHistoryRef.current = false
       setIsLoadingHistory(false)
@@ -251,6 +251,7 @@ export default function Page() {
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()
   const isAtEnd = virtualizer.isAtEnd()
+  const currentMessages = messagesRef.current
 
   return (
     <main style={{ padding: 20, maxWidth: 760, width: "100%", margin: "0 auto" }}>
@@ -293,7 +294,7 @@ export default function Page() {
       >
         <div style={{ height: totalSize, width: "100%", position: "relative" }}>
           {virtualItems.map((virtualItem) => {
-            const message = messages[virtualItem.index]
+            const message = currentMessages[virtualItem.index]
             if (!message) return null
 
             const isOwnMessage = message.author === "You"
@@ -331,7 +332,7 @@ export default function Page() {
       </div>
 
       <div style={{ display: "flex", gap: 16, marginTop: 12, color: "#64748b", fontSize: 13 }}>
-        <span>Messages: {messages.length}</span>
+        <span>Messages: {currentMessages.length}</span>
         <span>Rendered: {virtualItems.length}</span>
         <span>Distance from end: {Math.round(virtualizer.getDistanceFromEnd())}px</span>
       </div>

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { type UIEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useListVirtualizer } from "@/hooks/use-virtualizer"
 
 type ChatMessage = {
@@ -11,6 +11,7 @@ type ChatMessage = {
 
 const HISTORY_PAGE_SIZE = 12
 const SCROLL_END_THRESHOLD = 120
+const HISTORY_LOAD_THRESHOLD = 120
 
 function makeMessage(index: number): ChatMessage {
   const author = index % 4 === 0 ? "You" : "Assistant"
@@ -31,6 +32,7 @@ const initialMessages = Array.from({ length: 36 }, (_, index) => makeMessage(ind
 export default function Page() {
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const didInitialScrollRef = useRef(false)
+  const autoHistoryEnabledRef = useRef(false)
   const loadingHistoryRef = useRef(false)
   const streamTimerRef = useRef<number | null>(null)
   const firstMessageIndexRef = useRef(0)
@@ -108,6 +110,40 @@ export default function Page() {
     scroll()
   }, [scrollToLatest])
 
+  const prependHistory = useCallback(() => {
+    if (loadingHistoryRef.current) return
+
+    loadingHistoryRef.current = true
+    setIsLoadingHistory(true)
+
+    window.setTimeout(() => {
+      const nextFirstIndex = firstMessageIndexRef.current - HISTORY_PAGE_SIZE
+      firstMessageIndexRef.current = nextFirstIndex
+
+      setMessages((current) => [
+        ...Array.from({ length: HISTORY_PAGE_SIZE }, (_, offset) => makeMessage(nextFirstIndex + offset)),
+        ...current,
+      ])
+
+      loadingHistoryRef.current = false
+      setIsLoadingHistory(false)
+    }, 200)
+  }, [])
+
+  const handleTranscriptScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      virtualizer.handleScroll(event)
+
+      if (!autoHistoryEnabledRef.current) return
+      if (loadingHistoryRef.current) return
+      if (virtualizer.isAtEnd()) return
+      if (event.currentTarget.scrollTop > HISTORY_LOAD_THRESHOLD) return
+
+      prependHistory()
+    },
+    [prependHistory, virtualizer],
+  )
+
   useEffect(() => {
     virtualizer.updateOptions({
       count: messages.length,
@@ -139,6 +175,7 @@ export default function Page() {
 
       if (didInitialScrollRef.current) return
       didInitialScrollRef.current = true
+      autoHistoryEnabledRef.current = true
     }
 
     frame = requestAnimationFrame(scroll)
@@ -155,26 +192,6 @@ export default function Page() {
         window.clearInterval(streamTimerRef.current)
       }
     }
-  }, [])
-
-  const prependHistory = useCallback(() => {
-    if (loadingHistoryRef.current) return
-
-    loadingHistoryRef.current = true
-    setIsLoadingHistory(true)
-
-    window.setTimeout(() => {
-      const nextFirstIndex = firstMessageIndexRef.current - HISTORY_PAGE_SIZE
-      firstMessageIndexRef.current = nextFirstIndex
-
-      setMessages((current) => [
-        ...Array.from({ length: HISTORY_PAGE_SIZE }, (_, offset) => makeMessage(nextFirstIndex + offset)),
-        ...current,
-      ])
-
-      loadingHistoryRef.current = false
-      setIsLoadingHistory(false)
-    }, 200)
   }, [])
 
   const appendMessage = useCallback(() => {
@@ -224,7 +241,7 @@ export default function Page() {
       <h1>Chat Virtualizer</h1>
       <p style={{ color: "#64748b", fontSize: 14 }}>
         End anchoring keeps prepended history stable, follows appended messages only when already pinned, and preserves
-        the latest message while streamed content grows.
+        the latest message while streamed content grows. Scroll near the top to load older messages automatically.
       </p>
 
       <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 16 }}>
@@ -244,7 +261,7 @@ export default function Page() {
 
       <div
         ref={setScrollElementRef}
-        onScroll={virtualizer.handleScroll}
+        onScroll={handleTranscriptScroll}
         {...virtualizer.getContainerAriaAttrs()}
         tabIndex={0}
         aria-label="Chat transcript"

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useListVirtualizer } from "@/hooks/use-virtualizer"
+
+type ChatMessage = {
+  id: string
+  author: "You" | "Assistant"
+  text: string
+}
+
+const HISTORY_PAGE_SIZE = 12
+
+function makeMessage(index: number): ChatMessage {
+  const author = index % 4 === 0 ? "You" : "Assistant"
+  const detail =
+    index % 5 === 0
+      ? "This message is intentionally longer so the example exercises dynamic row measurement and anchor correction."
+      : "Short update."
+
+  return {
+    id: `message-${index}`,
+    author,
+    text: `${author} message ${index}. ${detail}`,
+  }
+}
+
+const initialMessages = Array.from({ length: 36 }, (_, index) => makeMessage(index))
+
+export default function Page() {
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const didInitialScrollRef = useRef(false)
+  const loadingHistoryRef = useRef(false)
+  const streamTimerRef = useRef<number | null>(null)
+  const firstMessageIndexRef = useRef(0)
+  const nextMessageIndexRef = useRef(initialMessages.length)
+
+  const [messages, setMessages] = useState(initialMessages)
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false)
+  const [isStreaming, setIsStreaming] = useState(false)
+
+  const keyToIndexMap = useMemo(() => {
+    return new Map(messages.map((message, index) => [message.id, index]))
+  }, [messages])
+
+  const indexToKey = useCallback((index: number) => messages[index]!.id, [messages])
+  const keyToIndex = useCallback((key: string | number) => keyToIndexMap.get(String(key)) ?? -1, [keyToIndexMap])
+  const estimatedSize = useCallback(
+    (index: number) => ((messages[index]?.text.length ?? 0) > 110 ? 112 : 78),
+    [messages],
+  )
+
+  const { virtualizer, ref } = useListVirtualizer({
+    count: messages.length,
+    estimatedSize,
+    indexToKey,
+    keyToIndex,
+    anchorTo: "end",
+    followOnAppend: true,
+    scrollEndThreshold: 80,
+    overscan: 6,
+  })
+
+  virtualizer.updateOptions({
+    count: messages.length,
+    estimatedSize,
+    indexToKey,
+    keyToIndex,
+    anchorTo: "end",
+    followOnAppend: true,
+    scrollEndThreshold: 80,
+  })
+
+  const setScrollElementRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      scrollRef.current = element
+      ref(element)
+    },
+    [ref],
+  )
+
+  useEffect(() => {
+    if (didInitialScrollRef.current) return
+    didInitialScrollRef.current = true
+
+    const frame = requestAnimationFrame(() => {
+      virtualizer.scrollToEnd()
+    })
+
+    return () => cancelAnimationFrame(frame)
+  }, [virtualizer])
+
+  useEffect(() => {
+    return () => {
+      if (streamTimerRef.current != null) {
+        window.clearInterval(streamTimerRef.current)
+      }
+    }
+  }, [])
+
+  const prependHistory = useCallback(() => {
+    if (loadingHistoryRef.current) return
+
+    loadingHistoryRef.current = true
+    setIsLoadingHistory(true)
+
+    window.setTimeout(() => {
+      const nextFirstIndex = firstMessageIndexRef.current - HISTORY_PAGE_SIZE
+      firstMessageIndexRef.current = nextFirstIndex
+
+      setMessages((current) => [
+        ...Array.from({ length: HISTORY_PAGE_SIZE }, (_, offset) => makeMessage(nextFirstIndex + offset)),
+        ...current,
+      ])
+
+      loadingHistoryRef.current = false
+      setIsLoadingHistory(false)
+    }, 200)
+  }, [])
+
+  const appendMessage = useCallback(() => {
+    const nextIndex = nextMessageIndexRef.current
+    nextMessageIndexRef.current += 1
+    setMessages((current) => [...current, makeMessage(nextIndex)])
+  }, [])
+
+  const streamReply = useCallback(() => {
+    if (streamTimerRef.current != null) return
+
+    const id = `stream-${Date.now()}`
+    const chunks = [
+      "Assistant is composing a streamed response.",
+      "Assistant is composing a streamed response. New tokens keep extending the latest row.",
+      "Assistant is composing a streamed response. New tokens keep extending the latest row while the viewport remains pinned only when you are already at the latest message.",
+    ]
+    let chunkIndex = 0
+
+    setIsStreaming(true)
+    setMessages((current) => [...current, { id, author: "Assistant", text: chunks[0]! }])
+
+    streamTimerRef.current = window.setInterval(() => {
+      chunkIndex += 1
+
+      if (chunkIndex >= chunks.length) {
+        if (streamTimerRef.current != null) {
+          window.clearInterval(streamTimerRef.current)
+          streamTimerRef.current = null
+        }
+        setIsStreaming(false)
+        return
+      }
+
+      setMessages((current) =>
+        current.map((message) => (message.id === id ? { ...message, text: chunks[chunkIndex]! } : message)),
+      )
+    }, 450)
+  }, [])
+
+  const virtualItems = virtualizer.getVirtualItems()
+  const totalSize = virtualizer.getTotalSize()
+  const isAtEnd = virtualizer.isAtEnd()
+
+  return (
+    <main style={{ padding: 20, maxWidth: 760, width: "100%", margin: "0 auto" }}>
+      <h1>Chat Virtualizer</h1>
+      <p style={{ color: "#64748b", fontSize: 14 }}>
+        End anchoring keeps prepended history stable, follows appended messages only when already pinned, and preserves
+        the latest message while streamed content grows.
+      </p>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 16 }}>
+        <button type="button" onClick={prependHistory} disabled={isLoadingHistory}>
+          {isLoadingHistory ? "Loading..." : "Load older messages"}
+        </button>
+        <button type="button" onClick={appendMessage}>
+          Append message
+        </button>
+        <button type="button" onClick={streamReply} disabled={isStreaming}>
+          {isStreaming ? "Streaming..." : "Stream reply"}
+        </button>
+        <button type="button" onClick={() => virtualizer.scrollToEnd({ smooth: true })} disabled={isAtEnd}>
+          Jump to latest
+        </button>
+      </div>
+
+      <div
+        ref={setScrollElementRef}
+        onScroll={virtualizer.handleScroll}
+        {...virtualizer.getContainerAriaAttrs()}
+        tabIndex={0}
+        aria-label="Chat transcript"
+        style={{
+          ...virtualizer.getContainerStyle(),
+          height: 460,
+          border: "1px solid #cbd5e1",
+          borderRadius: 12,
+          marginTop: 16,
+          background: "#f8fafc",
+        }}
+      >
+        <div style={{ height: totalSize, width: "100%", position: "relative" }}>
+          {virtualItems.map((virtualItem) => {
+            const message = messages[virtualItem.index]
+            if (!message) return null
+
+            const isOwnMessage = message.author === "You"
+
+            return (
+              <div
+                key={virtualItem.key}
+                ref={virtualItem.measureElement}
+                data-index={virtualItem.index}
+                {...virtualizer.getItemAriaAttrs(virtualItem.index)}
+                style={{
+                  ...virtualizer.getItemStyle(virtualItem),
+                  boxSizing: "border-box",
+                  padding: "10px 14px",
+                }}
+              >
+                <article
+                  style={{
+                    marginLeft: isOwnMessage ? "auto" : 0,
+                    maxWidth: "78%",
+                    padding: "12px 14px",
+                    borderRadius: 14,
+                    background: isOwnMessage ? "#2563eb" : "#ffffff",
+                    color: isOwnMessage ? "#ffffff" : "#0f172a",
+                    boxShadow: "0 1px 2px rgba(15, 23, 42, 0.08)",
+                  }}
+                >
+                  <strong style={{ display: "block", fontSize: 12, marginBottom: 4 }}>{message.author}</strong>
+                  <span style={{ lineHeight: 1.5 }}>{message.text}</span>
+                </article>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: 16, marginTop: 12, color: "#64748b", fontSize: 13 }}>
+        <span>Messages: {messages.length}</span>
+        <span>Rendered: {virtualItems.length}</span>
+        <span>Distance from end: {Math.round(virtualizer.getDistanceFromEnd())}px</span>
+      </div>
+    </main>
+  )
+}

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -10,6 +10,7 @@ type ChatMessage = {
 }
 
 const HISTORY_PAGE_SIZE = 12
+const SCROLL_END_THRESHOLD = 120
 
 function makeMessage(index: number): ChatMessage {
   const author = index % 4 === 0 ? "You" : "Assistant"
@@ -57,7 +58,7 @@ export default function Page() {
     keyToIndex,
     anchorTo: "end",
     followOnAppend: true,
-    scrollEndThreshold: 80,
+    scrollEndThreshold: SCROLL_END_THRESHOLD,
     overscan: 6,
   })
 
@@ -100,7 +101,7 @@ export default function Page() {
       keyToIndex,
       anchorTo: "end",
       followOnAppend: true,
-      scrollEndThreshold: 80,
+      scrollEndThreshold: SCROLL_END_THRESHOLD,
     })
   }, [estimatedSize, indexToKey, keyToIndex, messages.length, virtualizer])
 

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { type UIEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { type UIEvent, useCallback, useEffect, useRef, useState } from "react"
 import { useListVirtualizer } from "@/hooks/use-virtualizer"
 
 type ChatMessage = {
@@ -29,6 +29,10 @@ function makeMessage(index: number): ChatMessage {
 
 const initialMessages = Array.from({ length: 36 }, (_, index) => makeMessage(index))
 
+function getMessageIndexById(messages: ChatMessage[]) {
+  return new Map(messages.map((message, index) => [message.id, index]))
+}
+
 export default function Page() {
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const didInitialScrollRef = useRef(false)
@@ -38,20 +42,18 @@ export default function Page() {
   const streamTimerRef = useRef<number | null>(null)
   const firstMessageIndexRef = useRef(0)
   const nextMessageIndexRef = useRef(initialMessages.length)
+  const messagesRef = useRef(initialMessages)
+  const messageIndexByIdRef = useRef(getMessageIndexById(initialMessages))
 
   const [messages, setMessages] = useState(initialMessages)
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
   const [isStreaming, setIsStreaming] = useState(false)
 
-  const keyToIndexMap = useMemo(() => {
-    return new Map(messages.map((message, index) => [message.id, index]))
-  }, [messages])
-
-  const indexToKey = useCallback((index: number) => messages[index]!.id, [messages])
-  const keyToIndex = useCallback((key: string | number) => keyToIndexMap.get(String(key)) ?? -1, [keyToIndexMap])
+  const indexToKey = useCallback((index: number) => messagesRef.current[index]!.id, [])
+  const keyToIndex = useCallback((key: string | number) => messageIndexByIdRef.current.get(String(key)) ?? -1, [])
   const estimatedSize = useCallback(
-    (index: number) => ((messages[index]?.text.length ?? 0) > 110 ? 112 : 78),
-    [messages],
+    (index: number) => ((messagesRef.current[index]?.text.length ?? 0) > 110 ? 112 : 78),
+    [],
   )
 
   const { virtualizer, ref } = useListVirtualizer({
@@ -111,6 +113,12 @@ export default function Page() {
     scroll()
   }, [scrollToLatest])
 
+  const syncMessages = useCallback((nextMessages: ChatMessage[]) => {
+    messagesRef.current = nextMessages
+    messageIndexByIdRef.current = getMessageIndexById(nextMessages)
+    setMessages(nextMessages)
+  }, [])
+
   const prependHistory = useCallback(() => {
     if (loadingHistoryRef.current) return
 
@@ -120,16 +128,20 @@ export default function Page() {
     window.setTimeout(() => {
       const nextFirstIndex = firstMessageIndexRef.current - HISTORY_PAGE_SIZE
       firstMessageIndexRef.current = nextFirstIndex
+      const olderMessages = Array.from({ length: HISTORY_PAGE_SIZE }, (_, offset) =>
+        makeMessage(nextFirstIndex + offset),
+      )
+      const nextMessages = [...olderMessages, ...messagesRef.current]
 
-      setMessages((current) => [
-        ...Array.from({ length: HISTORY_PAGE_SIZE }, (_, offset) => makeMessage(nextFirstIndex + offset)),
-        ...current,
-      ])
+      messagesRef.current = nextMessages
+      messageIndexByIdRef.current = getMessageIndexById(nextMessages)
+      virtualizer.prependItems(HISTORY_PAGE_SIZE)
+      setMessages(nextMessages)
 
       loadingHistoryRef.current = false
       setIsLoadingHistory(false)
     }, 200)
-  }, [])
+  }, [virtualizer])
 
   const handleTranscriptScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
@@ -144,18 +156,6 @@ export default function Page() {
     },
     [prependHistory, virtualizer],
   )
-
-  useEffect(() => {
-    virtualizer.updateOptions({
-      count: messages.length,
-      estimatedSize,
-      indexToKey,
-      keyToIndex,
-      anchorTo: "end",
-      followOnAppend: true,
-      scrollEndThreshold: SCROLL_END_THRESHOLD,
-    })
-  }, [estimatedSize, indexToKey, keyToIndex, messages.length, virtualizer])
 
   useEffect(() => {
     if (didInitialScrollRef.current) return
@@ -199,11 +199,13 @@ export default function Page() {
     const shouldFollow = virtualizer.isAtEnd()
     const nextIndex = nextMessageIndexRef.current
     nextMessageIndexRef.current += 1
-    setMessages((current) => [...current, makeMessage(nextIndex)])
+    const nextMessages = [...messagesRef.current, makeMessage(nextIndex)]
+    syncMessages(nextMessages)
+    virtualizer.updateOptions({ count: nextMessages.length })
     if (shouldFollow) {
       requestAnimationFrame(scrollToLatestSettled)
     }
-  }, [scrollToLatestSettled, virtualizer])
+  }, [scrollToLatestSettled, syncMessages, virtualizer])
 
   const streamReply = useCallback(() => {
     if (streamTimerRef.current != null) return
@@ -218,7 +220,9 @@ export default function Page() {
     let chunkIndex = 0
 
     setIsStreaming(true)
-    setMessages((current) => [...current, { id, author: "Assistant", text: chunks[0]! }])
+    const nextMessages = [...messagesRef.current, { id, author: "Assistant" as const, text: chunks[0]! }]
+    syncMessages(nextMessages)
+    virtualizer.updateOptions({ count: nextMessages.length })
     if (shouldFollowStreamRef.current) {
       requestAnimationFrame(scrollToLatestSettled)
     }
@@ -235,14 +239,14 @@ export default function Page() {
         return
       }
 
-      setMessages((current) =>
-        current.map((message) => (message.id === id ? { ...message, text: chunks[chunkIndex]! } : message)),
+      syncMessages(
+        messagesRef.current.map((message) => (message.id === id ? { ...message, text: chunks[chunkIndex]! } : message)),
       )
       if (shouldFollowStreamRef.current) {
         requestAnimationFrame(scrollToLatestSettled)
       }
     }, 450)
-  }, [scrollToLatestSettled, virtualizer])
+  }, [scrollToLatestSettled, syncMessages, virtualizer])
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -222,7 +222,7 @@ export default function Page() {
         <button type="button" onClick={streamReply} disabled={isStreaming}>
           {isStreaming ? "Streaming..." : "Stream reply"}
         </button>
-        <button type="button" onClick={() => scrollToLatest({ smooth: true })} disabled={isAtEnd}>
+        <button type="button" onClick={() => scrollToLatest()} disabled={isAtEnd}>
           Jump to latest
         </button>
       </div>

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -61,16 +61,6 @@ export default function Page() {
     overscan: 6,
   })
 
-  virtualizer.updateOptions({
-    count: messages.length,
-    estimatedSize,
-    indexToKey,
-    keyToIndex,
-    anchorTo: "end",
-    followOnAppend: true,
-    scrollEndThreshold: 80,
-  })
-
   const setScrollElementRef = useCallback(
     (element: HTMLDivElement | null) => {
       scrollRef.current = element
@@ -101,6 +91,18 @@ export default function Page() {
     },
     [virtualizer],
   )
+
+  useEffect(() => {
+    virtualizer.updateOptions({
+      count: messages.length,
+      estimatedSize,
+      indexToKey,
+      keyToIndex,
+      anchorTo: "end",
+      followOnAppend: true,
+      scrollEndThreshold: 80,
+    })
+  }, [estimatedSize, indexToKey, keyToIndex, messages.length, virtualizer])
 
   useEffect(() => {
     if (didInitialScrollRef.current) return

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -79,17 +79,57 @@ export default function Page() {
     [ref],
   )
 
+  const scrollToLatest = useCallback(
+    (options: { smooth?: boolean } = {}) => {
+      if (options.smooth) {
+        virtualizer.scrollToEnd({ smooth: true })
+        return
+      }
+
+      virtualizer.scrollToEnd()
+
+      const element = scrollRef.current
+      if (!element) return
+
+      element.scrollTop = Math.max(0, element.scrollHeight - element.clientHeight)
+      virtualizer.handleScroll({
+        currentTarget: {
+          scrollTop: element.scrollTop,
+          scrollLeft: element.scrollLeft,
+        },
+      })
+    },
+    [virtualizer],
+  )
+
   useEffect(() => {
     if (didInitialScrollRef.current) return
 
-    const frame = requestAnimationFrame(() => {
+    let frame = 0
+    let attempts = 0
+    let cancelled = false
+
+    const scroll = () => {
+      if (cancelled || didInitialScrollRef.current) return
+      scrollToLatest()
+      attempts += 1
+
+      if (attempts < 4) {
+        frame = requestAnimationFrame(scroll)
+        return
+      }
+
       if (didInitialScrollRef.current) return
       didInitialScrollRef.current = true
-      virtualizer.scrollToEnd()
-    })
+    }
 
-    return () => cancelAnimationFrame(frame)
-  }, [virtualizer])
+    frame = requestAnimationFrame(scroll)
+
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(frame)
+    }
+  }, [scrollToLatest])
 
   useEffect(() => {
     return () => {
@@ -179,7 +219,7 @@ export default function Page() {
         <button type="button" onClick={streamReply} disabled={isStreaming}>
           {isStreaming ? "Streaming..." : "Stream reply"}
         </button>
-        <button type="button" onClick={() => virtualizer.scrollToEnd({ smooth: true })} disabled={isAtEnd}>
+        <button type="button" onClick={() => scrollToLatest({ smooth: true })} disabled={isAtEnd}>
           Jump to latest
         </button>
       </div>

--- a/examples/next-ts/app/virtualizer/chat/page.tsx
+++ b/examples/next-ts/app/virtualizer/chat/page.tsx
@@ -33,6 +33,7 @@ export default function Page() {
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const didInitialScrollRef = useRef(false)
   const autoHistoryEnabledRef = useRef(false)
+  const shouldFollowStreamRef = useRef(false)
   const loadingHistoryRef = useRef(false)
   const streamTimerRef = useRef<number | null>(null)
   const firstMessageIndexRef = useRef(0)
@@ -203,6 +204,7 @@ export default function Page() {
   const streamReply = useCallback(() => {
     if (streamTimerRef.current != null) return
 
+    shouldFollowStreamRef.current = virtualizer.isAtEnd()
     const id = `stream-${Date.now()}`
     const chunks = [
       "Assistant is composing a streamed response.",
@@ -213,6 +215,9 @@ export default function Page() {
 
     setIsStreaming(true)
     setMessages((current) => [...current, { id, author: "Assistant", text: chunks[0]! }])
+    if (shouldFollowStreamRef.current) {
+      requestAnimationFrame(scrollToLatestSettled)
+    }
 
     streamTimerRef.current = window.setInterval(() => {
       chunkIndex += 1
@@ -229,8 +234,11 @@ export default function Page() {
       setMessages((current) =>
         current.map((message) => (message.id === id ? { ...message, text: chunks[chunkIndex]! } : message)),
       )
+      if (shouldFollowStreamRef.current) {
+        requestAnimationFrame(scrollToLatestSettled)
+      }
     }, 450)
-  }, [])
+  }, [scrollToLatestSettled, virtualizer])
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()

--- a/packages/utilities/virtualizer/src/index.ts
+++ b/packages/utilities/virtualizer/src/index.ts
@@ -3,6 +3,7 @@ export { ListVirtualizer } from "./list-virtualizer"
 export { WaterfallVirtualizer } from "./waterfall-virtualizer"
 export type {
   CSSProperties,
+  FollowOnAppend,
   GridVirtualizerOptions,
   GroupMeta,
   InitialMeasurements,
@@ -18,11 +19,13 @@ export type {
   ScrollAnchor,
   ScrollByOptions,
   ScrollState,
+  ScrollToEndOptions,
   ScrollToIndexOptions,
   ScrollToIndexResult,
   ShouldAdjustScrollOnSizeChangeContext,
   TimerId,
   VirtualizerDir,
+  VirtualizerAnchor,
   VirtualItem,
   VirtualizerOrientation,
   VirtualRange,

--- a/packages/utilities/virtualizer/src/types.ts
+++ b/packages/utilities/virtualizer/src/types.ts
@@ -47,6 +47,8 @@ export interface ScrollAnchor {
 }
 
 type ScrollAlignment = "start" | "center" | "end" | "auto"
+export type VirtualizerAnchor = "start" | "end"
+export type FollowOnAppend = boolean | "auto" | "smooth" | "instant"
 export type ScrollEasing = (t: number) => number
 
 export interface ScrollToIndexOptions {
@@ -79,6 +81,8 @@ export interface ScrollByOptions {
   /** Enable smooth scrolling with custom options */
   smooth?: ScrollToIndexOptions["smooth"]
 }
+
+export interface ScrollToEndOptions extends ScrollByOptions {}
 
 export interface VirtualRange {
   startIndex: number
@@ -217,6 +221,26 @@ export interface VirtualizerOptions {
 
   /** Enable scroll anchor preservation during updates */
   preserveScrollAnchor?: boolean
+
+  /**
+   * Controls which side of the scrollable content is treated as the stable anchor.
+   *
+   * Use "end" for chat, logs, and reverse feeds where the latest item appears at
+   * the end and the viewport should stay pinned while streaming output grows.
+   */
+  anchorTo?: VirtualizerAnchor
+
+  /**
+   * When used with `anchorTo: "end"`, follow appended items only if the viewport
+   * was already at the end before the append. `true` is equivalent to "auto".
+   */
+  followOnAppend?: FollowOnAppend
+
+  /**
+   * Distance in pixels from the end that still counts as being at the end.
+   * Used by `followOnAppend` and `isAtEnd()`.
+   */
+  scrollEndThreshold?: number
 
   /**
    * Control whether a measured size change should compensate the current scroll offset.

--- a/packages/utilities/virtualizer/src/virtualizer.ts
+++ b/packages/utilities/virtualizer/src/virtualizer.ts
@@ -9,6 +9,7 @@ import type {
   ScrollByOptions,
   ScrollAnchor,
   ScrollState,
+  ScrollToEndOptions,
   ScrollToIndexOptions,
   ScrollToIndexResult,
   ShouldAdjustScrollOnSizeChangeContext,
@@ -31,6 +32,13 @@ type RangeChangeReasonDetails = { reason: RangeChangeReason }
 type SmoothScrollOptions = Exclude<NonNullable<ScrollToIndexOptions["smooth"]>, boolean>
 type SmoothScrollFunction = NonNullable<SmoothScrollOptions["scrollFunction"]>
 type RtlScrollBehavior = "negative" | "positive-descending" | "positive-ascending"
+type AnchorSnapshot = ScrollAnchor & { align: "start" | "end" }
+type CountChangeSnapshot = {
+  previousCount: number
+  nextCount: number
+  previousLastKey: string | number | undefined
+  wasAtEnd: boolean
+}
 
 function easeOutCubic(t: number): number {
   const shiftedT = t - 1
@@ -159,6 +167,9 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
       rangeExtractor: defaultRangeExtractor,
       rootMargin: "50px",
       preserveScrollAnchor: true,
+      anchorTo: "start",
+      followOnAppend: false,
+      scrollEndThreshold: 0,
       overflowAnchor: "none",
       observeScrollElementSize: false,
       scrollEndDelay: SCROLL_END_DELAY_MS,
@@ -854,6 +865,20 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
     return this.scrollToOffset(this.scrollOffset + delta, options)
   }
 
+  getDistanceFromEnd(): number {
+    const viewportEnd = this.scrollOffset + this.getScrollMargin() + this.viewportSize
+    return Math.max(0, this.getTotalSize() - viewportEnd)
+  }
+
+  isAtEnd(threshold = this.options.scrollEndThreshold): boolean {
+    return this.getDistanceFromEnd() <= threshold
+  }
+
+  scrollToEnd(options: ScrollToEndOptions = {}): ScrollToIndexResult {
+    const targetOffset = Math.max(0, this.getTotalSize() - this.getScrollMargin() - this.viewportSize)
+    return this.scrollToOffset(targetOffset, options)
+  }
+
   private applyInitialScrollOffset(): void {
     if (this.hasAppliedInitialOffset || this.options.disableScrollOnInit) return
 
@@ -1071,6 +1096,7 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
     const previousSize = this.getKnownItemSize(index) ?? this.getEstimatedSize(index)
     const delta = size - previousSize
     const shouldAdjust = this.shouldAdjustScrollOnSizeChange(index, delta)
+    const shouldPreserveEnd = this.shouldPreserveEndOnSizeChange(delta)
     let changed = false
     const applyMeasurement = () => {
       changed = this.onItemMeasured(index, size)
@@ -1079,7 +1105,12 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
       }
     }
 
-    if (shouldAdjust) {
+    if (shouldPreserveEnd) {
+      applyMeasurement()
+      if (changed) {
+        this.scrollToEnd()
+      }
+    } else if (shouldAdjust) {
       this.preserveScrollPosition(index, applyMeasurement)
     } else {
       applyMeasurement()
@@ -1103,6 +1134,7 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
     const previousSize = this.getKnownItemSize(index) ?? this.getEstimatedSize(index)
     const delta = size - previousSize
     const shouldAdjust = this.shouldAdjustScrollOnSizeChange(index, delta)
+    const shouldPreserveEnd = this.shouldPreserveEndOnSizeChange(delta)
     let changed = false
     const applyMeasurement = () => {
       changed = this.onItemMeasured(index, size)
@@ -1111,7 +1143,12 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
       }
     }
 
-    if (shouldAdjust) {
+    if (shouldPreserveEnd) {
+      applyMeasurement()
+      if (changed) {
+        this.scrollToEnd()
+      }
+    } else if (shouldAdjust) {
       this.preserveScrollPosition(index, applyMeasurement)
     } else {
       applyMeasurement()
@@ -1165,7 +1202,7 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
 
     if (this.pendingSizeUpdates.size === 0) return
 
-    const updates: Array<{ index: number; size: number; shouldAdjust: boolean }> = []
+    const updates: Array<{ index: number; size: number; shouldAdjust: boolean; shouldPreserveEnd: boolean }> = []
     for (const [index, { size, element }] of this.pendingSizeUpdates) {
       if (element && this.elementsByIndex.get(index) !== element) continue
       const previousSize = this.getKnownItemSize(index) ?? this.getEstimatedSize(index)
@@ -1174,6 +1211,7 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
         index,
         size,
         shouldAdjust: this.shouldAdjustScrollOnSizeChange(index, delta),
+        shouldPreserveEnd: this.shouldPreserveEndOnSizeChange(delta),
       })
     }
 
@@ -1195,12 +1233,18 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
       this.invalidateMeasurements(minIndex)
     }
 
+    const shouldPreserveEnd = updates.some((update) => update.shouldPreserveEnd)
     const adjustCandidate = updates.reduce((min, update) => {
       if (!update.shouldAdjust) return min
       return update.index < min ? update.index : min
     }, Infinity)
 
-    if (adjustCandidate !== Infinity) {
+    if (shouldPreserveEnd) {
+      applyMeasurements()
+      if (anySizeChanged) {
+        this.scrollToEnd()
+      }
+    } else if (adjustCandidate !== Infinity) {
       this.preserveScrollPosition(adjustCandidate, applyMeasurements)
     } else {
       applyMeasurements()
@@ -1299,6 +1343,13 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
     return measurement.start < viewportStart
   }
 
+  private shouldPreserveEndOnSizeChange(delta: number): boolean {
+    if (!this.options.preserveScrollAnchor) return false
+    if (this.options.anchorTo !== "end") return false
+    if (delta === 0) return false
+    return this.isAtEnd()
+  }
+
   protected toLogicalHorizontalOffset(rawOffset: number, target: HTMLElement | null): number {
     if (!this.isHorizontal || !this.isRtl) return rawOffset
     const mode = this.resolveRtlScrollBehavior(target)
@@ -1374,25 +1425,43 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
   }
 
   getScrollAnchor(): ScrollAnchor | null {
+    const anchor = this.getAnchorSnapshot("start")
+    return anchor ? { key: anchor.key, offset: anchor.offset } : null
+  }
+
+  private getAnchorSnapshot(align: "start" | "end" = this.options.anchorTo): AnchorSnapshot | null {
     this.calculateRange()
     if (this.range.startIndex < 0 || this.range.endIndex < 0) return null
 
     const { count } = this.options
     const scrollMargin = this.getScrollMargin()
     const viewportStart = this.scrollOffset + scrollMargin
-    const anchorIndex = Math.min(count - 1, Math.max(0, this.findIndexAtOffset(viewportStart)))
+    const viewportEnd = viewportStart + this.viewportSize
+    const anchorOffset = align === "end" ? Math.max(viewportStart, viewportEnd - 1) : viewportStart
+    const anchorIndex = Math.min(count - 1, Math.max(0, this.findIndexAtOffset(anchorOffset)))
     const measurement = this.getMeasurement(anchorIndex)
     const key = this.getItemKey(anchorIndex)
 
-    return { key, offset: viewportStart - measurement.start }
+    return {
+      key,
+      offset: align === "end" ? measurement.end - viewportEnd : viewportStart - measurement.start,
+      align,
+    }
   }
 
   restoreScrollAnchor(anchor: ScrollAnchor): ScrollToIndexResult | null {
+    return this.restoreAnchorSnapshot({ ...anchor, align: "start" })
+  }
+
+  private restoreAnchorSnapshot(anchor: AnchorSnapshot): ScrollToIndexResult | null {
     const index = this.getIndexForKey(anchor.key)
     if (index === undefined) return null
 
     const measurement = this.getMeasurement(index)
-    const targetOffset = measurement.start + anchor.offset - this.getScrollMargin()
+    const targetOffset =
+      anchor.align === "end"
+        ? measurement.end - anchor.offset - this.viewportSize - this.getScrollMargin()
+        : measurement.start + anchor.offset - this.getScrollMargin()
     return this.scrollToOffset(targetOffset)
   }
 
@@ -1589,10 +1658,12 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
   updateOptions(nextOptions: Partial<O>): void {
     if (this.isDestroyed) return
     const prev = { ...this.options }
+    const countChanged = nextOptions.count !== undefined && nextOptions.count !== this.options.count
     const preserveAnchor = nextOptions.preserveScrollAnchor ?? this.options.preserveScrollAnchor
-    const shouldRestoreAnchor =
-      preserveAnchor && nextOptions.count !== undefined && nextOptions.count !== this.options.count
-    const anchor = shouldRestoreAnchor ? this.getScrollAnchor() : null
+    const nextAnchorTo = nextOptions.anchorTo ?? this.options.anchorTo
+    const shouldRestoreAnchor = preserveAnchor && countChanged
+    const anchor = shouldRestoreAnchor ? this.getAnchorSnapshot(nextAnchorTo) : null
+    const countSnapshot = countChanged ? this.getCountChangeSnapshot(nextOptions.count!) : null
 
     Object.assign(this.options, nextOptions)
     if (nextOptions.dir !== undefined) {
@@ -1621,9 +1692,38 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
 
     this.forceUpdate({ reason })
 
-    if (anchor) {
-      this.restoreScrollAnchor(anchor)
+    if (countSnapshot && this.shouldFollowOnAppend(countSnapshot)) {
+      this.followAppendedItems()
+    } else if (anchor) {
+      this.restoreAnchorSnapshot(anchor)
     }
+  }
+
+  private getCountChangeSnapshot(nextCount: number): CountChangeSnapshot {
+    const nextScrollEndThreshold = this.options.scrollEndThreshold
+    return {
+      previousCount: this.options.count,
+      nextCount,
+      previousLastKey: this.options.count > 0 ? this.getItemKey(this.options.count - 1) : undefined,
+      wasAtEnd: this.getDistanceFromEnd() <= nextScrollEndThreshold,
+    }
+  }
+
+  private shouldFollowOnAppend(snapshot: CountChangeSnapshot): boolean {
+    if (this.options.anchorTo !== "end") return false
+    if (this.options.followOnAppend === false) return false
+    if (!snapshot.wasAtEnd) return false
+    if (snapshot.nextCount <= snapshot.previousCount) return false
+    if (snapshot.previousCount === 0) return true
+    if (snapshot.previousLastKey === undefined) return false
+
+    return this.getIndexForKey(snapshot.previousLastKey) === snapshot.previousCount - 1
+  }
+
+  private followAppendedItems(): void {
+    const followOnAppend = this.options.followOnAppend
+    const smooth = followOnAppend === "smooth" && this.scrollElement ? true : undefined
+    this.scrollToEnd({ smooth })
   }
 
   /** Regular method (not a class field) so subclasses can override with `super`. */

--- a/packages/utilities/virtualizer/src/virtualizer.ts
+++ b/packages/utilities/virtualizer/src/virtualizer.ts
@@ -533,10 +533,14 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
 
   protected getIndexForKey(key: string | number): number | undefined {
     const byUser = this.options.keyToIndex?.(key)
-    if (byUser !== undefined) return byUser
+    if (byUser !== undefined) {
+      return Number.isInteger(byUser) && byUser >= 0 && byUser < this.options.count ? byUser : undefined
+    }
 
     const cached = this.keyIndexCache.get(key)
-    if (cached !== undefined) return cached
+    if (cached !== undefined) {
+      return cached >= 0 && cached < this.options.count ? cached : undefined
+    }
 
     for (let i = 0; i < this.options.count; i++) {
       if (this.getItemKey(i) === key) return i

--- a/packages/utilities/virtualizer/src/virtualizer.ts
+++ b/packages/utilities/virtualizer/src/virtualizer.ts
@@ -886,8 +886,19 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
   }
 
   scrollToEnd(options: ScrollToEndOptions = {}): ScrollToIndexResult {
-    const targetOffset = Math.max(0, this.getTotalSize() - this.getScrollMargin() - this.viewportSize)
-    return this.scrollToOffset(targetOffset, options)
+    return this.scrollToOffset(this.getEndOffset(), options)
+  }
+
+  private getEndOffset(): number {
+    if (this.scrollElement && this.shouldApplyScrollToScrollElement()) {
+      if (this.isHorizontal) {
+        return this.getMaxHorizontalOffset(this.scrollElement)
+      }
+
+      return Math.max(0, this.scrollElement.scrollHeight - this.scrollElement.clientHeight)
+    }
+
+    return Math.max(0, this.getTotalSize() - this.getScrollMargin() - this.viewportSize)
   }
 
   private applyInitialScrollOffset(): void {

--- a/packages/utilities/virtualizer/src/virtualizer.ts
+++ b/packages/utilities/virtualizer/src/virtualizer.ts
@@ -1714,9 +1714,11 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
 
     this.forceUpdate({ reason })
 
+    const didAppend = countSnapshot ? this.isAppendChange(countSnapshot) : false
+
     if (countSnapshot && this.shouldFollowOnAppend(countSnapshot)) {
       this.followAppendedItems()
-    } else if (anchor) {
+    } else if (anchor && !didAppend) {
       this.restoreAnchorSnapshot(anchor)
     }
   }
@@ -1735,6 +1737,10 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
     if (this.options.anchorTo !== "end") return false
     if (this.options.followOnAppend === false) return false
     if (!snapshot.wasAtEnd) return false
+    return this.isAppendChange(snapshot)
+  }
+
+  private isAppendChange(snapshot: CountChangeSnapshot): boolean {
     if (snapshot.nextCount <= snapshot.previousCount) return false
     if (snapshot.previousCount === 0) return true
     if (snapshot.previousLastKey === undefined) return false

--- a/packages/utilities/virtualizer/src/virtualizer.ts
+++ b/packages/utilities/virtualizer/src/virtualizer.ts
@@ -866,6 +866,17 @@ export abstract class Virtualizer<O extends VirtualizerOptions = VirtualizerOpti
   }
 
   getDistanceFromEnd(): number {
+    if (this.scrollElement && this.shouldApplyScrollToScrollElement()) {
+      if (this.isHorizontal) {
+        const maxOffset = this.getMaxHorizontalOffset(this.scrollElement)
+        const currentOffset = this.toLogicalHorizontalOffset(this.scrollElement.scrollLeft, this.scrollElement)
+        return Math.max(0, maxOffset - currentOffset)
+      }
+
+      const maxOffset = Math.max(0, this.scrollElement.scrollHeight - this.scrollElement.clientHeight)
+      return Math.max(0, maxOffset - this.scrollElement.scrollTop)
+    }
+
     const viewportEnd = this.scrollOffset + this.getScrollMargin() + this.viewportSize
     return Math.max(0, this.getTotalSize() - viewportEnd)
   }

--- a/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
+++ b/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
@@ -848,6 +848,147 @@ describe("ListVirtualizer", () => {
     expect(virtualizer.getScrollAnchor()).toEqual({ key: "a", offset: 5 })
   })
 
+  test("exposes end distance helpers and scrollToEnd", () => {
+    const virtualizer = new ListVirtualizer({
+      count: 10,
+      estimatedSize: () => 10,
+      overscan: 0,
+      initialRect: initialRect(30),
+      initialOffset: 20,
+      scrollEndThreshold: 5,
+    })
+
+    expect(virtualizer.getDistanceFromEnd()).toBe(50)
+    expect(virtualizer.isAtEnd()).toBe(false)
+    expect(virtualizer.scrollToEnd()).toEqual({ scrollTop: 70, scrollLeft: 0 })
+    expect(virtualizer.getDistanceFromEnd()).toBe(0)
+    expect(virtualizer.isAtEnd()).toBe(true)
+  })
+
+  test("follows appended items when end anchored and already at the end", () => {
+    const initialItems = ["a", "b", "c", "d", "e"]
+    let items = initialItems
+
+    const virtualizer = new ListVirtualizer({
+      count: items.length,
+      estimatedSize: () => 10,
+      overscan: 0,
+      initialRect: initialRect(30),
+      anchorTo: "end",
+      followOnAppend: true,
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    virtualizer.scrollToEnd()
+    expect(virtualizer.getScrollState().offset.y).toBe(20)
+
+    items = [...initialItems, "f"]
+    virtualizer.updateOptions({
+      count: items.length,
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    expect(virtualizer.getScrollState().offset.y).toBe(30)
+    expect(virtualizer.isAtEnd()).toBe(true)
+  })
+
+  test("does not follow appended items when the user is reading history", () => {
+    const initialItems = ["a", "b", "c", "d", "e"]
+    let items = initialItems
+
+    const virtualizer = new ListVirtualizer({
+      count: items.length,
+      estimatedSize: () => 10,
+      overscan: 0,
+      initialRect: initialRect(30),
+      anchorTo: "end",
+      followOnAppend: true,
+      scrollEndThreshold: 5,
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    virtualizer.scrollToOffset(10)
+    expect(virtualizer.getDistanceFromEnd()).toBe(10)
+
+    items = [...initialItems, "f"]
+    virtualizer.updateOptions({
+      count: items.length,
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    expect(virtualizer.getScrollState().offset.y).toBe(10)
+    expect(virtualizer.getDistanceFromEnd()).toBe(20)
+  })
+
+  test("uses scrollEndThreshold to decide whether appended items should follow", () => {
+    const initialItems = ["a", "b", "c", "d", "e"]
+    let items = initialItems
+
+    const virtualizer = new ListVirtualizer({
+      count: items.length,
+      estimatedSize: () => 10,
+      overscan: 0,
+      initialRect: initialRect(30),
+      anchorTo: "end",
+      followOnAppend: "instant",
+      scrollEndThreshold: 6,
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    virtualizer.scrollToOffset(15)
+    expect(virtualizer.getDistanceFromEnd()).toBe(5)
+
+    items = [...initialItems, "f"]
+    virtualizer.updateOptions({
+      count: items.length,
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    expect(virtualizer.getScrollState().offset.y).toBe(30)
+  })
+
+  test("keeps an end anchored viewport pinned when the last item grows", () => {
+    const virtualizer = new ListVirtualizer({
+      count: 5,
+      estimatedSize: () => 20,
+      overscan: 0,
+      initialRect: initialRect(60),
+      anchorTo: "end",
+    })
+
+    virtualizer.scrollToEnd()
+    expect(virtualizer.getScrollState().offset.y).toBe(40)
+
+    virtualizer.measureItem(4, 40)
+
+    expect(virtualizer.getTotalSize()).toBe(120)
+    expect(virtualizer.getScrollState().offset.y).toBe(60)
+    expect(virtualizer.isAtEnd()).toBe(true)
+  })
+
+  test("does not pin last item growth when the viewport is away from the end", () => {
+    const virtualizer = new ListVirtualizer({
+      count: 5,
+      estimatedSize: () => 20,
+      overscan: 0,
+      initialRect: initialRect(60),
+      anchorTo: "end",
+    })
+
+    virtualizer.scrollToOffset(20)
+    virtualizer.measureItem(4, 40)
+
+    expect(virtualizer.getTotalSize()).toBe(120)
+    expect(virtualizer.getScrollState().offset.y).toBe(20)
+    expect(virtualizer.isAtEnd()).toBe(false)
+  })
+
   test("preserves groups initialized during construction", () => {
     const virtualizer = new ListVirtualizer({
       count: 100,

--- a/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
+++ b/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
@@ -887,6 +887,8 @@ describe("ListVirtualizer", () => {
 
     expect(virtualizer.getDistanceFromEnd()).toBe(10)
     expect(virtualizer.isAtEnd()).toBe(true)
+    expect(virtualizer.scrollToEnd()).toEqual({ scrollTop: 70, scrollLeft: 0 })
+    expect(element.scrollTop).toBe(70)
   })
 
   test("follows appended items when end anchored and already at the end", () => {

--- a/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
+++ b/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
@@ -848,6 +848,20 @@ describe("ListVirtualizer", () => {
     expect(virtualizer.getScrollAnchor()).toEqual({ key: "a", offset: 5 })
   })
 
+  test("treats negative keyToIndex results as missing keys", () => {
+    const items = ["a", "b", "c"]
+    const virtualizer = new ListVirtualizer({
+      count: items.length,
+      estimatedSize: () => 10,
+      overscan: 0,
+      initialRect: initialRect(20),
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    expect(virtualizer.restoreScrollAnchor({ key: "missing", offset: 0 })).toBeNull()
+  })
+
   test("exposes end distance helpers and scrollToEnd", () => {
     const virtualizer = new ListVirtualizer({
       count: 10,

--- a/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
+++ b/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
@@ -865,6 +865,30 @@ describe("ListVirtualizer", () => {
     expect(virtualizer.isAtEnd()).toBe(true)
   })
 
+  test("uses the attached scroll element for distance from end", () => {
+    const { element } = createMockScrollContainer({
+      viewport: { width: 100, height: 30 },
+      scrollTop: 60,
+    })
+    Object.assign(element, {
+      clientHeight: 30,
+      scrollHeight: 100,
+    })
+
+    const virtualizer = new ListVirtualizer({
+      count: 10,
+      estimatedSize: () => 10,
+      overscan: 0,
+      initialRect: initialRect(30),
+      scrollEndThreshold: 10,
+    })
+
+    virtualizer.init(element)
+
+    expect(virtualizer.getDistanceFromEnd()).toBe(10)
+    expect(virtualizer.isAtEnd()).toBe(true)
+  })
+
   test("follows appended items when end anchored and already at the end", () => {
     const initialItems = ["a", "b", "c", "d", "e"]
     let items = initialItems

--- a/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
+++ b/packages/utilities/virtualizer/tests/list-virtualizer.test.ts
@@ -950,6 +950,36 @@ describe("ListVirtualizer", () => {
     expect(virtualizer.getDistanceFromEnd()).toBe(20)
   })
 
+  test("does not restore an end anchor for appends when the user is reading history", () => {
+    const initialItems = ["a", "b", "c", "d", "e"]
+    let items = initialItems
+
+    const virtualizer = new ListVirtualizer({
+      count: items.length,
+      estimatedSize: () => 100,
+      overscan: 0,
+      initialRect: initialRect(200),
+      anchorTo: "end",
+      followOnAppend: true,
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    for (let index = 0; index < items.length; index++) {
+      virtualizer.measureItem(index, 50)
+    }
+    virtualizer.scrollToOffset(0)
+
+    items = [...initialItems, "f"]
+    virtualizer.updateOptions({
+      count: items.length,
+      indexToKey: (index) => items[index]!,
+      keyToIndex: (key) => items.indexOf(key as string),
+    })
+
+    expect(virtualizer.getScrollState().offset.y).toBe(0)
+  })
+
   test("uses scrollEndThreshold to decide whether appended items should follow", () => {
     const initialItems = ["a", "b", "c", "d", "e"]
     let items = initialItems

--- a/shared/src/routes.ts
+++ b/shared/src/routes.ts
@@ -640,6 +640,7 @@ export const componentRoutes: ComponentRoute[] = [
       { slug: "scroll-padding", title: "Scroll Padding" },
       { slug: "sticky", title: "Sticky Headers" },
       { slug: "infinite-scroll", title: "Infinite Scroll" },
+      { slug: "chat", title: "Chat" },
       { slug: "window", title: "Window scroll" },
       { slug: "perf", title: "Perf: Fixed Height" },
       { slug: "perf-variable", title: "Perf: Variable (measureElement)" },

--- a/website/data/guides/virtualizer.mdx
+++ b/website/data/guides/virtualizer.mdx
@@ -68,6 +68,9 @@ const virtualizer = new ListVirtualizer({
   dir: "ltr",
   indexToKey: (index) => messages[index].id,
   keyToIndex: (key) => messageIndexById.get(key) ?? -1,
+  anchorTo: "end",
+  followOnAppend: true,
+  scrollEndThreshold: 80,
   onRangeChange: ({ range, reason }) => {
     // reason: "scroll" | "resize" | "measurement" | "count" | "manual"
     updateVisibleWindow(range, reason)
@@ -181,15 +184,29 @@ const virtualizer = new ListVirtualizer({
   estimatedSize: () => 20,
   indexToKey: (index) => items[index].id,
   keyToIndex: (key) => keyToIndexMap.get(key) ?? -1,
+  anchorTo: "end",
+  followOnAppend: true,
+  scrollEndThreshold: 80,
   shouldAdjustScrollOnSizeChange: ({ key, delta, viewportStart }) => {
     return isPrependedKey(key) && delta !== 0 && viewportStart > 0
   },
 })
 ```
 
+Chat-specific APIs:
+
+- `anchorTo: "end"` treats the end of the list as the stable edge. This is
+  useful for chat, logs, and reverse feeds.
+- `followOnAppend` scrolls to the end after appended items only when the
+  viewport was already within `scrollEndThreshold` of the end.
+- `scrollToEnd()`, `getDistanceFromEnd()`, and `isAtEnd()` power "Jump to
+  latest" controls with the same end-distance logic as `followOnAppend`.
+
 Practical pattern:
 
 1. Keep stable `indexToKey` / `keyToIndex`.
 2. Prepend data and update `count`.
 3. Re-measure prepended rows.
-4. Use `shouldAdjustScrollOnSizeChange` to decide when compensation applies.
+4. Use `anchorTo: "end"` and `followOnAppend` for latest-message behavior.
+5. Use `shouldAdjustScrollOnSizeChange` for custom compensation rules when
+   prepended or streamed rows resize.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## 📝 Description

Adds chat-oriented virtualizer options and helpers for end-anchored list experiences.

## ⛳️ Current behavior (updates)

List virtualization preserves top/start anchors and supports manual prepend compensation, but it does not expose a first-class end anchor, conditional append following, or end-distance helpers for chat UIs.

## 🚀 New behavior

- Adds `anchorTo`, `followOnAppend`, and `scrollEndThreshold` options.
- Adds `scrollToEnd()`, `getDistanceFromEnd()`, and `isAtEnd()` helpers.
- Keeps end-anchored viewports pinned when the latest row grows.
- Uses the attached scroll element for end-distance and end-scroll calculations when available.
- Hardens key restoration so `keyToIndex` `-1` results are treated as missing keys.
- Adds a full-width Next chat example with auto-load older history, manual load-older history, append/no-yank behavior, streamed replies, and a latest-message control.
- Keeps the chat example pinned to latest when manual history loading is triggered from the latest position, while preserving viewport position for near-top auto history loading.
- Adds unit coverage, virtualizer guide updates, and chat-focused E2E coverage.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Verification:

- `pnpm exec vitest packages/utilities/virtualizer/tests/list-virtualizer.test.ts --run`
- `pnpm --filter @zag-js/virtualizer typecheck`
- `pnpm build`
- `FRAMEWORK=react pnpm exec playwright test e2e/virtualizer.e2e.ts -g "(/virtualizer/chat|chat example)"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23e56926-d242-4985-af60-d19453e62736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23e56926-d242-4985-af60-d19453e62736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

