### PR TITLE
fix(date-picker): make translations prop type partial

### DIFF
--- a/.changeset/mighty-teeth-invent.md
+++ b/.changeset/mighty-teeth-invent.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/date-picker": patch
+---
+
+fix(date-picker): make translations prop type partial

--- a/packages/machines/date-picker/src/date-picker.types.ts
+++ b/packages/machines/date-picker/src/date-picker.types.ts
@@ -118,7 +118,7 @@ export interface DatePickerProps extends DirectionProperty, CommonProperties {
   /**
    * The localized messages to use.
    */
-  translations?: IntlTranslations | undefined
+  translations?: Partial<IntlTranslations> | undefined
   /**
    * The ids of the elements in the date picker. Useful for composition.
    */


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The prop type for date picker translations should be partial as it is merged with the defaults 

https://github.com/chakra-ui/zag/blob/main/packages/machines/date-picker/src/date-picker.connect.ts#L101

```
  const translations = { ...defaultTranslations, ...prop("translations") }
```

## ⛳️ Current behavior (updates)

Currently requires all translations to be passed in, instead of allowing one at a time. Practically, this may be how it's used, but it isn't required based on how it works.

## 🚀 New behavior

Translations are now partial

## 💣 Is this a breaking change (Yes/No):

No. It's just widening of a type.

## 📝 Additional Information

I came across this while trying to fix labels for view triggers in the date picker in my project that uses Chakra UI

Related: https://github.com/chakra-ui/zag/issues/3257


Also I noticed in other places where translations are used, they are _not_ merged against defaults ([example](https://github.com/chakra-ui/zag/blob/main/packages/machines/clipboard/src/clipboard.connect.ts#L10)), so they should not be wrapped with `Partial<>`. I'm not sure if this discrepancy is to be expected. 

EDIT: most of them are not merged, and the place where they're merged is inconsistent--

### `date-input.machine.ts`

This happens in the `*.machine.ts` file instead of in `*.connect.ts` like in the date-picker.

https://github.com/chakra-ui/zag/blob/main/packages/machines/date-input/src/date-input.machine.ts#L42

```
const translations = { ...defaultTranslations, ...prop("translations") }
```

### `floating-panel.machine.ts`

This also happens in the machine file, not the connect like the date picker.

https://github.com/chakra-ui/zag/blob/main/packages/machines/floating-panel/src/floating-panel.machine.ts#L43

```
      translations: {
        ...defaultTranslations,
        ...props.translations,
      },
```