### PR TITLE
fix(hover-card): keep open while pointer crosses gap between trigger and content

### DIFF
--- a/.changeset/short-lamps-brake.md
+++ b/.changeset/short-lamps-brake.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/hover-card": patch
+---
+
+Fix issue where hover card closes when the pointer crosses the gap between the trigger and the content (e.g. when using
+`positioning.gutter`). The close delay is now paused while the pointer travels across the grace area between both
+elements.

--- a/e2e/hover-card.e2e.ts
+++ b/e2e/hover-card.e2e.ts
@@ -97,3 +97,76 @@ test("should remain open after moving from content back to trigger", async ({ pa
   await page.hover(trigger)
   await expect(page.locator(content)).toBeVisible()
 })
+
+test("should remain open when pointer crosses the gutter gap slowly (trigger to content)", async ({ page }) => {
+  await page.hover(trigger)
+  await page.waitForSelector(content)
+  await expect(page.locator(content)).toBeVisible()
+
+  const triggerBox = await page.locator(trigger).boundingBox()
+  const contentBox = await page.locator(content).boundingBox()
+  if (!triggerBox || !contentBox) throw new Error("missing bounding boxes")
+
+  // walk straight down from the trigger into the gutter gap, pausing between
+  // steps so the traversal takes longer than the default `closeDelay` (300ms)
+  const x = triggerBox.x + triggerBox.width / 2
+  const startY = triggerBox.y + triggerBox.height - 1
+  const endY = contentBox.y + 1
+
+  await page.mouse.move(x, startY)
+  const steps = Math.max(6, Math.ceil(Math.abs(endY - startY) / 2))
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(x, startY + ((endY - startY) * i) / steps)
+    await page.waitForTimeout(100)
+    expect(await page.locator(content).isVisible()).toBe(true)
+  }
+})
+
+test("should close when pointer leaves the grace area between trigger and content", async ({ page }) => {
+  await page.hover(trigger)
+  await page.waitForSelector(content)
+  await expect(page.locator(content)).toBeVisible()
+
+  const triggerBox = await page.locator(trigger).boundingBox()
+  const contentBox = await page.locator(content).boundingBox()
+  if (!triggerBox || !contentBox) throw new Error("missing bounding boxes")
+
+  // move into the gutter gap and linger past the default `closeDelay` (300ms)
+  const x = triggerBox.x + triggerBox.width / 2
+  const y = (triggerBox.y + triggerBox.height + contentBox.y) / 2
+  await page.mouse.move(x, y - 2)
+  await page.mouse.move(x, y)
+  await page.waitForTimeout(400)
+  expect(await page.locator(content).isVisible()).toBe(true)
+
+  // veer away from the trigger and content
+  await page.mouse.move(x - 200, y, { steps: 5 })
+  await expect(page.locator(content)).toBeHidden()
+})
+
+test("should remain open when pointer crosses the gutter gap slowly (content to trigger)", async ({ page }) => {
+  await page.hover(trigger)
+  await page.waitForSelector(content)
+  await expect(page.locator(content)).toBeVisible()
+
+  await page.hover(content)
+  await expect(page.locator(content)).toBeVisible()
+
+  const triggerBox = await page.locator(trigger).boundingBox()
+  const contentBox = await page.locator(content).boundingBox()
+  if (!triggerBox || !contentBox) throw new Error("missing bounding boxes")
+
+  // walk straight up from the content into the gutter gap, pausing between
+  // steps so the traversal takes longer than the default `closeDelay` (300ms)
+  const x = triggerBox.x + triggerBox.width / 2
+  const startY = contentBox.y + 1
+  const endY = triggerBox.y + triggerBox.height - 1
+
+  await page.mouse.move(x, startY)
+  const steps = Math.max(6, Math.ceil(Math.abs(endY - startY) / 2))
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(x, startY + ((endY - startY) * i) / steps)
+    await page.waitForTimeout(100)
+    expect(await page.locator(content).isVisible()).toBe(true)
+  }
+})

--- a/packages/machines/hover-card/package.json
+++ b/packages/machines/hover-card/package.json
@@ -39,6 +39,7 @@
     "@zag-js/utils": "workspace:*",
     "@zag-js/dismissable": "workspace:*",
     "@zag-js/popper": "workspace:*",
+    "@zag-js/rect-utils": "workspace:*",
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/machines/hover-card/src/hover-card.connect.ts
+++ b/packages/machines/hover-card/src/hover-card.connect.ts
@@ -1,4 +1,4 @@
-import { dataAttr } from "@zag-js/dom-query"
+import { dataAttr, getEventPoint } from "@zag-js/dom-query"
 import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { NormalizeProps, PropTypes } from "@zag-js/types"
 import { parts } from "./hover-card.anatomy"
@@ -78,7 +78,7 @@ export function connect<T extends PropTypes>(service: HoverCardService, normaliz
         onPointerLeave(event) {
           if (event.pointerType === "touch") return
           if (prop("disabled")) return
-          send({ type: "POINTER_LEAVE", src: "trigger" })
+          send({ type: "POINTER_LEAVE", src: "trigger", point: getEventPoint(event) })
         },
         onFocus() {
           if (prop("disabled")) return
@@ -122,7 +122,7 @@ export function connect<T extends PropTypes>(service: HoverCardService, normaliz
         onPointerLeave(event) {
           if (event.pointerType === "touch") return
           if (prop("disabled")) return
-          send({ type: "POINTER_LEAVE", src: "content" })
+          send({ type: "POINTER_LEAVE", src: "content", point: getEventPoint(event) })
         },
       })
     },

--- a/packages/machines/hover-card/src/hover-card.machine.ts
+++ b/packages/machines/hover-card/src/hover-card.machine.ts
@@ -1,8 +1,12 @@
 import { createGuards, createMachine } from "@zag-js/core"
 import { trackDismissableElement } from "@zag-js/dismissable"
-import { getPlacement } from "@zag-js/popper"
+import { addDomEvent, getEventPoint } from "@zag-js/dom-query"
+import { getPlacement, getPlacementSide } from "@zag-js/popper"
+import { closestSideToPoint, createRect, isPointInPolygon, type Point } from "@zag-js/rect-utils"
+import { callAll } from "@zag-js/utils"
 import * as dom from "./hover-card.dom"
 import type { HoverCardSchema, Placement } from "./hover-card.types"
+import { createGraceArea, getOppositeSide } from "./hover-card.utils"
 
 const { not, and } = createGuards<HoverCardSchema>()
 
@@ -50,6 +54,12 @@ export const machine = createMachine<HoverCardSchema>({
     }
   },
 
+  refs() {
+    return {
+      graceArea: null,
+    }
+  },
+
   watch({ track, context, action, prop, send }) {
     track([() => prop("disabled")], () => {
       if (prop("disabled")) {
@@ -70,7 +80,7 @@ export const machine = createMachine<HoverCardSchema>({
   states: {
     closed: {
       tags: ["closed"],
-      entry: ["clearIsPointer"],
+      entry: ["clearIsPointer", "clearGraceArea"],
       on: {
         "CONTROLLED.OPEN": {
           target: "open",
@@ -163,6 +173,7 @@ export const machine = createMachine<HoverCardSchema>({
         },
         POINTER_LEAVE: {
           target: "closing",
+          actions: ["setGraceArea"],
         },
         CLOSE: [
           {
@@ -193,18 +204,26 @@ export const machine = createMachine<HoverCardSchema>({
 
     closing: {
       tags: ["open"],
-      effects: ["trackPositioning", "waitForCloseDelay"],
+      effects: ["trackPositioning", "waitForCloseDelay", "trackGraceArea"],
       on: {
         CLOSE_DELAY: [
           {
-            guard: "isOpenControlled",
+            guard: and("isOpenControlled", not("isPointerInTransit")),
             actions: ["invokeOnClose"],
           },
           {
+            guard: not("isPointerInTransit"),
             target: "closed",
             actions: ["invokeOnClose"],
           },
         ],
+        "GRACE_AREA.EXIT": {
+          // restart the close delay now that the pointer is no longer
+          // moving towards the content (or trigger)
+          target: "closing",
+          reenter: true,
+          actions: ["clearGraceArea"],
+        },
         "CONTROLLED.CLOSE": {
           target: "closed",
         },
@@ -214,7 +233,7 @@ export const machine = createMachine<HoverCardSchema>({
         POINTER_ENTER: {
           target: "open",
           // no need to invokeOnOpen here because it's still open (but about to close)
-          actions: ["setIsPointer"],
+          actions: ["setIsPointer", "clearGraceArea"],
         },
         TRIGGER_FOCUS: {
           target: "open",
@@ -232,6 +251,7 @@ export const machine = createMachine<HoverCardSchema>({
     guards: {
       isPointer: ({ context }) => !!context.get("isPointer"),
       isOpenControlled: ({ prop }) => prop("open") != null,
+      isPointerInTransit: ({ refs }) => refs.get("graceArea") != null,
     },
 
     effects: {
@@ -249,6 +269,26 @@ export const machine = createMachine<HoverCardSchema>({
         }, prop("closeDelay"))
 
         return () => clearTimeout(id)
+      },
+
+      trackGraceArea({ send, refs, scope }) {
+        if (!refs.get("graceArea")) return
+
+        const onPointerMove = (event: PointerEvent) => {
+          const graceArea = refs.get("graceArea")
+          if (!graceArea) return
+          if (isPointInPolygon(graceArea, getEventPoint(event))) return
+          send({ type: "GRACE_AREA.EXIT" })
+        }
+
+        const onPointerLeave = () => {
+          // the pointer left the document, so it can no longer be moving
+          // towards the content (or trigger)
+          send({ type: "GRACE_AREA.EXIT" })
+        }
+
+        const doc = scope.getDoc()
+        return callAll(addDomEvent(doc, "pointermove", onPointerMove), addDomEvent(doc, "pointerleave", onPointerLeave))
       },
 
       trackPositioning({ context, prop, scope }) {
@@ -297,6 +337,38 @@ export const machine = createMachine<HoverCardSchema>({
       },
       clearIsPointer({ context }) {
         context.set("isPointer", false)
+      },
+      setGraceArea({ context, event, refs, scope }) {
+        const point = event.point
+        const placement = context.get("currentPlacement")
+
+        let graceArea: Point[] | null = null
+
+        if (point && placement) {
+          // protect the path between the element the pointer left and the
+          // element it may be moving towards
+          const side = getPlacementSide(placement)
+          const fromContent = event.src === "content"
+          const targetSide = fromContent ? getOppositeSide(side) : side
+
+          const triggerEl = dom.getActiveTriggerEl(scope, context.get("triggerValue"))
+          const contentEl = dom.getContentEl(scope)
+          const exitedEl = fromContent ? contentEl : triggerEl
+          const targetEl = fromContent ? triggerEl : contentEl
+
+          // create the grace area only if the pointer left towards the target
+          // element (and not, say, in the opposite direction)
+          const exitSide = exitedEl ? closestSideToPoint(createRect(exitedEl.getBoundingClientRect()), point) : null
+
+          if (targetEl && exitSide === targetSide) {
+            graceArea = createGraceArea(point, targetSide, targetEl.getBoundingClientRect())
+          }
+        }
+
+        refs.set("graceArea", graceArea)
+      },
+      clearGraceArea({ refs }) {
+        refs.set("graceArea", null)
       },
       reposition({ context, prop, scope, event }) {
         const getPositionerEl = () => dom.getPositionerEl(scope)

--- a/packages/machines/hover-card/src/hover-card.types.ts
+++ b/packages/machines/hover-card/src/hover-card.types.ts
@@ -1,6 +1,7 @@
 import type { EventObject, Machine, Service } from "@zag-js/core"
 import type { InteractOutsideHandlers } from "@zag-js/dismissable"
 import type { Placement, PositioningOptions } from "@zag-js/popper"
+import type { Point } from "@zag-js/rect-utils"
 import type { CommonProperties, DirectionProperty, PropTypes, RequiredBy } from "@zag-js/types"
 
 /* -----------------------------------------------------------------------------
@@ -105,9 +106,18 @@ interface PrivateContext {
   triggerValue: string | null
 }
 
+interface Refs {
+  /**
+   * The polygon area between the trigger and the content, used to keep the
+   * hover card open while the pointer travels across the gap between them
+   */
+  graceArea: Point[] | null
+}
+
 export interface HoverCardSchema {
   props: RequiredBy<HoverCardProps, PropsWithDefault>
   context: PrivateContext
+  refs: Refs
   state: "opening" | "open" | "closing" | "closed"
   tag: "open" | "closed"
   action: string

--- a/packages/machines/hover-card/src/hover-card.utils.ts
+++ b/packages/machines/hover-card/src/hover-card.utils.ts
@@ -1,0 +1,62 @@
+import type { PlacementSide } from "@zag-js/popper"
+import { getElementPolygon, type Point, type RectInit } from "@zag-js/rect-utils"
+
+const oppositeSideMap: Record<PlacementSide, PlacementSide> = {
+  top: "bottom",
+  bottom: "top",
+  left: "right",
+  right: "left",
+}
+
+export function getOppositeSide(side: PlacementSide): PlacementSide {
+  return oppositeSideMap[side]
+}
+
+/**
+ * Returns a polygon that covers the area between the exit point and the target
+ * element, so the pointer can safely travel across the gap between the trigger
+ * and the content (e.g. when `positioning.gutter` is set) without closing the
+ * hover card.
+ *
+ * @param exitPoint - the point where the pointer left the element
+ * @param side - the side of the exit point on which the target element sits
+ * @param targetRect - the rect of the element the pointer may be moving towards
+ * @param padding - forgiveness (in px) applied around the exit point
+ */
+export function createGraceArea(
+  exitPoint: Point,
+  side: PlacementSide,
+  targetRect: RectInit,
+  padding = 5,
+): Point[] | null {
+  const polygon = getElementPolygon(targetRect, side)
+  if (!polygon) return null
+  const [first, second] = getPaddedExitPoints(exitPoint, side, padding)
+  return [first, ...polygon, second]
+}
+
+function getPaddedExitPoints(exitPoint: Point, side: PlacementSide, padding: number): [Point, Point] {
+  const { x, y } = exitPoint
+  switch (side) {
+    case "top":
+      return [
+        { x: x - padding, y: y + padding },
+        { x: x + padding, y: y + padding },
+      ]
+    case "bottom":
+      return [
+        { x: x - padding, y: y - padding },
+        { x: x + padding, y: y - padding },
+      ]
+    case "left":
+      return [
+        { x: x + padding, y: y - padding },
+        { x: x + padding, y: y + padding },
+      ]
+    case "right":
+      return [
+        { x: x - padding, y: y - padding },
+        { x: x - padding, y: y + padding },
+      ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2571,6 +2571,9 @@ importers:
       '@zag-js/popper':
         specifier: workspace:*
         version: link:../../utilities/popper
+      '@zag-js/rect-utils':
+        specifier: workspace:*
+        version: link:../../utilities/rect
       '@zag-js/types':
         specifier: workspace:*
         version: link:../../types


### PR DESCRIPTION
Closes #3181

## 📝 Description

When `positioning.gutter` (or an `offset`) creates a visual gap between the trigger and the content, moving the pointer across that gap can close the hover card, because the pointer briefly hovers neither element. This PR adds a grace area (safe polygon) between the trigger and the content, similar to Floating UI's `safePolygon` and Radix's hover card.

## ⛳️ Current behavior (updates)

- On `pointerleave`, the machine enters `closing` and closes after `closeDelay`, regardless of where the pointer is heading.
- Crossing the gutter gap works only if the crossing takes less than `closeDelay`, so users are forced to increase `closeDelay` globally to make interactive hover cards usable with a gutter.

## 🚀 New behavior

- When the pointer leaves the trigger towards the content (or leaves the content towards the trigger), a grace area polygon is computed from the exit point and the target element's rect (reusing `getElementPolygon`/`isPointInPolygon` from `@zag-js/rect-utils`, the same primitives the menu machine uses for its submenu intent polygon).
- While the pointer stays inside the grace area, the `CLOSE_DELAY` expiry is ignored, so the card stays open during the traversal no matter how small `closeDelay` is.
- As soon as the pointer exits the grace area (or leaves the document), the `closing` state re-enters and the regular `closeDelay` countdown restarts — so moving away still closes the card with the usual delay.
- The grace area is only created when the pointer actually exits on the side facing the target element. Leaving in any other direction (e.g. jumping to an unrelated part of the page) keeps the previous close behavior.

Interaction with `closeDelay`: the delay is effectively paused while the pointer is in transit between the two elements, and restarts once the pointer leaves the corridor. Entering the content/trigger cancels the close as before.

## 💣 Is this a breaking change (Yes/No):

No. Public API is unchanged; the grace area is internal (`refs`). The only new dependency is the existing workspace package `@zag-js/rect-utils`.

## 📝 Additional Information

- Added three e2e tests: slow traversal trigger → content and content → trigger through the gutter (both fail on `main`, pass with this fix), plus a test asserting the card still closes when the pointer enters the gap and then veers away.
- Limitation (matches Radix behavior): if the pointer stops inside the gap and never moves again, the card stays open until the pointer moves out of the grace area. Leaving the document while in the gap is treated as exiting the grace area.
- The grace area is intentionally not created for diagonal exits through a non-facing side (e.g. leaving the trigger's right edge when the content sits below); those fall back to the current `closeDelay` behavior.
