### PR TITLE
fix(date-picker): reorder range dates entered via input on blur

### DIFF
--- a/.changeset/date-picker-normalize-range-on-blur.md
+++ b/.changeset/date-picker-normalize-range-on-blur.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-picker": patch
+---
+
+Adds date reordering on blur for range selection to match other selection paths.

--- a/e2e/date-picker.e2e.ts
+++ b/e2e/date-picker.e2e.ts
@@ -292,4 +292,19 @@ test.describe("datepicker [range]", () => {
     // Should not crash and the new value should be set
     await I.seeInputHasValue("06/15/2025", 1)
   })
+
+  test("normalizes reversed range dates entered via input on blur", async () => {
+    // Regression test for issue #3186
+    await I.focusInput(0)
+    await I.type("06/20/2024", 0)
+    await I.clickOutsideToBlur()
+
+    await I.focusInput(1)
+    await I.type("06/10/2024", 1)
+    await I.clickOutsideToBlur()
+
+    // dates entered in reverse order should be swapped, matching the Enter/click path
+    await I.seeInputHasValue("06/10/2024", 0)
+    await I.seeInputHasValue("06/20/2024", 1)
+  })
 })

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -1203,13 +1203,14 @@ export const machine = createMachine<DatePickerSchema>({
         date = constrainValue(date, prop("min"), prop("max"))
 
         const values = Array.from(context.get("value"))
-        values[event.index] = date
+        values[event.index] = preserveTime(values[event.index], date)
+        const adjustedValues = adjustStartAndEndDate(values)
 
-        context.set("value", values)
+        context.set("value", adjustedValues)
 
         // always sync the input value, even if the selecteddate is not changed
         // e.g. selected value is 02/28/2024, and the input value changed to 02/28
-        const valueAsString = getValueAsString(values, prop)
+        const valueAsString = getValueAsString(adjustedValues, prop)
         context.set("inputValue", valueAsString[event.index])
       },
 


### PR DESCRIPTION
Closes #3186 

## 📝 Description

The date picker's blur-validated input skips the checks that the Enter/click path applies.

## ⛳️ Current behavior (updates)

This means that:
1. range dates are not reordered when `start date` > `end date`;
2. unavailable dates can be committed.

## 🚀 New behavior

The blur selection path now applies the same checks as the other selection paths, i.e., date ranges are reordered if needed and unavailable dates are rejected (=reverted to the last committed value).

The PR has been split into two commits, so that the unavailable date change could be dropped if the current behavior is the desired one.

## 💣 Is this a breaking change (Yes/No):

No
