### PR TITLE
fix(toast): measure untransformed height in overlap mode

### DIFF
--- a/.changeset/toast-measure-untransformed-height.md
+++ b/.changeset/toast-measure-untransformed-height.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/toast": patch
+---
+
+Fix toast height measurement including the `scale` transform in overlap mode, causing a
+height flicker when expanding the stack. Height is now measured from the untransformed
+element.

--- a/packages/machines/toast/src/toast.machine.ts
+++ b/packages/machines/toast/src/toast.machine.ts
@@ -1,5 +1,5 @@
 import { createGuards, createMachine, type Service } from "@zag-js/core"
-import { raf } from "@zag-js/dom-query"
+import { raf, setStyle } from "@zag-js/dom-query"
 import { ensureProps, setRafTimeout } from "@zag-js/utils"
 import * as dom from "./toast.dom"
 import type { ToastGroupSchema, ToastHeight, ToastSchema } from "./toast.types"
@@ -192,11 +192,7 @@ export const machine = createMachine<ToastSchema>({
           if (!rootEl) return
 
           const syncHeight = () => {
-            const originalHeight = rootEl.style.height
-            rootEl.style.height = "auto"
-            const height = rootEl.getBoundingClientRect().height
-            rootEl.style.height = originalHeight
-
+            const height = measureLayoutHeight(rootEl)
             const item = { id: prop("id"), height }
             setHeight(prop("parent"), item)
           }
@@ -234,10 +230,7 @@ export const machine = createMachine<ToastSchema>({
           const rootEl = dom.getRootEl(scope)
           if (!rootEl) return
 
-          const originalHeight = rootEl.style.height
-          rootEl.style.height = "auto"
-          const height = rootEl.getBoundingClientRect().height
-          rootEl.style.height = originalHeight
+          const height = measureLayoutHeight(rootEl)
           context.set("initialHeight", height)
 
           const item = { id: prop("id"), height }
@@ -279,6 +272,13 @@ export const machine = createMachine<ToastSchema>({
     },
   },
 })
+
+function measureLayoutHeight(el: HTMLElement): number {
+  const restore = setStyle(el, { transition: "none", scale: "1", translate: "none", height: "auto" })
+  const height = el.getBoundingClientRect().height
+  restore()
+  return height
+}
 
 function setHeight(parent: Service<ToastGroupSchema>, item: ToastHeight) {
   const { id, height } = item


### PR DESCRIPTION
## Description

Fixes #3173.

In overlap mode, sibling toasts get a `scale` transform (and a `transition` on `scale`/`height`) on the root element via the consuming CSS. Both `measureHeight` and `trackHeight` read height via `getBoundingClientRect().height` on that **same** element, so the stored height included the scale (and could capture an interpolated value mid-transition). That wrong value feeds `--initial-height`/`heights`, causing the height flicker when the stack expands on hover after dismissing the frontmost toast.

## Fix

Extracted a `measureLayoutHeight` helper (used by both call sites) that neutralizes `transition`, `scale`, and `translate` (via `setStyle` from `@zag-js/dom-query`) before reading the untransformed layout height, then restores the inline styles synchronously — no flicker, no triggered transition.

## Testing

Verified in the browser on `/toast/overlap` across **all five frameworks** (React, Preact, Svelte, Vue/Nuxt, Solid). In each, the sibling toast renders at `scale: 0.95` and the patched machine now stores the untransformed layout height (e.g. 60px) instead of the scaled value (57px).

## Is this a breaking change?

No

🤖 Generated with [Claude Code](https://claude.com/claude-code)