### PR TITLE
fix(solid,svelte): skip exit actions before machine start

### DIFF
--- a/.changeset/framework-ssr-cleanup.md
+++ b/.changeset/framework-ssr-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/solid": patch
+"@zag-js/svelte": patch
+---
+
+Skip machine exit actions when a component is disposed before the machine starts.

--- a/packages/frameworks/solid/src/machine.ts
+++ b/packages/frameworks/solid/src/machine.ts
@@ -242,6 +242,8 @@ export function useMachine<T extends MachineSchema>(
   })
 
   onCleanup(() => {
+    if (status !== MachineStatus.Started) return
+
     debug("unmounting...")
     status = MachineStatus.Stopped
 

--- a/packages/frameworks/solid/tests/machine.test.ts
+++ b/packages/frameworks/solid/tests/machine.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from "@solidjs/testing-library"
 import { createGuards, createMachine } from "@zag-js/core"
 import type { Machine } from "@zag-js/core"
-import { createSignal } from "solid-js"
+import { createRoot, createSignal } from "solid-js"
 import { useMachine } from "../src"
 import { renderMachine } from "./render"
 
@@ -932,6 +932,31 @@ describe("uniform coverage", () => {
     cleanup()
     expect(rootExit).toHaveBeenCalledOnce()
     expect(rootCleanup).toHaveBeenCalledOnce()
+  })
+
+  test("does not run root exit before the machine starts", () => {
+    const rootExit = vi.fn()
+    const machine = createMachine<any>({
+      initialState() {
+        return "idle"
+      },
+      exit: ["rootExit"],
+      states: {
+        idle: {},
+      },
+      implementations: {
+        actions: {
+          rootExit,
+        },
+      },
+    })
+
+    createRoot((dispose) => {
+      useMachine(machine)
+      dispose()
+    })
+
+    expect(rootExit).not.toHaveBeenCalled()
   })
 
   test("internal transition without target runs actions without reentry", async () => {

--- a/packages/frameworks/svelte/src/machine.svelte.ts
+++ b/packages/frameworks/svelte/src/machine.svelte.ts
@@ -238,6 +238,8 @@ export function useMachine<T extends MachineSchema>(
   })
 
   onDestroy(() => {
+    if (status !== MachineStatus.Started) return
+
     debug("unmounting...")
     status = MachineStatus.Stopped
 

--- a/packages/frameworks/svelte/tests/ssr.test.ts
+++ b/packages/frameworks/svelte/tests/ssr.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+
+import { createMachine } from "@zag-js/core"
+import { render } from "svelte/server"
+import MachineHarness from "./MachineHarness.svelte"
+
+test("does not run root exit actions during server rendering", () => {
+  const onExit = vi.fn()
+  const machine = createMachine<any>({
+    initialState() {
+      return "idle"
+    },
+    exit: ["onExit"],
+    states: {
+      idle: {},
+    },
+    implementations: {
+      actions: {
+        onExit,
+      },
+    },
+  })
+
+  void render(MachineHarness, {
+    props: {
+      machine,
+      onReady() {},
+    },
+  }).body
+
+  expect(onExit).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Closes #3225

## 📝 Description

Do not run machine exit actions when Solid or Svelte components are cleaned up before their machines start.

## ⛳️ Current behavior (updates)

The Solid `onCleanup` and Svelte `onDestroy` hooks can run during server rendering even though `onMount` never starts the machine. Both adapters still run machine-level exit actions. The Splitter exit action accesses `document`, which causes SolidStart SSR to fail.

## 🚀 New behavior

Both adapters only tear down a machine after its status reaches `Started`. Normal client unmount behavior is unchanged. Regression coverage includes Solid pre-mount disposal and Svelte server rendering.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

None.
