### PR TITLE
fix(drawer): prevent backdrop flickering when using an async open setter

### DIFF
--- a/.changeset/ninety-bushes-fold.md
+++ b/.changeset/ninety-bushes-fold.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/drawer": patch
+---
+
+fix(drawer): prevent backdrop flickering when using an async open setter

--- a/packages/machines/drawer/src/drawer.machine.ts
+++ b/packages/machines/drawer/src/drawer.machine.ts
@@ -514,7 +514,10 @@ export const machine = createMachine<DrawerSchema>({
         backdropEl.style.setProperty("animation", "none", "important")
       },
 
-      clearSwipeOpenAnimation({ scope }) {
+      clearSwipeOpenAnimation({ scope, event, prop }) {
+        // Skip when an `onOpenChange` handler can drive the close. It prevents
+        // running animations before the drawer actually starts to close.
+        if (prop("onOpenChange") != null && event.type != "CONTROLLED.CLOSE") return
         const contentEl = dom.getContentEl(scope)
         const backdropEl = dom.getBackdropEl(scope)
         if (contentEl) contentEl.style.removeProperty("animation")


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Fixes the backdrop part in #3149.

## ⛳️ Current behavior (updates)

Currently, `deferClearDragOffset` adds `animation: none !important` to the backdrop node, `clearSwipeOpenAnimation` is intended to clear this style, but due to a timing issue, it runs before the `CONTROLLED.CLOSE` event is received, and since the drawer is not yet in closing state, the opening animation runs.

## 🚀 New behavior

Now, if there is a defined `onOpenChange` prop, `clearSwipeOpenAnimation` only runs when the `CONTROLLED.CLOSE` event is received.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
