### PR TITLE
fix(date-input): commit deferred entry on segment leave

### DIFF
--- a/.changeset/stale-segment-display-fix.md
+++ b/.changeset/stale-segment-display-fix.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/date-input": patch
+---
+
+Fix stale value shown when editing over a committed date. A partial segment entry (e.g. day `3` that could still
+become `30`) kept the previous committed value rendered after moving to another segment until the whole control lost
+focus. The pending entry is now committed when its segment is left via click, Tab, or arrow navigation.

--- a/e2e/date-input.e2e.ts
+++ b/e2e/date-input.e2e.ts
@@ -464,6 +464,39 @@ test.describe("date-input [single]", () => {
     await I.seeSegmentIsNotPlaceholder("day")
   })
 
+  test("[editingValue] re-typing over a committed date shows the new digits before blur", async () => {
+    // Commit 6/2/2000: "6" completes the month (auto-advance), "2" is a partial day entry,
+    // Tab moves to year, "2000" completes the date.
+    await I.focusSegment("month")
+    await I.type("6")
+    await I.seeSegmentFocused("day")
+    await I.type("2")
+    await I.pressKey("Tab")
+    await I.seeSegmentFocused("year")
+    await I.type("2000")
+    await I.clickOutsideToBlur()
+    await I.seeSelectedValue("6/2/2000")
+    await I.seeSegmentText("day", "2")
+
+    // Re-type 6/3 over the committed value, then Tab to the year segment
+    await I.focusSegment("month")
+    await I.type("6")
+    await I.seeSegmentFocused("day")
+    await I.type("3")
+    await I.pressKey("Tab")
+    await I.seeSegmentFocused("year")
+
+    // Segments must reflect the in-progress edit (6/3/2000), not the stale committed value (6/2/2000)
+    await I.seeSegmentText("month", "6")
+    await I.seeSegmentText("day", "3")
+    await I.seeSegmentText("year", "2000")
+
+    // Blur commits the edit
+    await I.clickOutsideToBlur()
+    await I.seeSelectedValue("6/3/2000")
+    await I.seeSegmentText("day", "3")
+  })
+
   test("[placeholderValue] ArrowUp after clearing a previously typed year starts from placeholder year", async () => {
     // Regression: before the editingValue fix, clearing year after a full commit left
     // a stale edited year in the context, causing ArrowUp to start from year 1 instead

--- a/packages/machines/date-input/src/date-input.machine.ts
+++ b/packages/machines/date-input/src/date-input.machine.ts
@@ -266,7 +266,7 @@ export const machine = createMachine<DateInputSchema>({
     focused: {
       on: {
         "SEGMENT.FOCUS": {
-          actions: ["setActiveSegmentIndex", "clearEnteredKeys"],
+          actions: ["commitDeferredSegmentValue", "setActiveSegmentIndex", "clearEnteredKeys"],
         },
         "SEGMENT.BLUR": {
           target: "idle",
@@ -279,10 +279,10 @@ export const machine = createMachine<DateInputSchema>({
           actions: ["invokeOnSegmentAdjust", "clearEnteredKeys", "announceSegmentValue"],
         },
         "SEGMENT.ARROW_LEFT": {
-          actions: ["setPreviousActiveSegmentIndex", "clearEnteredKeys"],
+          actions: ["commitDeferredSegmentValue", "setPreviousActiveSegmentIndex", "clearEnteredKeys"],
         },
         "SEGMENT.ARROW_RIGHT": {
-          actions: ["setNextActiveSegmentIndex", "clearEnteredKeys"],
+          actions: ["commitDeferredSegmentValue", "setNextActiveSegmentIndex", "clearEnteredKeys"],
         },
         "SEGMENT.BACKSPACE": [
           {
@@ -565,6 +565,20 @@ export const machine = createMachine<DateInputSchema>({
 
         const valueText = segment.isPlaceholder ? "Empty" : segment.text
         announcer.announce(`${getSegmentLabel(segment.type)}, ${valueText}`)
+      },
+
+      // A partial entry (e.g. day "3" that could still become "30") defers the commit while
+      // enteredKeys is pending. Leaving the segment finalizes the entry — commit it, otherwise
+      // the segments keep rendering the stale committed value until the control blurs.
+      commitDeferredSegmentValue(params) {
+        const { context, prop } = params
+        if (context.get("enteredKeys") === "") return
+        const index = context.get("activeIndex")
+        const displayValue = context.get("displayValues")[index]
+        if (!displayValue) return
+        const allSegmentTypes = Object.keys(prop("allSegments")) as SegmentType[]
+        if (!displayValue.isComplete(allSegmentTypes)) return
+        commitValue(params, index, displayValue)
       },
 
       // On blur, if only dayPeriod is unfilled, auto-fill it and commit the value.

--- a/shared/src/routes.ts
+++ b/shared/src/routes.ts
@@ -545,10 +545,17 @@ const componentsMap = new Map(
   componentRoutes.map((component) => [component.slug, { slug: component.slug, label: component.label }]),
 )
 
-export const componentRoutesData = Array.from(componentsMap.values()).sort((a, b) => a.label.localeCompare(b.label))
+// Pin the collation locale: the sort runs on the server (OS locale) and in the browser, and the
+// two must agree — e.g. Czech collation orders "Ch" after "H", which flips Checkbox/Clipboard
+// and causes a hydration mismatch in the examples nav.
+export const componentRoutesData = Array.from(componentsMap.values()).sort((a, b) =>
+  a.label.localeCompare(b.label, "en-US"),
+)
 
 export function getComponentExamples(component: string): ExampleRoute[] {
-  return exampleRoutes.filter((route) => route.component === component).sort((a, b) => a.title.localeCompare(b.title))
+  return exampleRoutes
+    .filter((route) => route.component === component)
+    .sort((a, b) => a.title.localeCompare(b.title, "en-US"))
 }
 
 const componentByPath = new Map<string, string>()


### PR DESCRIPTION
## Summary

Editing over a committed date showed the stale value until the whole control lost focus.

**Repro:** commit `6/2/2000`, refocus, type `6`, `3`, Tab → segments kept rendering `6/2/2000` instead of `6/3/2000` until clicking outside. The day segment DOM even disagreed with itself: `data-value="3"` / `aria-valuenow="3"` but rendered text `2`.

**Root cause:** a partial segment entry (day `3` that could still become `30`) keeps `enteredKeys` pending, which defers the commit in `setSegmentValue`. The `segments` computed then prefers the committed value over the in-progress display value (`isFullyCommitted` branch), so the stale date stays rendered. Only control blur (`confirmPlaceholder`) committed the deferred entry.

**Fix:** new `commitDeferredSegmentValue` action commits the pending entry when its segment is left via click, Tab, or arrow navigation (`SEGMENT.FOCUS`, `SEGMENT.ARROW_LEFT`, `SEGMENT.ARROW_RIGHT`) — the same semantics blur already applied, just at the moment the entry becomes final.

Also included: `fix(shared)` pins the examples nav sort to `en-US` collation. The sort ran with the OS locale on the server and the browser locale on the client; where collations disagree (e.g. Czech orders "Ch" after "H", flipping Checkbox/Clipboard) the nav failed hydration and the Next dev overlay blocked pointer events during local e2e runs on non-English machines.

## Test plan

- New e2e regression test `[editingValue] re-typing over a committed date shows the new digits before blur` — fails without the machine fix (`Expected "3", Received "2"`), passes with it.
- Full `date-input` e2e suite: 83/86 pass; the 3 failures are pre-existing local flakes (fail identically without this change; timing race between `type()` and rAF segment focus, green in CI).
- Changeset included (`@zag-js/date-input` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)