### PR TITLE
feat(splitter): support data-collapsed attr

### DIFF
--- a/packages/docs/data/data-attr.json
+++ b/packages/docs/data/data-attr.json
@@ -1863,6 +1863,7 @@
       "data-part": "panel",
       "data-orientation": "The orientation of the panel",
       "data-dragging": "Present when in the dragging state",
+      "data-collapsed": "Present when collapsed",
       "data-id": "",
       "data-index": "The index of the item"
     },

--- a/packages/machines/splitter/src/splitter.connect.ts
+++ b/packages/machines/splitter/src/splitter.connect.ts
@@ -77,6 +77,16 @@ export function connect<T extends PropTypes>(service: SplitterService, normalize
     }
   }
 
+  const isPanelCollapsed = (id: string): boolean => {
+    const panels = context.get("panels")
+    const size = getResolvedSizes()
+    const panelData = getPanelById(panels, id)
+
+    const { collapsedSize = 0, collapsible, panelSize } = panelDataHelper(panels, panelData, size)
+    ensure(panelSize != null, () => `Panel size not found for panel "${panelData.id}"`)
+    return collapsible === true && fuzzyNumbersEqual(panelSize, collapsedSize)
+  }
+
   return {
     dragging,
     orientation,
@@ -126,15 +136,7 @@ export function connect<T extends PropTypes>(service: SplitterService, normalize
 
       return panelSize
     },
-    isPanelCollapsed(id) {
-      const panels = context.get("panels")
-      const size = getResolvedSizes()
-      const panelData = getPanelById(panels, id)
-
-      const { collapsedSize = 0, collapsible, panelSize } = panelDataHelper(panels, panelData, size)
-      ensure(panelSize != null, () => `Panel size not found for panel "${panelData.id}"`)
-      return collapsible === true && fuzzyNumbersEqual(panelSize, collapsedSize)
-    },
+    isPanelCollapsed,
     isPanelExpanded(id) {
       const panels = context.get("panels")
       const size = getResolvedSizes()
@@ -172,6 +174,7 @@ export function connect<T extends PropTypes>(service: SplitterService, normalize
         ...parts.panel.attrs,
         "data-orientation": orientation,
         "data-dragging": dataAttr(dragging),
+        "data-collapsed": dataAttr(isPanelCollapsed(id)),
         dir: prop("dir"),
         "data-id": id,
         "data-index": findPanelIndex(prop("panels"), id),


### PR DESCRIPTION
## 📝 Description

> Add `data-collapsed` data attribute to splitter's panels.

## 🚀 New behavior

> When a given splitter panel gets collapsed, it toggles the booleanish data attribute `data-collapsed`.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

This simple change can be very helpful to, for instance, control the styling of the panel with CSS only, based on whether it's collapsed or not. Overall it's behavior that should probably be exposed.