### PR TITLE
fix(bindable): Fix bindable initial value precedence in Vue/Svelte

### DIFF
--- a/.changeset/bright-coins-dress.md
+++ b/.changeset/bright-coins-dress.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/vue": patch
+"@zag-js/svelte": patch
+---
+
+Fix bindable initial value so `defaultValue: null` is preserved (align with React/Solid).

--- a/.changeset/bright-coins-dress.md
+++ b/.changeset/bright-coins-dress.md
@@ -3,4 +3,4 @@
 "@zag-js/svelte": patch
 ---
 
-Fix bindable initial value so `defaultValue: null` is preserved (align with React/Solid).
+Fix bindable to resolve `value` before `defaultValue`, matching React/Solid.

--- a/packages/frameworks/svelte/src/bindable.svelte.ts
+++ b/packages/frameworks/svelte/src/bindable.svelte.ts
@@ -3,7 +3,7 @@ import { identity, isFunction } from "@zag-js/utils"
 import { flushSync, onDestroy, untrack } from "svelte"
 
 export function bindable<T>(props: () => BindableParams<T>): Bindable<T> {
-  const initial = props().defaultValue ?? props().value
+  const initial = props().value ?? props().defaultValue
   const eq = props().isEqual ?? Object.is
 
   let value = $state(initial)

--- a/packages/frameworks/vue/src/bindable.ts
+++ b/packages/frameworks/vue/src/bindable.ts
@@ -3,7 +3,7 @@ import { isFunction } from "@zag-js/utils"
 import { computed as __computed, onUnmounted, shallowRef } from "vue"
 
 export function bindable<T>(props: () => BindableParams<T>): Bindable<T> {
-  const initial = props().defaultValue ?? props().value
+  const initial = props().value ?? props().defaultValue
   const eq = props().isEqual ?? Object.is
 
   const v = shallowRef(initial)


### PR DESCRIPTION
Closes # chakra-ui/ark#3942

## 📝 Description

In `@ark-ui/vue` Drawer, the **first** open after page mount does not play the CSS open animation. Computed style on `Drawer.Content` shows `animation: none` (inline `animation: none !important`). Closing works normally; opening a **second** time plays the open animation as expected.


## Root Cause

### 1. Vue `bindable` drops `defaultValue: null`

In `@zag-js/vue`:

```ts
// packages/frameworks/vue/src/bindable.ts
const initial = props().defaultValue ?? props().value
```

In Drawer machine context:

```ts
dragOffset: bindable(() => ({
  defaultValue: null,
}))
```

Because `??` treats `null` as missing:

```text
null ?? undefined  →  undefined
```

So on mount, `context.get("dragOffset")` is **`undefined`**, not `null`.

Compare React / Solid (works correctly):

```js
const initial = props().value ?? props().defaultValue
// undefined ?? null → null
```

BTW, `Svelte` uses the same `defaultValue ?? value` pattern as `Vue`

### 2. Drawer treats non-`null` as “dragging”

In `@zag-js/drawer` connect:

```js
const dragging = dragOffset !== null   //  undefined !== null  →  true
```

So immediately after mount (drawer still closed):

- `api.dragging === true`
- Content gets `data-dragging` / `data-swiping`
- `transition-duration: 0s` is applied

### 3. First `open` entry suppresses CSS animation

`open` state entry includes `deferClearDragOffset`:

```js
deferClearDragOffset({ context, refs, scope }) {
  const dragOffset = context.get("dragOffset")
  if (dragOffset === null) return  // undefined === null → false; does NOT return
  contentEl.style.setProperty("animation", "none", "important")
  backdropEl.style.setProperty("animation", "none", "important")
  raf(() => {
    refs.get("swipeSession").resetDragOffset()
    context.set("dragOffset", null)
  })
}
```

Intent: after swipe-to-open, temporarily disable CSS animations so they do not fight transform-driven settle.

Bug: first click-to-open also hits this path because `dragOffset` is `undefined`, so open CSS animations are killed with `!important`.

### 4. Why the second open works

- First open’s `raf` eventually runs `context.set("dragOffset", null)`
- Close runs `clearSwipeOpenAnimation`, which `removeProperty("animation")`
- Later opens see real `null` → `deferClearDragOffset` early-returns → CSS open animation runs

## 💣 Is this a breaking change (Yes/No): No

## Addition

Since this default value binding issue has only surfaced in the `Drawer` component so far, I'm not yet certain whether it could affect other components as well. Fixing it as soon as possible will help align the behavior of the `Vue` and `Svelte` implementations with `React`.

P.S. Special thanks to `Cursor Grok 4.5` model for helping quickly pinpoint this subtle issue.