### PR TITLE
fix(dismissable): clear layer stack metadata from the layer node on removal

### DIFF
--- a/.changeset/dismissable-clear-layer-node-mirror.md
+++ b/.changeset/dismissable-clear-layer-node-mirror.md
@@ -1,0 +1,9 @@
+---
+"@zag-js/dismissable": patch
+---
+
+Fix layer stack metadata never being cleared from the layer node itself. `syncLayers` stamps `--layer-index`,
+`--nested-layer-count`, `data-nested` and `data-has-nested` on `layer.node` as well as on each style target, but
+`remove` cleared only the style targets. A dismissed layer's node kept its last stamp indefinitely, so CSS keyed on
+those attributes styled the wrong state until the layer opened again, and the attributes could not be used to tell a
+live layer from a removed one.

--- a/packages/utilities/dismissable/src/layer-stack.ts
+++ b/packages/utilities/dismissable/src/layer-stack.ts
@@ -106,6 +106,9 @@ export const layerStack = {
     if (index < 0) return
 
     const layer = this.layers[index]
+    // `syncLayers` stamps the metadata on the layer node as well as its style targets,
+    // so removal has to clear both or the node keeps its last stamp for good.
+    clearLayerStyleMirror(layer.node)
     layer.styleTargets?.forEach((getTarget) => {
       const target = getTarget()
       if (target) {

--- a/packages/utilities/dismissable/tests/layer-stack.test.ts
+++ b/packages/utilities/dismissable/tests/layer-stack.test.ts
@@ -126,6 +126,28 @@ describe("layerStack", () => {
       expect(backdrop.style.getPropertyValue("--z-index")).toBe("")
     })
 
+    test("clears mirrored styles on the layer node itself when removed", () => {
+      const parent = document.createElement("div")
+      const child = document.createElement("div")
+      document.body.append(parent, child)
+
+      layerStack.add(createLayer(parent))
+      layerStack.add(createLayer(child))
+
+      expect(child.style.getPropertyValue("--layer-index")).toBe("1")
+      expect(child.getAttribute("data-nested")).toBe("dialog")
+      expect(parent.getAttribute("data-has-nested")).toBe("dialog")
+
+      layerStack.remove(child)
+
+      expect(child.style.getPropertyValue("--layer-index")).toBe("")
+      expect(child.style.getPropertyValue("--nested-layer-count")).toBe("")
+      expect(child.hasAttribute("data-nested")).toBe(false)
+      // The remaining layer is re-synced, so only the removed node goes stale.
+      expect(parent.style.getPropertyValue("--layer-index")).toBe("0")
+      expect(parent.hasAttribute("data-has-nested")).toBe(false)
+    })
+
     test("skips mirroring when target is the same node as the layer", () => {
       const node = document.createElement("div")
       document.body.append(node)


### PR DESCRIPTION
## 📝 Description

`layerStack`'s DOM mirror is write-only for the layer node: `syncLayers` stamps it, `remove` never
clears it.

```ts
syncLayers() {
  this.layers.forEach((layer, index) => {
    applyLayerStackMetadata(layer, index, layer.node)   // ← the node
    layer.styleTargets?.forEach(/* ← and each style target */)
  })
},

remove(node) {
  const layer = this.layers[index]
  layer.styleTargets?.forEach((getTarget) => {
    const target = getTarget()
    if (target) clearLayerStyleMirror(target)           // ← style targets only
  })
  ...
}
```

`clearLayerStyleMirror` has exactly one call site, that loop. So a removed layer's node keeps
`--layer-index`, `--nested-layer-count`, `data-nested` and `data-has-nested` for good.

Style targets already clear correctly and are covered by
`styleTargets > clears mirrored styles when the layer is removed`, so this looks like the node was
simply missed rather than an intentional asymmetry.

## ⛳️ Current behavior (updates)

A dismissed layer whose node stays mounted — the normal case for content that is hidden rather than
unmounted — keeps its last stamp until it is opened again and re-stamped. Two consequences:

- CSS keyed on `[data-nested]`, `[data-has-nested]` or `var(--layer-index)` styles the closed layer
  as if it were still on the stack.
- The attributes cannot be used to observe the stack: a removed layer's node is indistinguishable
  from a live one. I hit this while debugging a nested-layer problem — reading the mirror from the
  console gave a stale ordering, with a corpse and a live layer both reporting index `1`.

## 🚀 New behavior

`remove` clears the mirror on `layer.node` as well as on the style targets. Remaining layers are
still re-synced by the existing `syncLayers()` call, so only the removed node changes.

Added `styleTargets > clears mirrored styles on the layer node itself when removed`, which fails on
`main` with `expected '1' to be ''` and passes with the fix. `pnpm exec vitest run
packages/utilities/dismissable/tests/` is green (20 tests).

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The `v2` branch supersedes this by construction rather than by fixing it: `dismissable` no longer
writes the DOM at all, `syncLayers` publishes a `LayerSnapshot` through `onLayerChange`, machines
store it in context, and `connect` renders the attributes from that state — so `remove`'s explicit
`{ active: false, blocked: false }` publish clears them declaratively. This PR is only for the 1.x
line, which is still receiving releases.
