### PR TITLE
fix(date-picker): keep input focus when open is controlled

### DIFF
--- a/.changeset/date-picker-controlled-open-focus.md
+++ b/.changeset/date-picker-controlled-open-focus.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/date-picker": patch
+---
+
+Fix issue where clicking the input moved focus into the calendar grid when the `open` state is controlled. Focus now
+stays in the input, matching the uncontrolled behavior.

--- a/e2e/date-picker.e2e.ts
+++ b/e2e/date-picker.e2e.ts
@@ -403,6 +403,28 @@ test.describe("datepicker [controlled open]", () => {
   })
 })
 
+test.describe("datepicker [controlled open + openOnClick]", () => {
+  test.beforeEach(async ({ page }) => {
+    I = new DatePickerModel(page)
+    await I.goto("/date-picker/controlled")
+  })
+
+  test("clicking the input opens the calendar but keeps focus in the input", async () => {
+    await I.clickInput()
+    await I.seeContent()
+    // let the focus raf settle before asserting, otherwise focus could still be stolen
+    await I.waitForCalendarRender()
+    await I.seeInputIsFocused()
+  })
+
+  test("clicking the trigger opens the calendar and focuses the active cell", async () => {
+    await I.clickTrigger()
+    await I.seeContent()
+    await I.waitForCalendarRender()
+    await I.seeTodayCellIsFocused()
+  })
+})
+
 test.describe("datepicker [min-view]", () => {
   test.beforeEach(async ({ page }) => {
     I = new DatePickerModel(page)

--- a/e2e/models/datepicker.model.ts
+++ b/e2e/models/datepicker.model.ts
@@ -158,6 +158,10 @@ export class DatePickerModel extends Model {
     return this.trigger.click()
   }
 
+  clickInput(index = 0) {
+    return this.getInput(index).click()
+  }
+
   type(value: string, index = 0) {
     return this.getInput(index).pressSequentially(value)
   }

--- a/examples/next-ts/pages/date-picker/controlled.tsx
+++ b/examples/next-ts/pages/date-picker/controlled.tsx
@@ -1,0 +1,52 @@
+import * as datePicker from "@zag-js/date-picker"
+import { normalizeProps, useMachine } from "@zag-js/react"
+import { useId, useState } from "react"
+import { StateVisualizer } from "../../components/state-visualizer"
+import { Toolbar } from "../../components/toolbar"
+
+export default function Page() {
+  const [open, setOpen] = useState(false)
+
+  const service = useMachine(datePicker.machine, {
+    id: useId(),
+    locale: "en",
+    openOnClick: true,
+    open: open,
+    onOpenChange: (details) => setOpen(details.open),
+  })
+
+  const api = datePicker.connect(service, normalizeProps)
+
+  return (
+    <>
+      <main className="date-picker">
+        <div {...api.getControlProps()}>
+          <input {...api.getInputProps()} />
+          <button {...api.getTriggerProps()}>🗓</button>
+        </div>
+
+        <div {...api.getPositionerProps()}>
+          <div {...api.getContentProps()}>
+            <table {...api.getTableProps({ view: "day" })}>
+              <tbody {...api.getTableBodyProps({ view: "day" })}>
+                {api.weeks.map((week, i) => (
+                  <tr key={i} {...api.getTableRowProps({ view: "day" })}>
+                    {week.map((value, j) => (
+                      <td key={j} {...api.getDayTableCellProps({ value })}>
+                        <div {...api.getDayTableCellTriggerProps({ value })}>{value.day}</div>
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </main>
+
+      <Toolbar viz>
+        <StateVisualizer state={service} omit={["weeks"]} />
+      </Toolbar>
+    </>
+  )
+}

--- a/packages/machines/date-picker/src/date-picker.machine.ts
+++ b/packages/machines/date-picker/src/date-picker.machine.ts
@@ -1095,7 +1095,9 @@ export const machine = createMachine<DatePickerSchema>({
         context.set("activeIndex", 0)
       },
       focusActiveCell({ scope, context, event }) {
-        if (event.src === "input.click") return
+        // when `open` is controlled, `toggleVisibility` re-dispatches the originating event
+        // as `previousEvent`, so read the origin through it
+        if ((event.previousEvent || event).src === "input.click") return
         raf(() => {
           const view = context.get("view")
           dom.getFocusedCell(scope, view)?.focus({ preventScroll: true })


### PR DESCRIPTION
## 📝 Description

Clicking the date picker's text input opens the calendar and then moves DOM focus into the calendar grid — but only when
`open` is controlled. Focus is pulled out from under the user while they are typing a date. With uncontrolled `open`, the
same click correctly leaves focus in the input.

## ⛳️ Current behavior (updates)

The input's click handler sends the open event tagged with its origin:

```ts
send({ type: "OPEN", src: "input.click" })
```

and `focusActiveCell` uses that tag to skip pulling focus into the grid:

```ts
focusActiveCell({ scope, context, event }) {
  if (event.src === "input.click") return
  // ...
}
```

Under a controlled `open` that `OPEN` event never reaches the state transition. `isOpenControlled` short-circuits it to
`invokeOnOpen`, the consumer flips the `open` prop, and the `watch` on `prop("open")` re-dispatches through
`toggleVisibility`:

```ts
send({ type: prop("open") ? "CONTROLLED.OPEN" : "CONTROLLED.CLOSE", previousEvent: event })
```

`CONTROLLED.OPEN` in both `idle` and `focused` runs `["resetView", "focusFirstSelectedDate", "focusActiveCell"]`. By then
`event.src` is `undefined` — the origin only survives at `event.previousEvent.src` — so the guard never matches and focus
is always taken.

The guard is correct; the event it inspects is the wrapper rather than the cause.

## 🚀 New behavior

`focusActiveCell` reads the origin through `previousEvent`, so a controlled open initiated by an input click is treated
the same as an uncontrolled one:

```ts
if ((event.previousEvent || event).src === "input.click") return
```

This matches how the rest of the codebase already reads event fields across the controlled boundary — `getOpenChangeReason`
in `combobox.machine.ts` uses exactly `(event.previousEvent || event).src`, and `isInteractOutsideEvent` in this same
machine already reads `event.previousEvent?.type`. `focusActiveCell` was the only place reading `event.src` without the
fallback.

Opening via the calendar trigger button still moves focus into the grid, so keyboard/a11y behaviour is unchanged.

### Scope notes

- The other two actions in this machine that read event fields this way are not reachable through the `CONTROLLED.*`
  wrapper: `focusActiveCellIfNeeded` (`if (!event.focus) return`) only fires from the `focusedValue` watcher and `focus`
  is only ever set by `TABLE.*` keyboard events, and `focusFirstInputElement` (`if (event.focus === false) return`) only
  runs on `VALUE.CLEAR`. Both fail closed, so neither steals focus on the controlled path.
- The sibling machines that share the `toggleVisibility` / `previousEvent` convention (combobox, select, cascade-select,
  menu, popover, editable, tooltip) already unwrap `previousEvent` where they read across it, so this looks like a
  one-off rather than a class of bug.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

**Repro:** a controlled-`open` date picker with `openOnClick` — added as `examples/next-ts/pages/date-picker/controlled.tsx`,
since the existing `open-control` example hardcodes `open={false}` and so cannot reach the `CONTROLLED.OPEN` path.

**Tests:** added `datepicker [controlled open + openOnClick]` to `e2e/date-picker.e2e.ts` covering both directions —
input click under controlled `open` keeps focus in the input, and trigger click still focuses the active cell. The first
test fails on `main` and passes with this change; the second passes both before and after.
