### PR TITLE
fix(date-picker): preserve active view when closing the calendar

### DIFF
--- a/.changeset/date-picker-preserve-view-on-close.md
+++ b/.changeset/date-picker-preserve-view-on-close.md
@@ -1,0 +1,8 @@
+---
+"@zag-js/date-picker": patch
+---
+
+Fix the calendar briefly flashing the day view when closing while on the month or year view.
+The active view was reset on close (during the exit animation), so the day view became visible
+for the duration of the close. The view is now reset when the picker opens instead, preserving
+the current view through the close animation.

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -419,8 +419,9 @@ export const machine = createMachine<DatePickerSchema>({
 
     open: {
       tags: ["open"],
+      entry: ["resetView"],
       effects: ["trackDismissableElement", "trackPositioning"],
-      exit: ["clearHoveredDate", "resetView"],
+      exit: ["clearHoveredDate"],
       on: {
         "CONTROLLED.CLOSE": [
           {


### PR DESCRIPTION
Closes #3188

## 📝 Description

When the calendar is on the month or year view and is closed (e.g. by clicking outside), the day view briefly flashes during the close.

## ⛳️ Current behavior (updates)

`resetView` runs on the `open` state's `exit`, so the view is reset to its initial value (`day`) as part of the close transition — while the content is still mounted for the exit animation. The user sees the month/year view swap to the day view for the duration of the close.

## 🚀 New behavior

`resetView` now runs on the `open` state's `entry` instead of `exit`. The current view is preserved through the close animation, and is reset (to `defaultView`) the next time the picker opens — so reopening still starts on the default view.

## 💣 Is this a breaking change (Yes/No):

No