### PR TITLE
fix(marquee): use content size for animation duration so speed is viewport-independent

### DIFF
--- a/.changeset/marquee-duration-content-size.md
+++ b/.changeset/marquee-duration-content-size.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/marquee": patch
+---
+
+Fix the marquee scrolling speed depending on the content width. The duration is now derived from the
+content size (the actual translation distance) instead of the root size, so the configured 
+matches the real pixel speed even when the content is smaller than the viewport.

--- a/packages/machines/marquee/src/marquee.machine.ts
+++ b/packages/machines/marquee/src/marquee.machine.ts
@@ -1,5 +1,6 @@
 import { createMachine } from "@zag-js/core"
 import { dom } from "./marquee.dom"
+import { calculateDuration } from "./marquee.utils"
 import type { MarqueeSchema } from "./marquee.types"
 
 export const machine = createMachine<MarqueeSchema>({
@@ -208,19 +209,3 @@ export const machine = createMachine<MarqueeSchema>({
     },
   },
 })
-
-function calculateDuration(options: {
-  rootSize: number
-  contentSize: number
-  speed: number
-  multiplier: number
-  autoFill: boolean
-}): number {
-  const { rootSize, contentSize, speed, multiplier, autoFill } = options
-
-  if (autoFill) {
-    return (contentSize * multiplier) / speed
-  }
-
-  return contentSize < rootSize ? rootSize / speed : contentSize / speed
-}

--- a/packages/machines/marquee/src/marquee.utils.ts
+++ b/packages/machines/marquee/src/marquee.utils.ts
@@ -51,3 +51,25 @@ export const getMarqueeTranslate = (options: PositionOptions): string => {
   const shouldBeNegative = (side === "start" && dir === "ltr") || (side === "end" && dir === "rtl")
   return shouldBeNegative ? "-100%" : "100%"
 }
+
+interface DurationOptions {
+  rootSize: number
+  contentSize: number
+  speed: number
+  multiplier: number
+  autoFill: boolean
+}
+
+export function calculateDuration(options: DurationOptions): number {
+  const { contentSize, speed, multiplier, autoFill } = options
+
+  if (autoFill) {
+    return (contentSize * multiplier) / speed
+  }
+
+  // Each content element is translated by 100% of its own size, so the animation distance is
+  // always the content size, regardless of the viewport size. Using the root size here made
+  // the effective speed scale with the content/viewport ratio when the content was smaller
+  // than the viewport.
+  return contentSize / speed
+}

--- a/packages/machines/marquee/tests/marquee.utils.test.ts
+++ b/packages/machines/marquee/tests/marquee.utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest"
+import { calculateDuration } from "../src/marquee.utils"
+
+describe("@zag-js/marquee utils", () => {
+  describe("calculateDuration", () => {
+    // Each content element translates by 100% of its own size, so the animation distance is
+    // the content size. The duration must therefore be contentSize / speed for the configured
+    // speed to be the actual pixel speed, independent of the viewport size.
+    test("uses content size for the distance when content is smaller than the viewport", () => {
+      // Regression for the case reported in #3231: 1000px viewport, 100px content, speed 100.
+      // The content only moves 100px, so the duration should be 1s (=> 100px/s), not 10s.
+      expect(calculateDuration({ rootSize: 1000, contentSize: 100, speed: 100, multiplier: 1, autoFill: false })).toBe(
+        1,
+      )
+    })
+
+    test("keeps the configured speed when content is larger than the viewport", () => {
+      expect(calculateDuration({ rootSize: 500, contentSize: 1000, speed: 100, multiplier: 1, autoFill: false })).toBe(
+        10,
+      )
+    })
+
+    test("actual pixel speed equals the configured speed regardless of viewport size", () => {
+      const speed = 100
+      for (const [rootSize, contentSize] of [
+        [1000, 100],
+        [1000, 2000],
+        [300, 300],
+      ]) {
+        const duration = calculateDuration({ rootSize, contentSize, speed, multiplier: 1, autoFill: false })
+        expect(contentSize / duration).toBe(speed)
+      }
+    })
+
+    test("autoFill scales the distance by the multiplier", () => {
+      expect(calculateDuration({ rootSize: 1000, contentSize: 100, speed: 100, multiplier: 10, autoFill: true })).toBe(
+        10,
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #3231

The marquee computes `--marquee-duration` from `rootSize`, but each content element is translated by `100%` of its own size (`translateX(100%)` in the `marqueeX`/`marqueeY` keyframes), so the actual animation distance is always `contentSize`. When the content is smaller than the viewport, the configured `speed` no longer matches the real pixel speed — it scales by `contentSize / rootSize`. With the reporter's example (1000px viewport, 100px content, `speed: 100`), the duration was `10s` for a 100px move → 10px/s instead of 100px/s.

**Fix:** in the non-`autoFill` branch, base the duration on `contentSize` (the real translation distance) rather than `rootSize`. `calculateDuration` is moved to `marquee.utils.ts` and unit-tested (matching the utils-test convention used across the machines).

Verified: the new `marquee.utils.test.ts` covers the reported case and asserts `contentSize / duration === speed` across viewport/content ratios; the bug cases fail against the previous `rootSize`-based logic.
