### PR TITLE
fix(solid): controlled mode predicate in solidjs

### DIFF
--- a/.changeset/soft-melons-sniff.md
+++ b/.changeset/soft-melons-sniff.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/solid": patch
+---
+
+fix: controlled mode predicate in solidjs

--- a/packages/frameworks/solid/src/bindable.ts
+++ b/packages/frameworks/solid/src/bindable.ts
@@ -8,7 +8,7 @@ export function createBindable<T>(props: Accessor<BindableParams<T>>): Bindable<
   const eq = props().isEqual ?? Object.is
 
   const [value, setValue] = createSignal(initial as T)
-  const controlled = createMemo(() => props().value != undefined)
+  const controlled = createMemo(() => props().value !== undefined)
 
   const valueRef = { current: value() }
   const prevValue: Record<"current", T | undefined> = { current: undefined }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description
The predication for controlled mode is not correct in solidjs adapter.

## ⛳️ Current behavior (updates)
The predication for controlled mode is not correct in solidjs adpator. It treated `null` as `undefined`.

## 🚀 New behavior
`null` is different with `undefined`, just like in react or vue adapter.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
