### PR TITLE
fix(splitter): blur resize trigger after pointer drag ends

### DIFF
--- a/packages/machines/splitter/src/splitter.connect.ts
+++ b/packages/machines/splitter/src/splitter.connect.ts
@@ -250,7 +250,7 @@ export function connect<T extends PropTypes>(service: SplitterService, normalize
 
           // Safari doesn't move focus to non-form elements on pointer down,
           // so focus explicitly to enable keyboard resizing after clicking.
-          event.currentTarget.focus({ preventScroll: true })
+          event.currentTarget.focus({ preventScroll: true, focusVisible: false })
 
           // If registry is enabled, it handles pointer events
           if (registry) {

--- a/packages/machines/splitter/src/splitter.machine.ts
+++ b/packages/machines/splitter/src/splitter.machine.ts
@@ -224,7 +224,7 @@ export const machine = createMachine<SplitterSchema>({
           },
           {
             target: "idle",
-            actions: ["invokeOnResizeEnd", "clearGlobalCursor"],
+            actions: ["invokeOnResizeEnd", "clearGlobalCursor", "blurResizeTrigger"],
           },
         ],
       },
@@ -707,6 +707,14 @@ export const machine = createMachine<SplitterSchema>({
 
       clearGlobalCursor({ scope }) {
         dom.removeGlobalCursor(scope)
+      },
+
+      blurResizeTrigger({ context, scope }) {
+        const dragState = context.get("dragState")
+        const resizeTriggerEl = dom.getResizeTriggerEl(scope, dragState?.resizeTriggerId)
+        if (scope.isActiveElement(resizeTriggerEl)) {
+          resizeTriggerEl?.blur()
+        }
       },
 
       focusNextResizeTrigger({ event, scope }) {


### PR DESCRIPTION
## Problem

After a pointer drag on the `Splitter.ResizeTrigger`, the trigger **remained focused**. `onPointerDown` explicitly called `.focus()` (to enable keyboard resizing after clicking, since Safari doesn't move focus to non-form elements on pointer down), but nothing removed that focus when the drag ended.

The ARIA [window splitter pattern](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) requires the separator to be *focusable and keyboard-operable* — it does **not** require focus to remain after a pointer drag. The leftover focus caused three degradations:

1. **Persistent focus styling** — focus-related visual styling stayed active after the temporary dragging state ended. Focus and dragging are separate states and should not appear as one persistent interaction state.
2. **Arrow keys captured** — after a purely pointer-based resize, subsequent arrow-key presses were still captured by the splitter, unexpectedly resizing it instead of navigating form controls or scrolling.
3. **` :focus-visible` matched after pointer interaction** — the programmatic focus made `:focus-visible` match even when the styling defines separate `:focus-visible` and `:focus` rules.

## Fix

- **`splitter.connect.ts`**: focus with `{ focusVisible: false }` on pointer down, so keyboard-focus styling is not applied for a pointer-initiated focus.
- **`splitter.machine.ts`**: on `POINTER_UP` in the *dragging* state, blur the resize trigger (`blurResizeTrigger` action) so focus is removed once the pointer drag ends. Keyboard resizing (arrow keys) is unaffected — the trigger is still reachable with Tab and operable with the keyboard.

Closes #3263