### PR TITLE
fix(date-picker): preserve active view when closing the calendar

### DIFF
--- a/.changeset/date-picker-preserve-view-on-close.md
+++ b/.changeset/date-picker-preserve-view-on-close.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-picker": patch
+---
+
+Fix day view briefly flashing when closing the date picker from the month or year view.

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -362,7 +362,7 @@ export const machine = createMachine<DatePickerSchema>({
       on: {
         "CONTROLLED.OPEN": {
           target: "open",
-          actions: ["focusFirstSelectedDate", "focusActiveCell"],
+          actions: ["resetView", "focusFirstSelectedDate", "focusActiveCell"],
         },
         "TRIGGER.CLICK": [
           {
@@ -371,7 +371,7 @@ export const machine = createMachine<DatePickerSchema>({
           },
           {
             target: "open",
-            actions: ["focusFirstSelectedDate", "focusActiveCell", "invokeOnOpen"],
+            actions: ["resetView", "focusFirstSelectedDate", "focusActiveCell", "invokeOnOpen"],
           },
         ],
         OPEN: [
@@ -381,7 +381,7 @@ export const machine = createMachine<DatePickerSchema>({
           },
           {
             target: "open",
-            actions: ["focusFirstSelectedDate", "focusActiveCell", "invokeOnOpen"],
+            actions: ["resetView", "focusFirstSelectedDate", "focusActiveCell", "invokeOnOpen"],
           },
         ],
       },
@@ -392,7 +392,7 @@ export const machine = createMachine<DatePickerSchema>({
       on: {
         "CONTROLLED.OPEN": {
           target: "open",
-          actions: ["focusFirstSelectedDate", "focusActiveCell"],
+          actions: ["resetView", "focusFirstSelectedDate", "focusActiveCell"],
         },
         "TRIGGER.CLICK": [
           {
@@ -401,7 +401,7 @@ export const machine = createMachine<DatePickerSchema>({
           },
           {
             target: "open",
-            actions: ["focusFirstSelectedDate", "focusActiveCell", "invokeOnOpen"],
+            actions: ["resetView", "focusFirstSelectedDate", "focusActiveCell", "invokeOnOpen"],
           },
         ],
         OPEN: [
@@ -411,7 +411,7 @@ export const machine = createMachine<DatePickerSchema>({
           },
           {
             target: "open",
-            actions: ["focusFirstSelectedDate", "focusActiveCell", "invokeOnOpen"],
+            actions: ["resetView", "focusFirstSelectedDate", "focusActiveCell", "invokeOnOpen"],
           },
         ],
       },
@@ -420,7 +420,7 @@ export const machine = createMachine<DatePickerSchema>({
     open: {
       tags: ["open"],
       effects: ["trackDismissableElement", "trackPositioning"],
-      exit: ["clearHoveredDate", "resetView"],
+      exit: ["clearHoveredDate"],
       on: {
         "CONTROLLED.CLOSE": [
           {


### PR DESCRIPTION
Closes #3188 

## 📝 Description

This PR adds `resetView` in the `open` paths and removes it from the `exit` path.

## ⛳️ Current behavior (updates)

Quoting the issue: "When clicking outside the datepicker while the view is set to either month or year, the day view flashes on close."

## 🚀 New behavior

The current view remains active when closing the calendar.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This is impossible to test with the current e2e setup. HMU if you want to add a machine-only setup.