### PR TITLE
fix(color-picker): ignore Enter during IME composition in channel input

### DIFF
--- a/.changeset/quiet-pillows-cross.md
+++ b/.changeset/quiet-pillows-cross.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/color-picker": patch
+---
+
+Fix the color channel input committing a partial value when `Enter` is pressed to confirm an IME composition.

--- a/packages/machines/color-picker/src/color-picker.connect.ts
+++ b/packages/machines/color-picker/src/color-picker.connect.ts
@@ -1,5 +1,5 @@
 import { getColorAreaGradient, normalizeColor } from "@zag-js/color-utils"
-import { getEventKey, getEventPoint, getEventStep, isLeftClick, isModifierKey } from "@zag-js/dom-query"
+import { getEventKey, getEventPoint, getEventStep, isComposingEvent, isLeftClick, isModifierKey } from "@zag-js/dom-query"
 import { dataAttr, query, visuallyHiddenStyle } from "@zag-js/dom-query"
 import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { NormalizeProps, PropTypes, EventKeyMap } from "@zag-js/types"
@@ -583,6 +583,7 @@ export function connect<T extends PropTypes>(
         onKeyDown(event) {
           if (event.defaultPrevented) return
           if (!interactive) return
+          if (isComposingEvent(event)) return
           if (event.key === "Enter") {
             const value = isTextField ? event.currentTarget.value : event.currentTarget.valueAsNumber
             send({ type: "CHANNEL_INPUT.CHANGE", channel, value, isTextField })


### PR DESCRIPTION
The color channel input commits its value on `Enter`:

```ts
onKeyDown(event) {
  if (event.defaultPrevented) return
  if (!interactive) return
  if (event.key === "Enter") {
    const value = isTextField ? event.currentTarget.value : event.currentTarget.valueAsNumber
    send({ type: "CHANNEL_INPUT.CHANGE", channel, value, isTextField })
    event.preventDefault()
  }
}
```

The `hex` and `css` channels are plain text fields. When an IME is active (Japanese, Chinese, Korean), the `Enter` that confirms a composition reaches this handler before the text is finalized, so a partial value is committed and the confirmation key is swallowed.

The number input already guards this with `isComposingEvent`:

```ts
// packages/machines/number-input/src/number-input.connect.ts
if (event.defaultPrevented) return
if (readOnly) return
if (isComposingEvent(event)) return
```

This applies the same guard to the channel input. When no IME is active `isComposingEvent` returns `false`, so normal `Enter` behavior is unchanged.

Verified the handler logic against `isComposingEvent` directly: a composing `Enter` (via `isComposing` or `keyCode === 229`) is now ignored, while a plain `Enter` still commits. I was not able to run the Playwright suite in this environment.
