### PR TITLE
fix(splitter): handle focus while resize trigger is hovered

### DIFF
--- a/.changeset/splitter-hover-focus.md
+++ b/.changeset/splitter-hover-focus.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/splitter": patch
+---
+
+Fix keyboard resizing when a resize trigger receives focus while hovered.

--- a/e2e/splitter.e2e.ts
+++ b/e2e/splitter.e2e.ts
@@ -28,6 +28,27 @@ test.describe("splitter", () => {
     expect(page.locator(part("resize-trigger")).nth(1)).toHaveAttribute("aria-valuenow", "36")
   })
 
+  test("should resize with keyboard when focused after hover", async ({ page }) => {
+    const trigger = page.locator(part("resize-trigger")).first()
+
+    await page.locator("main").evaluate((main) => {
+      const button = document.createElement("button")
+      button.textContent = "Before splitter"
+      main.prepend(button)
+      button.focus()
+    })
+
+    await trigger.hover()
+    await page.keyboard.press("Tab")
+
+    await expect(trigger).toBeFocused()
+    const value = Number(await trigger.getAttribute("aria-valuenow"))
+
+    await page.keyboard.press("ArrowRight")
+
+    await expect(trigger).toHaveAttribute("aria-valuenow", String(value + 1))
+  })
+
   test("should decrease panel when arrow left pressed", async ({ page }) => {
     await page.click("main")
 

--- a/packages/machines/splitter/src/splitter.machine.ts
+++ b/packages/machines/splitter/src/splitter.machine.ts
@@ -155,6 +155,10 @@ export const machine = createMachine<SplitterSchema>({
         HOVER_DELAY: {
           target: "hover",
         },
+        FOCUS: {
+          target: "focused",
+          actions: ["setKeyboardState"],
+        },
         POINTER_DOWN: {
           target: "dragging",
           actions: ["setDraggingState"],
@@ -168,6 +172,10 @@ export const machine = createMachine<SplitterSchema>({
     hover: {
       tags: ["focus"],
       on: {
+        FOCUS: {
+          target: "focused",
+          actions: ["setKeyboardState"],
+        },
         POINTER_DOWN: {
           target: "dragging",
           actions: ["setDraggingState"],


### PR DESCRIPTION
Closes #3223

## 📝 Description

Keep keyboard resizing working when a splitter resize trigger receives focus after being hovered.

## ⛳️ Current behavior (updates)

Hovering a resize trigger before moving focus to it leaves the machine in a hover state. The trigger receives DOM focus, but arrow keys do not resize the panels.

## 🚀 New behavior

Focusing a hovered resize trigger moves the machine into its focused state, so arrow-key resizing works as expected. An end-to-end test covers the hover, Tab, and ArrowRight sequence.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

None.
