### PR TITLE
fix(focus-trap): don't crash when unpause finds no focusable element

### DIFF
--- a/.changeset/fix-nested-focus-trap-unpause-throw.md
+++ b/.changeset/fix-nested-focus-trap-unpause-throw.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/focus-trap": patch
+---
+
+Fix an uncaught error thrown when a nested focus trap (e.g. a popover or menu inside a dialog) deactivates and automatically resumes an outer trap that has no focusable element at that instant. The outer trap now silently skips refocusing instead of crashing.

--- a/packages/utilities/focus-trap/src/focus-trap.ts
+++ b/packages/utilities/focus-trap/src/focus-trap.ts
@@ -238,7 +238,7 @@ export class FocusTrap {
 
   private listenerCleanups: VoidFunction[] = []
 
-  private addListeners() {
+  private addListeners(isUnpausing = false) {
     if (!this.state.active) return
 
     // There can be only one listening focus trap at a time
@@ -246,9 +246,9 @@ export class FocusTrap {
 
     this.state.delayInitialFocusTimer = this.config.delayInitialFocus
       ? delay(() => {
-          this.tryFocus(this.getInitialFocusNode())
+          this.tryFocus(this.getInitialFocusNode(isUnpausing))
         })
-      : this.tryFocus(this.getInitialFocusNode())
+      : this.tryFocus(this.getInitialFocusNode(isUnpausing))
 
     this.listenerCleanups.push(
       addDomEvent(this.doc, "focusin", this.handleFocus, true),
@@ -503,7 +503,7 @@ export class FocusTrap {
     }
   }
 
-  private getInitialFocusNode = () => {
+  private getInitialFocusNode = (isUnpausing = false) => {
     let node = this.getNodeForOption("initialFocus", { hasFallback: true })
 
     // false explicitly indicates we want no initialFocus at all
@@ -529,7 +529,13 @@ export class FocusTrap {
       node = this.getNodeForOption("fallbackFocus")
     }
 
+    // `isUnpausing` means this call came from `unpause()`'s own automatic re-focus
+    // housekeeping (e.g. a nested trap just deactivated), not from an explicit
+    // `activate()` call. Unlike a real "no focusable element" misconfiguration, this
+    // can transiently happen while the trap is still legitimately active, so treat it
+    // like `initialFocus: false` (don't focus) instead of throwing.
     if (!node) {
+      if (isUnpausing) return false
       throw new Error("Your focus-trap needs to have at least one focusable element")
     }
 
@@ -538,6 +544,7 @@ export class FocusTrap {
     }
 
     if (!node || !node.isConnected) {
+      if (isUnpausing) return false
       throw new Error("Your focus-trap needs to have at least one focusable element")
     }
 
@@ -678,7 +685,7 @@ export class FocusTrap {
     onUnpause?.()
 
     this.updateTabbableNodes()
-    this.addListeners()
+    this.addListeners(true)
     this.updateObservedNodes()
 
     onPostUnpause?.()

--- a/packages/utilities/focus-trap/tests/focus-trap.test.ts
+++ b/packages/utilities/focus-trap/tests/focus-trap.test.ts
@@ -349,4 +349,42 @@ describe("FocusTrap", () => {
 
     expect(trap.active).toBe(false)
   })
+
+  it("does not throw when deactivating a nested trap auto-unpauses an outer trap whose fallback focus target is gone", () => {
+    // Simulates a Dialog (outer trap) containing a Popover (inner trap). Deactivating
+    // the Popover makes `deactivateTrap()` call `unpause()` on the Dialog trap as pure
+    // internal housekeeping, even though the Dialog itself stays open the whole time.
+    const dialogContainer = createContainer()
+    const dialogTrigger = createButton("Dialog trigger")
+    dialogContainer.append(dialogTrigger)
+
+    const popoverContainer = createContainer()
+    popoverContainer.append(createButton("Popover button"))
+
+    const dialogTrap = track(
+      new FocusTrap(dialogContainer, {
+        document,
+        delayInitialFocus: false,
+        fallbackFocus: () => dialogTrigger,
+      }),
+    )
+    dialogTrap.activate()
+
+    const popoverTrap = track(
+      new FocusTrap(popoverContainer, {
+        document,
+        delayInitialFocus: false,
+        fallbackFocus: popoverContainer,
+      }),
+    )
+    popoverTrap.activate() // pauses dialogTrap via the shared trap stack
+
+    // The dialog's only tabbable/fallback element is removed while the popover is
+    // still open (e.g. mid re-render), so at the moment of automatic re-focus the
+    // dialog trap has zero connected focusable elements.
+    dialogTrigger.remove()
+
+    expect(() => popoverTrap.deactivate({ returnFocus: false })).not.toThrow()
+    expect(dialogTrap.active).toBe(true)
+  })
 })


### PR DESCRIPTION
## Description

When two `FocusTrap` instances share a trap stack (the default), deactivating the inner one (e.g. a popover or menu) automatically calls `unpause()` on whichever trap is now on top of the stack (e.g. a dialog) as pure internal housekeeping — see `activeFocusTraps.deactivateTrap()`:

```ts
deactivateTrap(trapStack: FocusTrap[], trap: FocusTrap) {
  const trapIndex = trapStack.indexOf(trap)
  if (trapIndex !== -1) {
    trapStack.splice(trapIndex, 1)
  }

  if (trapStack.length > 0) {
    trapStack[trapStack.length - 1].unpause()
  }
}
```

`unpause()` calls `updateTabbableNodes()` and then `addListeners()`, which synchronously calls `getInitialFocusNode()` to refocus (when `delayInitialFocus: false`, this happens inline; with the default `delayInitialFocus: true` it happens a tick later inside the `setTimeout`, but the underlying issue is the same). If, at that exact instant, the outer trap's container has no connected focusable element — a transient state that can legitimately happen while a nested overlay is being torn down mid re-render — `getInitialFocusNode()` throws unconditionally:

```
Error: Your focus-trap needs to have at least one focusable element
    at FocusTrap.getInitialFocusNode
    at FocusTrap.addListeners
    at FocusTrap.unpause
    at Object.deactivateTrap
    at FocusTrap.deactivate
```

This happens even though the outer trap (e.g. the dialog) is still fully active and its content is still visible on screen — it's not a real "no focusable element" misconfiguration, just a momentary DOM state during the inner trap's teardown.

### Current behavior (updates)

Nesting focus traps (e.g. a `Popover`/`Menu` inside a `Dialog`, all sharing the default trap stack) can throw an uncaught error whenever the inner overlay closes, if the outer trap's container has zero connected focusable elements at that exact moment. This surfaces in real apps as nested Dialog → Popover → Menu UIs (e.g. a template picker with an edit menu inside a popover inside a message-composer dialog) throwing this error every time the innermost overlay closes, even though the outer dialog stays open and fully functional.

Minimal repro (see the added test): activate an outer trap configured with `fallbackFocus: () => someElement`, activate an inner trap (pausing the outer one via the shared stack), then remove `someElement` from the DOM before deactivating the inner trap. Deactivating the inner trap throws.

### New behavior

`unpause()`'s own automatic re-focus (as opposed to an explicit `activate()` call) no longer throws when it can't find a focusable element. Instead, it now returns `false` from `getInitialFocusNode()` and skips focusing — the same sentinel the code already uses for an explicit `initialFocus: false`. `activate()` is unaffected: calling `.activate()` on a trap with no focusable element (a genuine misconfiguration) still throws exactly as before.

Implementation: `addListeners()` and `getInitialFocusNode()` take an `isUnpausing` flag, set only by the call from `unpause()`, so only that internal housekeeping path is softened.

### Is this a breaking change (Yes/No):

No. The only externally observable difference is that `unpause()`'s automatic re-focus no longer throws in a situation where it previously crashed; `activate()`'s validation behavior (the documented/tested "throws when there is no valid focus target" case) is unchanged.

### Additional Information

- Added a regression test (`packages/utilities/focus-trap/tests/focus-trap.test.ts`) that reproduces the exact reported stack trace shape (`getInitialFocusNode` ← `addListeners` ← `unpause` ← `deactivateTrap` ← `deactivate`) using two traps on the shared trap stack.
- Confirmed the new test fails against the current `main` source (throws with the reported error message) before the fix, and passes after.
- All existing `packages/utilities/focus-trap` tests (16) still pass, plus the new one (17 total). `tsc --noEmit` and `eslint src` are clean for the package.
- Added a changeset for `@zag-js/focus-trap` (patch).