### PR TITLE
fix(image-cropper): account for flip when mapping crop box to source pixels

### DIFF
--- a/.changeset/image-cropper-flip-source-rect.md
+++ b/.changeset/image-cropper-flip-source-rect.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/image-cropper": patch
+---
+
+Fix `getCroppedImage()` and `getCropData()` sampling the mirror-opposite region of the source image when a horizontal or
+vertical flip is active

--- a/packages/machines/image-cropper/src/image-cropper.connect.ts
+++ b/packages/machines/image-cropper/src/image-cropper.connect.ts
@@ -128,6 +128,7 @@ export function connect<T extends PropTypes>(
         offset,
         viewportSize: viewportRect,
         naturalSize,
+        flip,
       })
 
       return {

--- a/packages/machines/image-cropper/src/image-cropper.dom.ts
+++ b/packages/machines/image-cropper/src/image-cropper.dom.ts
@@ -53,6 +53,7 @@ export function drawCroppedImageToCanvas(params: ImageCropperService): HTMLCanva
     offset,
     viewportSize: viewportRect,
     naturalSize,
+    flip,
   })
 
   ctx.drawImage(

--- a/packages/machines/image-cropper/src/image-cropper.utils.ts
+++ b/packages/machines/image-cropper/src/image-cropper.utils.ts
@@ -491,19 +491,28 @@ interface SourceRectParams {
   offset: Point
   viewportSize: Size
   naturalSize: Size
+  flip?: FlipState | undefined
 }
 
 /**
  * Maps the crop rect (viewport coordinates) to the source rect in natural
  * image pixels. The viewport -> natural scale is `naturalSize / viewportSize`.
+ *
+ * The preview image is transformed with `translate() scale(zoom * flipSign)`,
+ * so a horizontal/vertical flip mirrors the sampled region across the image
+ * center. The offset (pan) is applied in viewport space and is unaffected by
+ * the flip.
  */
 export function getCropSourceRect(params: SourceRectParams): Rect {
-  const { crop, zoom, offset, viewportSize, naturalSize } = params
+  const { crop, zoom, offset, viewportSize, naturalSize, flip } = params
 
   const scaleX = viewportSize.width > 0 ? naturalSize.width / viewportSize.width : 1
   const scaleY = viewportSize.height > 0 ? naturalSize.height / viewportSize.height : 1
 
   const safeZoom = zoom > 0 ? zoom : 1
+
+  const flipX = flip?.horizontal ? -1 : 1
+  const flipY = flip?.vertical ? -1 : 1
 
   const viewportCenterX = viewportSize.width / 2
   const viewportCenterY = viewportSize.height / 2
@@ -514,8 +523,8 @@ export function getCropSourceRect(params: SourceRectParams): Rect {
   const cropCenterX = crop.x + crop.width / 2
   const cropCenterY = crop.y + crop.height / 2
 
-  const sourceCenterX = imageCenterX + ((cropCenterX - viewportCenterX - offset.x) / safeZoom) * scaleX
-  const sourceCenterY = imageCenterY + ((cropCenterY - viewportCenterY - offset.y) / safeZoom) * scaleY
+  const sourceCenterX = imageCenterX + flipX * ((cropCenterX - viewportCenterX - offset.x) / safeZoom) * scaleX
+  const sourceCenterY = imageCenterY + flipY * ((cropCenterY - viewportCenterY - offset.y) / safeZoom) * scaleY
 
   const sourceWidth = (crop.width / safeZoom) * scaleX
   const sourceHeight = (crop.height / safeZoom) * scaleY

--- a/packages/machines/image-cropper/tests/image-cropper.utils.test.ts
+++ b/packages/machines/image-cropper/tests/image-cropper.utils.test.ts
@@ -145,3 +145,89 @@ describe("@zag-js/image-cropper getCropSourceRect", () => {
     expect(result).toEqual({ x: 0, y: 0, width: 100, height: 100 })
   })
 })
+
+describe("@zag-js/image-cropper getCropSourceRect flip", () => {
+  test("horizontal flip mirrors the sampled region across the image center", () => {
+    const shared = {
+      crop: { x: 250, y: 150, width: 100, height: 100 },
+      viewportSize: { width: 400, height: 400 },
+      naturalSize: { width: 400, height: 400 },
+    }
+    const base = getCropSourceRect({ zoom: 1, offset: ZERO, ...shared })
+    const flipped = getCropSourceRect({ zoom: 1, offset: ZERO, ...shared, flip: { horizontal: true, vertical: false } })
+
+    // Only x mirrors across the image center (200); y and size are unchanged.
+    expect(base).toEqual({ x: 250, y: 150, width: 100, height: 100 })
+    expect(flipped).toEqual({ x: 50, y: 150, width: 100, height: 100 })
+  })
+
+  test("vertical flip mirrors the sampled region across the image center", () => {
+    const shared = {
+      crop: { x: 150, y: 250, width: 100, height: 100 },
+      viewportSize: { width: 400, height: 400 },
+      naturalSize: { width: 400, height: 400 },
+    }
+    const base = getCropSourceRect({ zoom: 1, offset: ZERO, ...shared })
+    const flipped = getCropSourceRect({ zoom: 1, offset: ZERO, ...shared, flip: { horizontal: false, vertical: true } })
+
+    expect(base).toEqual({ x: 150, y: 250, width: 100, height: 100 })
+    expect(flipped).toEqual({ x: 150, y: 50, width: 100, height: 100 })
+  })
+
+  test("flipping both axes mirrors the region on both axes", () => {
+    const flipped = getCropSourceRect({
+      crop: { x: 250, y: 250, width: 100, height: 100 },
+      zoom: 1,
+      offset: ZERO,
+      viewportSize: { width: 400, height: 400 },
+      naturalSize: { width: 400, height: 400 },
+      flip: { horizontal: true, vertical: true },
+    })
+
+    expect(flipped).toEqual({ x: 50, y: 50, width: 100, height: 100 })
+  })
+
+  test("a centered crop is unaffected by flipping", () => {
+    const shared = {
+      crop: { x: 150, y: 150, width: 100, height: 100 },
+      viewportSize: { width: 400, height: 400 },
+      naturalSize: { width: 400, height: 400 },
+    }
+    const base = getCropSourceRect({ zoom: 1, offset: ZERO, ...shared })
+    const flipped = getCropSourceRect({ zoom: 1, offset: ZERO, ...shared, flip: { horizontal: true, vertical: true } })
+
+    expect(flipped).toEqual(base)
+  })
+
+  test("horizontal flip samples the mirror-opposite region (reported bug)", () => {
+    // Reporter's setup: 1200x800 image in a 600x400 viewport (2x scale), crop
+    // over the top-right of the screen. Without flip the crop samples the right
+    // half of the source; a horizontal flip must sample the mirror-opposite
+    // left half, not the same right-half region.
+    const shared = {
+      crop: { x: 400, y: 50, width: 150, height: 150 },
+      viewportSize: { width: 600, height: 400 },
+      naturalSize: { width: 1200, height: 800 },
+    }
+    const base = getCropSourceRect({ zoom: 1, offset: ZERO, ...shared })
+    const flipped = getCropSourceRect({ zoom: 1, offset: ZERO, ...shared, flip: { horizontal: true, vertical: false } })
+
+    expect(base).toEqual({ x: 800, y: 100, width: 300, height: 300 })
+    expect(flipped).toEqual({ x: 100, y: 100, width: 300, height: 300 })
+  })
+
+  test("flip mirrors the region while the pan offset stays in viewport space", () => {
+    const flipped = getCropSourceRect({
+      crop: { x: 250, y: 150, width: 100, height: 100 },
+      zoom: 1,
+      offset: { x: 50, y: 0 },
+      viewportSize: { width: 400, height: 400 },
+      naturalSize: { width: 400, height: 400 },
+      flip: { horizontal: true, vertical: false },
+    })
+
+    // (cropCenterX - viewportCenterX - offset.x) = 300 - 200 - 50 = 50, mirrored -> -50
+    // sourceCenterX = 200 - 50 = 150 -> x = 150 - width/2 = 100
+    expect(flipped).toEqual({ x: 100, y: 150, width: 100, height: 100 })
+  })
+})


### PR DESCRIPTION
Closes #3238

## 📝 Description

`getCroppedImage()` and `getCropData()` return the wrong region of the source image when a horizontal or vertical flip is active. Zoom and pan alone are fine.

## ⛳️ Current behavior

The preview is transformed with `translate(offset) rotate(rotation) scale(zoom × flipSign)` (see `getImageProps`), but `getCropSourceRect` — which maps the crop box back to source pixels — only inverts pan and zoom. Flip is not a parameter, so the sampled center is never mirrored: a horizontal flip of a crop over the top-right of the viewport samples the top-*right* quadrant, and the canvas's `ctx.scale(±1)` then mirrors that already-wrong tile — the top-*left* quadrant the user actually sees is never sampled.

## 🚀 New behavior

`getCropSourceRect` now takes the `flip` state and mirrors the sampled region's center across the image center per axis, leaving the sampled size and the viewport-space pan offset untouched. Both consumers (`getCropData` and the canvas draw) pass it through; the canvas's existing `ctx.scale(flip)` still supplies the visual orientation.

Added unit tests for horizontal / vertical / combined flips, the centered-crop invariant, the pan-offset interaction, and a regression matching the reported reproduction. Reverting the fix fails the mirroring assertions while the existing zoom/pan/scale tests stay green.

**Note on rotation:** the title also mentions rotation. Flip is a clean, exact fix (an axis-aligned source rect stays axis-aligned under a mirror). Arbitrary rotation (`rotation` is clamped 0–360, not quantized to 90°) is deeper: an axis-aligned source rect can't represent a rotated crop, so a fully-correct `getCroppedImage()` under rotation needs `drawCroppedImageToCanvas` to replicate the full CSS transform via `ctx.setTransform(...)`, and `getCropData()`'s axis-aligned rect is ambiguous under rotation. I scoped this PR to the flip fix that resolves the reported reproduction, and I'm happy to follow up on rotation in a separate PR — I have the `setTransform` approach worked out.

## 💣 Is this a breaking change (Yes/No):

No. `flip` is optional; existing behavior (no flip) is unchanged.
