### PR TITLE
fix(date-picker): match keyboard range selection to pointer behavior

### DIFF
--- a/.changeset/date-picker-range-keyboard.md
+++ b/.changeset/date-picker-range-keyboard.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-picker": patch
+---
+
+Fix keyboard range selection to match the pointer behavior.

--- a/.changeset/date-picker-resume-range.md
+++ b/.changeset/date-picker-resume-range.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-picker": patch
+---
+
+Resume range selection when reopening the calendar with an incomplete range.

--- a/e2e/date-picker.e2e.ts
+++ b/e2e/date-picker.e2e.ts
@@ -343,6 +343,26 @@ test.describe("datepicker [range]", () => {
     await expect(I.todayCell).toHaveAttribute("data-range-start", "")
     await expect(I.getNextDayCell()).toHaveAttribute("data-in-hover-range", "")
   })
+
+  test("reopening with only a start date resumes range selection", async () => {
+    const start = I.getDate({ day: 10 })
+    const end = I.getDate({ day: 20 })
+
+    // commit only a start date, then click outside
+    await I.clickTrigger()
+    await I.seeContent()
+    await I.clickDayCell(10)
+    await I.clickOutsideToBlur()
+    await I.seeInputHasValue(start.formatted, 0)
+    await I.seeInputHasValue("", 1)
+
+    // reopening and picking another date should complete the range
+    await I.clickTrigger()
+    await I.seeContent()
+    await I.clickDayCell(20)
+    await I.seeInputHasValue(start.formatted, 0)
+    await I.seeInputHasValue(end.formatted, 1)
+  })
 })
 
 test.describe("datepicker [locale numerals]", () => {

--- a/e2e/date-picker.e2e.ts
+++ b/e2e/date-picker.e2e.ts
@@ -307,6 +307,42 @@ test.describe("datepicker [range]", () => {
     await I.seeInputHasValue("06/10/2024", 0)
     await I.seeInputHasValue("06/20/2024", 1)
   })
+
+  test("Enter on a completed range starts a new range instead of keeping the old end", async () => {
+    // create initial range
+    await I.focusInput(0)
+    await I.type("06/10/2024", 0)
+    await I.clickOutsideToBlur()
+    await I.focusInput(1)
+    await I.type("06/20/2024", 1)
+    await I.clickOutsideToBlur()
+    await I.seeInputHasValue("06/10/2024", 0)
+    await I.seeInputHasValue("06/20/2024", 1)
+
+    // reopen and pick a new date with the keyboard
+    await I.clickTrigger()
+    await I.seeContent()
+    await I.seeDayCellIsFocused("2024-06-10")
+    await I.pressKey("ArrowRight")
+    await I.seeDayCellIsFocused("2024-06-11")
+    await I.pressKey("Enter")
+
+    // should reset to a single new start, stay open and move to the next day
+    await I.seeInputHasValue("06/11/2024", 0)
+    await I.seeInputHasValue("", 1)
+    await I.seeContent()
+    await I.seeDayCellIsFocused("2024-06-12")
+  })
+
+  test("selecting a range start with Enter previews the range band", async () => {
+    await I.clickTrigger()
+    await I.seeContent()
+    await I.seeTodayCellIsFocused()
+    await I.pressKey("Enter")
+    // the start is selected and the band previews to the next focused day, without moving first
+    await expect(I.todayCell).toHaveAttribute("data-range-start", "")
+    await expect(I.getNextDayCell()).toHaveAttribute("data-in-hover-range", "")
+  })
 })
 
 test.describe("datepicker [locale numerals]", () => {

--- a/e2e/models/datepicker.model.ts
+++ b/e2e/models/datepicker.model.ts
@@ -253,4 +253,12 @@ export class DatePickerModel extends Model {
   seeFocusedValue(value: string) {
     return expect(this.page.locator(".date-output")).toContainText(`Focused: ${value}`)
   }
+
+  getDayCellByValue(value: string) {
+    return this.page.locator(`${part("table-cell-trigger")}[data-view=day][data-value="${value}"]`)
+  }
+
+  seeDayCellIsFocused(value: string) {
+    return expect(this.getDayCellByValue(value)).toBeFocused()
+  }
 }

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -539,7 +539,7 @@ export const machine = createMachine<DatePickerSchema>({
           },
           {
             guard: and("isRangePicker", "hasSelectedRange"),
-            actions: ["setActiveIndexToStart", "clearDateValue", "setSelectedDate", "setActiveIndexToEnd"],
+            actions: ["setActiveIndexToStart", "resetSelection", "setActiveIndexToEnd", "focusNextDay"],
           },
           // === Grouped transitions (based on `closeOnSelect` and `isOpenControlled`) ===
           {
@@ -1109,12 +1109,10 @@ export const machine = createMachine<DatePickerSchema>({
         })
       },
       setHoveredValueIfKeyboard({ context, event, prop }) {
-        if (
-          !event.type.startsWith("TABLE.ARROW") ||
-          prop("selectionMode") !== "range" ||
-          context.get("activeIndex") === 0
-        )
-          return
+        const isKeyboardNavigation =
+          event.type.startsWith("TABLE.ARROW") ||
+          ["TABLE.ENTER", "TABLE.HOME", "TABLE.END", "TABLE.PAGE_UP", "TABLE.PAGE_DOWN"].includes(event.type)
+        if (!isKeyboardNavigation || prop("selectionMode") !== "range" || context.get("activeIndex") === 0) return
         context.set("hoveredValue", context.get("focusedValue").copy())
       },
       focusTriggerElement({ scope }) {

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -419,6 +419,7 @@ export const machine = createMachine<DatePickerSchema>({
 
     open: {
       tags: ["open"],
+      entry: ["resumeRangeSelection"],
       effects: ["trackDismissableElement", "trackPositioning"],
       exit: ["clearHoveredDate"],
       on: {
@@ -1093,6 +1094,11 @@ export const machine = createMachine<DatePickerSchema>({
       },
       setActiveIndexToStart({ context }) {
         context.set("activeIndex", 0)
+      },
+      resumeRangeSelection({ context, prop }) {
+        if (prop("selectionMode") === "range" && context.get("value").length === 1) {
+          context.set("activeIndex", 1)
+        }
       },
       focusActiveCell({ scope, context, event }) {
         if (event.src === "input.click") return


### PR DESCRIPTION
## 📝 Description

This PR fixes the datepicker's keyboard range selection to match the pointer behavior. It also includes code to resume an incomplete range when reopening the calendar.

## ⛳️ Current behavior (updates)

When the datepicker is set with `selectionMode: "range"`:
1. If a range already exists, using the keyboard to reopen the calendar, navigate and select a new date incorrectly updates the current range and keeps the calendar open, instead of creating a new range (mouse behavior).
2. When the previous point is fixed, selecting a date for a new range does not move focus to the next day, which is the behavior when creating a new range from an empty selection.
3. The "range band" is not highlighted when creating ranges using non-arrow keys (e.g., <kbd>Home</kbd>/<kbd>End</kbd> or <kbd>PgUp</kbd>/<kbd>PgDown</kbd>), contrary to mouse behavior.
4. Additionally, committing only a start date (keyboard or mouse) by selecting a day then clicking outside to close the calendar, does not allow users to complete the range when reopening it, as selecting another day starts a new range.

(All these scenarios can be reproduced locally or on the [Chakra example page](https://chakra-ui.com/docs/components/date-picker#range-selection).)

## 🚀 New behavior

1. `resetSelection` is used in keyboard navigation as it is with mouse navigation.
2. `focusNextDay` is used when we're in this scenario.
3. `setHoveredValueIfKeyboard` takes navigation using non-arrow keys into account.
4. `resumeRangeSelection` added to cater to this particular scenario.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The fourth point is a UX judgment call. As such, it has been isolated in a separate commit should you want to drop it and keep the current behavior.