### PR TITLE
fix(menu): prevent typeahead highlight from being overridden by scroll-induced pointermove

### DIFF
--- a/packages/machines/menu/src/menu.machine.ts
+++ b/packages/machines/menu/src/menu.machine.ts
@@ -474,7 +474,7 @@ export const machine = createMachine<MenuSchema>({
         ],
         ITEM_POINTERMOVE: [
           {
-            guard: not("isPointerRoutingLocked"),
+            guard: and(not("isPointerRoutingLocked"), not("isTypingAhead")),
             actions: ["setHighlightedItem", "focusMenu", "closeSiblingMenus"],
           },
           {
@@ -482,7 +482,7 @@ export const machine = createMachine<MenuSchema>({
           },
         ],
         ITEM_POINTERLEAVE: {
-          guard: and(not("isPointerRoutingLocked"), not("isTriggerItem")),
+          guard: and(not("isPointerRoutingLocked"), not("isTypingAhead"), not("isTriggerItem")),
           actions: ["clearHighlightedItem"],
         },
         ITEM_CLICK: [
@@ -551,6 +551,7 @@ export const machine = createMachine<MenuSchema>({
       },
       isSubmenu: ({ context }) => context.get("isSubmenu"),
       isPointerRoutingLocked: ({ refs }) => refs.get("pointerRoutingLocked"),
+      isTypingAhead: ({ refs }) => refs.get("typeaheadState").keysSoFar !== "",
       isHighlightedItemEditable: ({ scope, computed }) => isEditableElement(scope.getById(computed("highlightedId")!)),
       // guard assertions (for controlled mode)
       isOpenControlled: ({ prop }) => prop("open") !== undefined,


### PR DESCRIPTION
## Problem

When the user hovers over the menu content with a mouse and then triggers typeahead (e.g. pressing h to find Hey), the matched item is highlighted and scrolled into view — but immediately deselected.

### Root cause

scrollToHighlightedItem scrolls the matched item into view. Because the menu items shift under the stationary cursor, the browser fires a pointermove event on a different item now under the cursor. That ITEM_POINTERMOVE event calls setHighlightedItem, overriding the typeahead highlight that was just set.

## Fix

Add an isTypingAhead guard to both ITEM_POINTERMOVE and ITEM_POINTERLEAVE so pointer events are ignored while typeahead search is active.

- Introduced a new isTypingAhead guard reading refs.typeaheadState.keysSoFar !== ""
- ITEM_POINTERMOVE: guard: and(not("isPointerRoutingLocked"), not("isTypingAhead"))
- ITEM_POINTERLEAVE: guard: and(not("isPointerRoutingLocked"), not("isTypingAhead"), not("isTriggerItem"))

The typeahead state has a built-in 350ms timeout (getByTypeahead), so normal pointer behavior resumes automatically once keysSoFar resets.

Fixes chakra-ui/zag#3255