### PR TITLE
fix(Tabs): incorrect ValueChangeDetails type

### DIFF
--- a/packages/machines/tabs/src/tabs.machine.ts
+++ b/packages/machines/tabs/src/tabs.machine.ts
@@ -33,7 +33,7 @@ export const machine = createMachine({
         defaultValue: prop("defaultValue"),
         value: prop("value"),
         onChange(value) {
-          prop("onValueChange")?.({ value: value! })
+          prop("onValueChange")?.({ value })
         },
       })),
       focusedValue: bindable(() => ({

--- a/packages/machines/tabs/src/tabs.types.ts
+++ b/packages/machines/tabs/src/tabs.types.ts
@@ -6,7 +6,7 @@ import type { CommonProperties, DirectionProperty, PropTypes, Rect, RequiredBy }
  * -----------------------------------------------------------------------------*/
 
 export interface ValueChangeDetails {
-  value: string
+  value: string | null // null when deselected
 }
 
 export interface FocusChangeDetails {


### PR DESCRIPTION
## 📝 Description

Incorrect type annotations for `ValueChangeDetails` of tab

## ⛳️ Current behavior (updates)
Marked as `string`

## 🚀 New behavior
Marked as `string | null` (null when deselected)

## 💣 Is this a breaking change (Yes/No):
Yes for typescript users.

## 📝 Additional Information
