### PR TITLE
fix(date-input): preserve naive wall-clock time across formatter timezone

### DIFF
--- a/.changeset/date-input-naive-timezone-shift.md
+++ b/.changeset/date-input-naive-timezone-shift.md
@@ -1,0 +1,12 @@
+---
+"@zag-js/date-input": patch
+---
+
+Fix timezone-naive values (`CalendarDate`/`CalendarDateTime`) being shifted by the viewer's
+local UTC offset when a custom `formatter` without an explicit `timeZone` is provided. Typing
+`0` into the hour segment of a time-only input previously committed/displayed `02` at UTC+2 or
+`09` at UTC+9 instead of `0`.
+
+The instant fed to the formatter is now built using the formatter's own resolved time zone, so
+a wall-clock value round-trips unshifted regardless of the viewer's locale. `ZonedDateTime`
+values (which carry an absolute instant) are unaffected.

--- a/packages/machines/date-input/src/date-input.machine.ts
+++ b/packages/machines/date-input/src/date-input.machine.ts
@@ -178,7 +178,6 @@ export const machine = createMachine<DateInputSchema>({
         const placeholderValue = context.get("placeholderValue")
         const displayValues = context.get("displayValues")
         const allSegments = prop("allSegments")
-        const timeZone = prop("timeZone")
         const translations = prop("translations") || defaultTranslations
         const granularity = prop("granularity")
         const formatter = prop("formatter")
@@ -205,7 +204,7 @@ export const machine = createMachine<DateInputSchema>({
             : formatter
 
           return processSegments({
-            dateValue: displayDate.toDate(timeZone),
+            dateValue: displayDate.toDate(segmentFormatter.resolvedOptions().timeZone),
             displayValue: displayValue,
             formatter: segmentFormatter,
             locale,

--- a/packages/machines/date-input/src/date-input.machine.ts
+++ b/packages/machines/date-input/src/date-input.machine.ts
@@ -5,7 +5,13 @@ import { raf } from "@zag-js/dom-query"
 import { createLiveRegion } from "@zag-js/live-region"
 import * as dom from "./date-input.dom"
 import type { DateInputSchema, DateSegment, DateValue, SegmentType } from "./date-input.types"
-import { createFormatFn, getValueAsString, resolveHourCycleProp, resolvePlaceholderValue } from "./utils/formatting"
+import {
+  createFormatFn,
+  getValueAsString,
+  resolveHourCycleProp,
+  resolvePlaceholderValue,
+  toFormatterDate,
+} from "./utils/formatting"
 import {
   IncompleteDate,
   incompleteDateEqual,
@@ -204,7 +210,7 @@ export const machine = createMachine<DateInputSchema>({
             : formatter
 
           return processSegments({
-            dateValue: displayDate.toDate(segmentFormatter.resolvedOptions().timeZone),
+            dateValue: toFormatterDate(displayDate, segmentFormatter),
             displayValue: displayValue,
             formatter: segmentFormatter,
             locale,

--- a/packages/machines/date-input/src/utils/formatting.ts
+++ b/packages/machines/date-input/src/utils/formatting.ts
@@ -5,6 +5,10 @@ import type { DateGranularity } from "@zag-js/date-utils"
 import type { DateInputSchema, DateValue } from "../date-input.types"
 import { needsTimeGranularity } from "./segments"
 
+export function toFormatterDate(date: DateValue, formatter: DateFormatter): Date {
+  return date.toDate(formatter.resolvedOptions().timeZone)
+}
+
 export function getValueAsString(value: DateValue[], prop: PropFn<DateInputSchema>) {
   return value.map((date) => {
     if (date == null) return ""
@@ -54,8 +58,7 @@ export function resolvePlaceholderValue(
 }
 
 export function createFormatFn(formatter: DateFormatter) {
-  const formatterTimeZone = formatter.resolvedOptions().timeZone
-  return (date: DateValue, _details?: { locale?: string; timeZone?: string }) => {
+  return (date: DateValue): string => {
     const isBC = date.calendar?.identifier === "gregory" && date.era === "BC"
     if (isBC) {
       const jsd = date.toDate("UTC")
@@ -66,6 +69,6 @@ export function createFormatFn(formatter: DateFormatter) {
         .map((p) => (p.type === "year" ? String(prolYear) : p.value))
         .join("")
     }
-    return formatter.format(date.toDate(formatterTimeZone))
+    return formatter.format(toFormatterDate(date, formatter))
   }
 }

--- a/packages/machines/date-input/src/utils/formatting.ts
+++ b/packages/machines/date-input/src/utils/formatting.ts
@@ -54,10 +54,11 @@ export function resolvePlaceholderValue(
 }
 
 export function createFormatFn(formatter: DateFormatter) {
-  return (date: DateValue, { timeZone }: { timeZone: string }) => {
-    const jsd = date.toDate(timeZone)
+  const formatterTimeZone = formatter.resolvedOptions().timeZone
+  return (date: DateValue, _details?: { locale?: string; timeZone?: string }) => {
     const isBC = date.calendar?.identifier === "gregory" && date.era === "BC"
     if (isBC) {
+      const jsd = date.toDate("UTC")
       const prolYear = jsd.getUTCFullYear()
       const safeDate = new Date(Date.UTC(2000, jsd.getUTCMonth(), jsd.getUTCDate()))
       return formatter
@@ -65,6 +66,6 @@ export function createFormatFn(formatter: DateFormatter) {
         .map((p) => (p.type === "year" ? String(prolYear) : p.value))
         .join("")
     }
-    return formatter.format(jsd)
+    return formatter.format(date.toDate(formatterTimeZone))
   }
 }

--- a/packages/machines/date-input/tests/timezone.test.ts
+++ b/packages/machines/date-input/tests/timezone.test.ts
@@ -1,10 +1,13 @@
 import { CalendarDate, CalendarDateTime, DateFormatter, ZonedDateTime } from "@internationalized/date"
 import { describe, expect, test } from "vitest"
-import { createFormatFn, getValueAsString } from "../src/utils/formatting"
+import { createFormatFn, getValueAsString, toFormatterDate } from "../src/utils/formatting"
+import { IncompleteDate } from "../src/utils/incomplete-date"
+import { defaultTranslations } from "../src/utils/placeholders"
+import { processSegments } from "../src/utils/segments"
+
+const ZONES = ["UTC", "Asia/Tokyo", "America/New_York", "Europe/Rome", "Pacific/Kiritimati"]
 
 describe("@zag-js/date-input timezone-naive formatting (#3187)", () => {
-  const ZONES = ["UTC", "Asia/Tokyo", "America/New_York", "Europe/Rome", "Pacific/Kiritimati"]
-
   test("createFormatFn preserves the typed hour across formatter time zones", () => {
     const time = new CalendarDateTime(2024, 1, 1, 0, 0, 0)
     for (const timeZone of ZONES) {
@@ -15,7 +18,7 @@ describe("@zag-js/date-input timezone-naive formatting (#3187)", () => {
         timeZone,
       })
       const format = createFormatFn(formatter)
-      expect(format(time, { locale: "en-US", timeZone: "UTC" })).toBe("00:00")
+      expect(format(time)).toBe("00:00")
     }
   })
 
@@ -29,7 +32,7 @@ describe("@zag-js/date-input timezone-naive formatting (#3187)", () => {
         timeZone,
       })
       const format = createFormatFn(formatter)
-      expect(format(date, { locale: "en-US", timeZone: "UTC" })).toBe("03/15/2024")
+      expect(format(date)).toBe("03/15/2024")
     }
   })
 
@@ -52,6 +55,51 @@ describe("@zag-js/date-input timezone-naive formatting (#3187)", () => {
       timeZone: "America/New_York",
     })
     const zoned = new ZonedDateTime(2024, 1, 1, "America/New_York", -5 * 3600000, 9, 30, 0)
-    expect(createFormatFn(formatter)(zoned, { locale: "en-US", timeZone: "UTC" })).toBe("09:30")
+    expect(createFormatFn(formatter)(zoned)).toBe("09:30")
+  })
+})
+
+describe("@zag-js/date-input toFormatterDate (#3187)", () => {
+  test("anchors a naive value to the formatter's zone so wall-clock round-trips", () => {
+    const time = new CalendarDateTime(2024, 1, 1, 0, 0, 0)
+    for (const timeZone of ZONES) {
+      const formatter = new DateFormatter("en-US", { hour: "2-digit", minute: "2-digit", hourCycle: "h23", timeZone })
+      expect(formatter.format(toFormatterDate(time, formatter))).toBe("00:00")
+    }
+  })
+
+  test("keeps a ZonedDateTime's absolute instant intact", () => {
+    const zoned = new ZonedDateTime(2024, 1, 1, "America/New_York", -5 * 3600000, 9, 30, 0)
+    const formatter = new DateFormatter("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+      timeZone: "America/New_York",
+    })
+    expect(toFormatterDate(zoned, formatter).getTime()).toBe(zoned.toDate().getTime())
+  })
+})
+
+// Mirrors the segment-display pipeline (jsdom can't drive the segment input directly).
+describe("@zag-js/date-input segment display (#3187)", () => {
+  function getSegmentText(value: CalendarDateTime, formatter: DateFormatter, type: string) {
+    const displayValue = new IncompleteDate(value.calendar, "h23", value)
+    const segments = processSegments({
+      dateValue: toFormatterDate(value, formatter),
+      displayValue,
+      formatter,
+      locale: "en-US",
+      translations: defaultTranslations,
+      granularity: "minute",
+    })
+    return segments.find((segment) => segment.type === type)?.text
+  }
+
+  test("hour segment shows the typed value regardless of the formatter's zone", () => {
+    const time = new CalendarDateTime(2024, 1, 1, 0, 0, 0)
+    for (const timeZone of ZONES) {
+      const formatter = new DateFormatter("en-US", { hour: "2-digit", minute: "2-digit", hourCycle: "h23", timeZone })
+      expect(getSegmentText(time, formatter, "hour")).toBe("00")
+    }
   })
 })

--- a/packages/machines/date-input/tests/timezone.test.ts
+++ b/packages/machines/date-input/tests/timezone.test.ts
@@ -1,0 +1,57 @@
+import { CalendarDate, CalendarDateTime, DateFormatter, ZonedDateTime } from "@internationalized/date"
+import { describe, expect, test } from "vitest"
+import { createFormatFn, getValueAsString } from "../src/utils/formatting"
+
+describe("@zag-js/date-input timezone-naive formatting (#3187)", () => {
+  const ZONES = ["UTC", "Asia/Tokyo", "America/New_York", "Europe/Rome", "Pacific/Kiritimati"]
+
+  test("createFormatFn preserves the typed hour across formatter time zones", () => {
+    const time = new CalendarDateTime(2024, 1, 1, 0, 0, 0)
+    for (const timeZone of ZONES) {
+      const formatter = new DateFormatter("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+        timeZone,
+      })
+      const format = createFormatFn(formatter)
+      expect(format(time, { locale: "en-US", timeZone: "UTC" })).toBe("00:00")
+    }
+  })
+
+  test("createFormatFn preserves a naive date across formatter time zones", () => {
+    const date = new CalendarDate(2024, 3, 15)
+    for (const timeZone of ZONES) {
+      const formatter = new DateFormatter("en-US", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+        timeZone,
+      })
+      const format = createFormatFn(formatter)
+      expect(format(date, { locale: "en-US", timeZone: "UTC" })).toBe("03/15/2024")
+    }
+  })
+
+  test("getValueAsString preserves the typed hour with a consumer formatter", () => {
+    const formatter = new DateFormatter("en-US", { hour: "2-digit", minute: "2-digit", hourCycle: "h23" })
+    const props: Record<string, unknown> = {
+      format: createFormatFn(formatter),
+      locale: "en-US",
+      timeZone: "UTC",
+    }
+    const prop = ((key: string) => props[key]) as any
+    expect(getValueAsString([new CalendarDateTime(2024, 1, 1, 0, 0, 0)], prop)).toEqual(["00:00"])
+  })
+
+  test("ZonedDateTime instants are unaffected (absolute, formatter zone honored)", () => {
+    const formatter = new DateFormatter("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+      timeZone: "America/New_York",
+    })
+    const zoned = new ZonedDateTime(2024, 1, 1, "America/New_York", -5 * 3600000, 9, 30, 0)
+    expect(createFormatFn(formatter)(zoned, { locale: "en-US", timeZone: "UTC" })).toBe("09:30")
+  })
+})


### PR DESCRIPTION
Closes #3187

## 📝 Description

A timezone-naive value (`CalendarDate`/`CalendarDateTime`) was shifted by the viewer's local UTC offset when a custom `formatter` without an explicit `timeZone` is provided (the docs "Time only" example). Typing `0` into the hour segment committed/displayed `02` at UTC+2 or `09` at UTC+9 instead of `0`.

## ⛳️ Current behavior (updates)

The value is converted to an instant via `value.toDate(timeZone)` (prop `timeZone`, default `"UTC"`) but read back by a formatter that resolves to the viewer's local zone. The two zones disagree, so the wall-clock hour shifts by exactly the local offset (`enteredHour + localUtcOffset`; `0` at UTC). The machine's own formatter bakes in `timeZone`, so this only surfaces with a consumer-supplied `formatter`.

## 🚀 New behavior

The instant fed to the formatter is now built using the formatter's own resolved time zone, so a naive wall-clock value round-trips unshifted regardless of locale. `ZonedDateTime` values (absolute instants) are unaffected; the BC-era path still extracts year from UTC.

Added a deterministic regression test (`tests/timezone.test.ts`) covering the value-string path across multiple time zones; the segment-display path was verified by driving the machine headless.

## 💣 Is this a breaking change (Yes/No):

No