### PR TITLE
fix(floating-panel): keep panel stack in sync on close and apply stack order to the positioner

### DIFF
--- a/.changeset/floating-panel-stack-close-zindex.md
+++ b/.changeset/floating-panel-stack-close-zindex.md
@@ -1,0 +1,11 @@
+---
+"@zag-js/floating-panel": patch
+---
+
+Fix panel stacking issues when multiple floating panels are open:
+
+- Closing a panel now removes it from the panel stack (previously only machine destroy did), so the next open panel is
+  correctly promoted to topmost.
+- The stack index is now applied to the positioner (`z-index` via `--z-index`), so focusing a panel actually brings it
+  above sibling panels. Previously the index was only mirrored on the content element, which cannot affect ordering
+  across sibling stacking contexts.

--- a/.changeset/floating-panel-stack-close-zindex.md
+++ b/.changeset/floating-panel-stack-close-zindex.md
@@ -2,10 +2,7 @@
 "@zag-js/floating-panel": patch
 ---
 
-Fix panel stacking issues when multiple floating panels are open:
+Fix panel stacking when multiple panels are open:
 
-- Closing a panel now removes it from the panel stack (previously only machine destroy did), so the next open panel is
-  correctly promoted to topmost.
-- The stack index is now applied to the positioner (`z-index` via `--z-index`), so focusing a panel actually brings it
-  above sibling panels. Previously the index was only mirrored on the content element, which cannot affect ordering
-  across sibling stacking contexts.
+- Closing a panel now removes it from the stack, so the next panel becomes topmost.
+- Stack order now applies to the positioner, so focusing a panel raises it above its siblings.

--- a/e2e/floating-panel.e2e.ts
+++ b/e2e/floating-panel.e2e.ts
@@ -203,4 +203,37 @@ test.describe("floating-panel", () => {
     await I.page.getByRole("button", { name: "API set size: 440x300" }).click()
     await I.seeContentHasSize(440, 300, 10)
   })
+
+  test("closing the topmost panel promotes the next panel to topmost", async ({ page }) => {
+    await I.goto("/floating-panel/stacking")
+
+    await page.getByTestId("trigger-A").click()
+    await page.getByTestId("trigger-B").click()
+
+    await expect(page.getByTestId("content-B")).toHaveAttribute("data-topmost", "")
+    await expect(page.getByTestId("content-A")).toHaveAttribute("data-behind", "")
+
+    await page.getByTestId("close-B").click()
+
+    await expect(page.getByTestId("content-A")).toHaveAttribute("data-topmost", "")
+    await expect(page.getByTestId("content-B")).not.toHaveAttribute("data-topmost", "")
+  })
+
+  test("focusing a panel raises its positioner above the other panels", async ({ page }) => {
+    await I.goto("/floating-panel/stacking")
+
+    const zIndex = (name: string) =>
+      page.getByTestId(`positioner-${name}`).evaluate((el) => Number(getComputedStyle(el).zIndex))
+
+    await page.getByTestId("trigger-A").click()
+    await page.getByTestId("trigger-B").click()
+
+    await expect(page.getByTestId("content-B")).toHaveAttribute("data-topmost", "")
+    expect(await zIndex("B")).toBeGreaterThan(await zIndex("A"))
+
+    await page.getByTestId("content-A").focus()
+
+    await expect(page.getByTestId("content-A")).toHaveAttribute("data-topmost", "")
+    expect(await zIndex("A")).toBeGreaterThan(await zIndex("B"))
+  })
 })

--- a/examples/next-ts/pages/floating-panel/stacking.tsx
+++ b/examples/next-ts/pages/floating-panel/stacking.tsx
@@ -1,0 +1,56 @@
+import * as floating from "@zag-js/floating-panel"
+import { normalizeProps, useMachine } from "@zag-js/react"
+import { XIcon } from "lucide-react"
+import { useId } from "react"
+
+interface PanelProps {
+  name: string
+  offset: number
+}
+
+function Panel(props: PanelProps) {
+  const { name, offset } = props
+
+  const service = useMachine(floating.machine, {
+    id: useId(),
+    defaultPosition: { x: 100 + offset, y: 100 + offset },
+  })
+
+  const api = floating.connect(service, normalizeProps)
+
+  return (
+    <div>
+      <button {...api.getTriggerProps()} data-testid={`trigger-${name}`}>
+        Toggle {name}
+      </button>
+      <div {...api.getPositionerProps()} data-testid={`positioner-${name}`}>
+        <div {...api.getContentProps()} data-testid={`content-${name}`}>
+          <div {...api.getDragTriggerProps()}>
+            <div {...api.getHeaderProps()}>
+              <p {...api.getTitleProps()}>Panel {name}</p>
+              <div {...api.getControlProps()}>
+                <button {...api.getCloseTriggerProps()} data-testid={`close-${name}`}>
+                  <XIcon />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div {...api.getBodyProps()}>
+            <p>Content {name}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function Page() {
+  return (
+    <main className="floating-panel">
+      <div style={{ display: "flex", gap: "12px" }}>
+        <Panel name="A" offset={0} />
+        <Panel name="B" offset={40} />
+      </div>
+    </main>
+  )
+}

--- a/examples/nuxt-ts/app/components/FloatingPanelStackItem.vue
+++ b/examples/nuxt-ts/app/components/FloatingPanelStackItem.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import * as floatingPanel from "@zag-js/floating-panel"
+import { normalizeProps, useMachine } from "@zag-js/vue"
+import { XIcon } from "lucide-vue-next"
+
+const props = defineProps<{ name: string; offset: number }>()
+
+const service = useMachine(floatingPanel.machine, {
+  id: useId(),
+  defaultPosition: { x: 100 + props.offset, y: 100 + props.offset },
+})
+
+const api = computed(() => floatingPanel.connect(service, normalizeProps))
+</script>
+
+<template>
+  <div>
+    <button v-bind="api.getTriggerProps()" :data-testid="`trigger-${name}`">Toggle {{ name }}</button>
+    <div v-bind="api.getPositionerProps()" :data-testid="`positioner-${name}`">
+      <div v-bind="api.getContentProps()" :data-testid="`content-${name}`">
+        <div v-bind="api.getDragTriggerProps()">
+          <div v-bind="api.getHeaderProps()">
+            <p v-bind="api.getTitleProps()">Panel {{ name }}</p>
+            <div v-bind="api.getControlProps()">
+              <button v-bind="api.getCloseTriggerProps()" :data-testid="`close-${name}`">
+                <XIcon />
+              </button>
+            </div>
+          </div>
+        </div>
+        <div v-bind="api.getBodyProps()">
+          <p>Content {{ name }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/examples/nuxt-ts/app/pages/floating-panel/stacking.vue
+++ b/examples/nuxt-ts/app/pages/floating-panel/stacking.vue
@@ -1,0 +1,8 @@
+<template>
+  <main class="floating-panel">
+    <div style="display: flex; gap: 12px">
+      <FloatingPanelStackItem name="A" :offset="0" />
+      <FloatingPanelStackItem name="B" :offset="40" />
+    </div>
+  </main>
+</template>

--- a/examples/preact-ts/src/pages/floating-panel/stacking.tsx
+++ b/examples/preact-ts/src/pages/floating-panel/stacking.tsx
@@ -1,0 +1,56 @@
+import * as floating from "@zag-js/floating-panel"
+import { normalizeProps, useMachine } from "@zag-js/preact"
+import { XIcon } from "lucide-preact"
+import { useId } from "react"
+
+interface PanelProps {
+  name: string
+  offset: number
+}
+
+function Panel(props: PanelProps) {
+  const { name, offset } = props
+
+  const service = useMachine(floating.machine, {
+    id: useId(),
+    defaultPosition: { x: 100 + offset, y: 100 + offset },
+  })
+
+  const api = floating.connect(service, normalizeProps)
+
+  return (
+    <div>
+      <button {...api.getTriggerProps()} data-testid={`trigger-${name}`}>
+        Toggle {name}
+      </button>
+      <div {...api.getPositionerProps()} data-testid={`positioner-${name}`}>
+        <div {...api.getContentProps()} data-testid={`content-${name}`}>
+          <div {...api.getDragTriggerProps()}>
+            <div {...api.getHeaderProps()}>
+              <p {...api.getTitleProps()}>Panel {name}</p>
+              <div {...api.getControlProps()}>
+                <button {...api.getCloseTriggerProps()} data-testid={`close-${name}`}>
+                  <XIcon />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div {...api.getBodyProps()}>
+            <p>Content {name}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function Page() {
+  return (
+    <main className="floating-panel">
+      <div style={{ display: "flex", gap: "12px" }}>
+        <Panel name="A" offset={0} />
+        <Panel name="B" offset={40} />
+      </div>
+    </main>
+  )
+}

--- a/examples/preact-ts/src/routes.ts
+++ b/examples/preact-ts/src/routes.ts
@@ -55,6 +55,7 @@ export const routes: RouteDefinition[] = [
   { path: "/floating-panel/controlled", component: lazy(() => import("./pages/floating-panel/controlled")) },
   { path: "/floating-panel/focus-trap", component: lazy(() => import("./pages/floating-panel/focus-trap")) },
   { path: "/floating-panel/popover-inside", component: lazy(() => import("./pages/floating-panel/popover-inside")) },
+  { path: "/floating-panel/stacking", component: lazy(() => import("./pages/floating-panel/stacking")) },
   { path: "/tour/basic", component: lazy(() => import("./pages/tour/basic")) },
   { path: "/tour/wait-step", component: lazy(() => import("./pages/tour/wait-step")) },
   { path: "/tour/wait-for-input-event", component: lazy(() => import("./pages/tour/wait-for-input-event")) },

--- a/examples/solid-ts/src/routes/floating-panel/stacking.tsx
+++ b/examples/solid-ts/src/routes/floating-panel/stacking.tsx
@@ -1,0 +1,54 @@
+import * as floatingPanel from "@zag-js/floating-panel"
+import { normalizeProps, useMachine } from "@zag-js/solid"
+import { XIcon } from "lucide-solid"
+import { createMemo, createUniqueId } from "solid-js"
+
+interface PanelProps {
+  name: string
+  offset: number
+}
+
+function Panel(props: PanelProps) {
+  const service = useMachine(floatingPanel.machine, {
+    id: createUniqueId(),
+    defaultPosition: { x: 100 + props.offset, y: 100 + props.offset },
+  })
+
+  const api = createMemo(() => floatingPanel.connect(service, normalizeProps))
+
+  return (
+    <div>
+      <button {...api().getTriggerProps()} data-testid={`trigger-${props.name}`}>
+        Toggle {props.name}
+      </button>
+      <div {...api().getPositionerProps()} data-testid={`positioner-${props.name}`}>
+        <div {...api().getContentProps()} data-testid={`content-${props.name}`}>
+          <div {...api().getDragTriggerProps()}>
+            <div {...api().getHeaderProps()}>
+              <p {...api().getTitleProps()}>Panel {props.name}</p>
+              <div {...api().getControlProps()}>
+                <button {...api().getCloseTriggerProps()} data-testid={`close-${props.name}`}>
+                  <XIcon />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div {...api().getBodyProps()}>
+            <p>Content {props.name}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function Page() {
+  return (
+    <main class="floating-panel">
+      <div style={{ display: "flex", gap: "12px" }}>
+        <Panel name="A" offset={0} />
+        <Panel name="B" offset={40} />
+      </div>
+    </main>
+  )
+}

--- a/examples/svelte-ts/src/lib/components/floating-panel-stack-item.svelte
+++ b/examples/svelte-ts/src/lib/components/floating-panel-stack-item.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import * as floatingPanel from "@zag-js/floating-panel"
+  import { normalizeProps, useMachine } from "@zag-js/svelte"
+  import { XIcon } from "lucide-svelte"
+
+  interface Props {
+    name: string
+    offset: number
+  }
+
+  const { name, offset }: Props = $props()
+
+  const id = $props.id()
+  const service = useMachine(floatingPanel.machine, {
+    id,
+    defaultPosition: { x: 100 + offset, y: 100 + offset },
+  })
+
+  const api = $derived(floatingPanel.connect(service, normalizeProps))
+</script>
+
+<div>
+  <button {...api.getTriggerProps()} data-testid={`trigger-${name}`}>
+    Toggle {name}
+  </button>
+  <div {...api.getPositionerProps()} data-testid={`positioner-${name}`}>
+    <div {...api.getContentProps()} data-testid={`content-${name}`}>
+      <div {...api.getDragTriggerProps()}>
+        <div {...api.getHeaderProps()}>
+          <p {...api.getTitleProps()}>Panel {name}</p>
+          <div {...api.getControlProps()}>
+            <button {...api.getCloseTriggerProps()} data-testid={`close-${name}`}>
+              <XIcon />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div {...api.getBodyProps()}>
+        <p>Content {name}</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/examples/svelte-ts/src/routes/floating-panel/stacking/+page.svelte
+++ b/examples/svelte-ts/src/routes/floating-panel/stacking/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import FloatingPanelStackItem from "$lib/components/floating-panel-stack-item.svelte"
+</script>
+
+<main class="floating-panel">
+  <div style="display: flex; gap: 12px;">
+    <FloatingPanelStackItem name="A" offset={0} />
+    <FloatingPanelStackItem name="B" offset={40} />
+  </div>
+</main>

--- a/packages/machines/floating-panel/package.json
+++ b/packages/machines/floating-panel/package.json
@@ -36,11 +36,9 @@
   "dependencies": {
     "@zag-js/anatomy": "workspace:*",
     "@zag-js/core": "workspace:*",
-    "@zag-js/store": "workspace:*",
     "@zag-js/dom-query": "workspace:*",
     "@zag-js/utils": "workspace:*",
     "@zag-js/rect-utils": "workspace:*",
-    "@zag-js/popper": "workspace:*",
     "@zag-js/types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/machines/floating-panel/src/floating-panel.connect.ts
+++ b/packages/machines/floating-panel/src/floating-panel.connect.ts
@@ -20,6 +20,7 @@ export function connect<T extends PropTypes>(
   const resizing = state.matches("open.resizing")
 
   const isTopmost = context.get("isTopmost")
+  const stackIndex = context.get("stackIndex")
   const size = context.get("size")
   const position = context.get("position")
 
@@ -87,7 +88,9 @@ export function connect<T extends PropTypes>(
           "--height": toPx(size?.height),
           "--x": toPx(position?.x),
           "--y": toPx(position?.y),
+          "--z-index": stackIndex > -1 ? stackIndex + 1 : undefined,
           position: prop("strategy"),
+          isolation: "isolate",
           top: "var(--y)",
           left: "var(--x)",
           zIndex: "var(--z-index)",

--- a/packages/machines/floating-panel/src/floating-panel.connect.ts
+++ b/packages/machines/floating-panel/src/floating-panel.connect.ts
@@ -90,6 +90,7 @@ export function connect<T extends PropTypes>(
           position: prop("strategy"),
           top: "var(--y)",
           left: "var(--x)",
+          zIndex: "var(--z-index)",
         },
       })
     },

--- a/packages/machines/floating-panel/src/floating-panel.machine.ts
+++ b/packages/machines/floating-panel/src/floating-panel.machine.ts
@@ -138,6 +138,9 @@ export const machine = createMachine<FloatingPanelSchema>({
   states: {
     closed: {
       tags: ["closed"],
+      // Leaving the stack on close (not only on destroy) promotes the next
+      // panel to topmost; reopening re-adds via the open state's entry (#3243).
+      entry: ["removeFromPanelStack"],
       on: {
         "CONTROLLED.OPEN": {
           target: "open",
@@ -314,13 +317,15 @@ export const machine = createMachine<FloatingPanelSchema>({
       trackPanelStack({ context, scope }) {
         const unsub = subscribe(panelStack, () => {
           context.set("isTopmost", panelStack.isTopmost(scope.id!))
-          const contentEl = dom.getContentEl(scope)
-          if (!contentEl) return
 
           const index = panelStack.indexOf(scope.id!)
           if (index === -1) return
 
-          contentEl.style.setProperty("--z-index", `${index + 1}`)
+          // Each positioner creates a sibling stacking context, so the stack
+          // index must be applied there for panels to reorder relative to each
+          // other. The content mirror is kept for userland styling.
+          dom.getPositionerEl(scope)?.style.setProperty("--z-index", `${index + 1}`)
+          dom.getContentEl(scope)?.style.setProperty("--z-index", `${index + 1}`)
         })
 
         return () => {
@@ -585,6 +590,9 @@ export const machine = createMachine<FloatingPanelSchema>({
 
       bringToFrontOfPanelStack({ prop }) {
         panelStack.bringToFront(prop("id"))
+      },
+      removeFromPanelStack({ prop }) {
+        panelStack.remove(prop("id"))
       },
       invokeOnOpen({ prop }) {
         prop("onOpenChange")?.({ open: true })

--- a/packages/machines/floating-panel/src/floating-panel.machine.ts
+++ b/packages/machines/floating-panel/src/floating-panel.machine.ts
@@ -14,7 +14,6 @@ import {
   type Point,
   type Size,
 } from "@zag-js/rect-utils"
-import { subscribe } from "@zag-js/store"
 import { clampValue, ensureProps, invariant, match, pick } from "@zag-js/utils"
 import * as dom from "./floating-panel.dom"
 import { panelStack } from "./floating-panel.store"
@@ -95,6 +94,9 @@ export const machine = createMachine<FloatingPanelSchema>({
       isTopmost: bindable<boolean | undefined>(() => ({
         defaultValue: undefined,
       })),
+      stackIndex: bindable<number>(() => ({
+        defaultValue: -1,
+      })),
     }
   },
 
@@ -138,9 +140,6 @@ export const machine = createMachine<FloatingPanelSchema>({
   states: {
     closed: {
       tags: ["closed"],
-      // Leaving the stack on close (not only on destroy) promotes the next
-      // panel to topmost; reopening re-adds via the open state's entry (#3243).
-      entry: ["removeFromPanelStack"],
       on: {
         "CONTROLLED.OPEN": {
           target: "open",
@@ -162,6 +161,7 @@ export const machine = createMachine<FloatingPanelSchema>({
     open: {
       tags: ["open"],
       entry: ["bringToFrontOfPanelStack"],
+      exit: ["removeFromPanelStack"],
       initial: "idle",
       on: {
         "CONTROLLED.CLOSE": {
@@ -315,17 +315,9 @@ export const machine = createMachine<FloatingPanelSchema>({
       },
 
       trackPanelStack({ context, scope }) {
-        const unsub = subscribe(panelStack, () => {
+        const unsub = panelStack.subscribe(() => {
           context.set("isTopmost", panelStack.isTopmost(scope.id!))
-
-          const index = panelStack.indexOf(scope.id!)
-          if (index === -1) return
-
-          // Each positioner creates a sibling stacking context, so the stack
-          // index must be applied there for panels to reorder relative to each
-          // other. The content mirror is kept for userland styling.
-          dom.getPositionerEl(scope)?.style.setProperty("--z-index", `${index + 1}`)
-          dom.getContentEl(scope)?.style.setProperty("--z-index", `${index + 1}`)
+          context.set("stackIndex", panelStack.indexOf(scope.id!))
         })
 
         return () => {

--- a/packages/machines/floating-panel/src/floating-panel.store.ts
+++ b/packages/machines/floating-panel/src/floating-panel.store.ts
@@ -1,27 +1,35 @@
-import { proxy } from "@zag-js/store"
+import { createStore } from "@zag-js/utils"
 
-export const panelStack = proxy({
-  stack: [] as string[],
+const store = createStore<{ stack: string[] }>({ stack: [] })
+
+export const panelStack = {
+  subscribe: store.subscribe,
   count() {
-    return this.stack.length
+    return store.get("stack").length
   },
   add(panelId: string) {
-    if (this.stack.includes(panelId)) return
-    this.stack.push(panelId)
+    const stack = store.get("stack")
+    if (stack.includes(panelId)) return
+    store.set("stack", [...stack, panelId])
   },
   remove(panelId: string) {
-    const index = this.stack.indexOf(panelId)
-    if (index < 0) return
-    this.stack.splice(index, 1)
+    const stack = store.get("stack")
+    if (!stack.includes(panelId)) return
+    store.set(
+      "stack",
+      stack.filter((id) => id !== panelId),
+    )
   },
-  bringToFront(id: string) {
-    this.remove(id)
-    this.add(id)
+  bringToFront(panelId: string) {
+    const stack = store.get("stack")
+    if (stack[stack.length - 1] === panelId) return
+    store.set("stack", [...stack.filter((id) => id !== panelId), panelId])
   },
-  isTopmost(id: string) {
-    return this.stack[this.stack.length - 1] === id
+  isTopmost(panelId: string) {
+    const stack = store.get("stack")
+    return stack[stack.length - 1] === panelId
   },
-  indexOf(id: string) {
-    return this.stack.indexOf(id)
+  indexOf(panelId: string) {
+    return store.get("stack").indexOf(panelId)
   },
-})
+}

--- a/packages/machines/floating-panel/src/floating-panel.types.ts
+++ b/packages/machines/floating-panel/src/floating-panel.types.ts
@@ -207,6 +207,10 @@ interface PrivateContext {
    */
   isTopmost?: boolean | undefined
   /**
+   * The index of the panel in the panel stack, or `-1` when not stacked
+   */
+  stackIndex: number
+  /**
    * The size of the panel
    */
   size: Size

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2534,15 +2534,9 @@ importers:
       '@zag-js/dom-query':
         specifier: workspace:*
         version: link:../../utilities/dom-query
-      '@zag-js/popper':
-        specifier: workspace:*
-        version: link:../../utilities/popper
       '@zag-js/rect-utils':
         specifier: workspace:*
         version: link:../../utilities/rect
-      '@zag-js/store':
-        specifier: workspace:*
-        version: link:../../store
       '@zag-js/types':
         specifier: workspace:*
         version: link:../../types

--- a/shared/src/routes.ts
+++ b/shared/src/routes.ts
@@ -136,6 +136,7 @@ export const componentRoutes: ComponentRoute[] = [
       { slug: "controlled", title: "Controlled" },
       { slug: "focus-trap", title: "Focus Trap" },
       { slug: "popover-inside", title: "Popover Inside" },
+      { slug: "stacking", title: "Stacking" },
     ],
   },
   {


### PR DESCRIPTION
Closes #3243
Closes #3242

## Problem

Two related panel-stacking bugs when multiple floating panels are open:

1. **Stale stack on close (#3243):** panels are added to the shared `panelStack` when they open, but only removed when the machine is *destroyed*. Closing the topmost panel left it in the stack, so it kept `data-topmost` while the remaining open panel stayed `data-behind`.
2. **Stack order never reaches the positioner (#3242):** `trackPanelStack` wrote the stack index (`--z-index`) only to the content element. Each positioner creates a sibling stacking context, so a z-index on the content can never reorder panels relative to each other — focusing a panel updated its state but it visually stayed behind.

## Fix

- The `closed` state now removes the panel from the stack on entry. The next panel is promoted to topmost immediately, and reopening re-adds the panel through the existing `open` entry action.
- The stack index is now also applied to the positioner element, and `getPositionerProps` consumes it via `zIndex: "var(--z-index)"`. The content mirror of `--z-index` is kept for userland styling.

## Tests

Added a two-panel `stacking` example page and two e2e regression tests (close-promotes-next and focus-raises-positioner, asserting `data-topmost` and computed positioner z-index). Both fail on `main` and pass with this change; verified locally with a rebuild in each direction.
