### PR TITLE
fix(auto-resize): use textContent to prevent DOM XSS in ghost measurement element

### DIFF
--- a/.changeset/auto-resize-input-textcontent.md
+++ b/.changeset/auto-resize-input-textcontent.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/auto-resize": patch
+---
+
+Fix `autoResizeInput` assigning the input value to the measurement ghost element via `innerHTML`, which parsed the value as HTML and allowed DOM-based XSS (e.g. `<img src=x onerror=...>`) when the input value came from untrusted data such as a stored/edited tag. The ghost element now uses `textContent`, which both prevents the HTML parsing and measures the raw text width correctly.

--- a/packages/utilities/auto-resize/src/autoresize-input.ts
+++ b/packages/utilities/auto-resize/src/autoresize-input.ts
@@ -23,7 +23,7 @@ export function autoResizeInput(input: HTMLInputElement | null) {
 
   function resize() {
     win.requestAnimationFrame(() => {
-      ghost.innerHTML = input!.value
+      ghost.textContent = input!.value
       const rect = win.getComputedStyle(ghost)
       input?.style.setProperty("width", rect.width)
     })


### PR DESCRIPTION
## Summary

`autoResizeInput` assigns the input's value to an off-screen "ghost" measurement element using `innerHTML`. Because `innerHTML` parses the assigned string as HTML, any markup contained in the input value is turned into live DOM. This is a DOM-based XSS sink.

`packages/utilities/auto-resize/src/autoresize-input.ts`:

```ts
function resize() {
  win.requestAnimationFrame(() => {
    ghost.innerHTML = input!.value   // <-- value parsed as HTML
    const rect = win.getComputedStyle(ghost)
    input?.style.setProperty("width", rect.width)
  })
}
```

`resize()` runs on mount and on every `input`/`change` event, so the value only needs to reach the input element; it never has to be typed live.

## Impact

If the input value originates from untrusted data, an attacker-supplied payload such as `<img src=x onerror="/* attacker JS */">` executes in the page origin. In this repo the utility is wired into the `tags-input` machine's editable-tag flow (`autoResize` action), where the input is pre-filled with a stored tag value. Tag collections are exactly the kind of data that is persisted and re-rendered, and can be authored by one user and displayed to another, so a stored tag value can trigger the sink the moment a tag enters edit mode. `@zag-js/auto-resize` is also a public package, so any consumer calling `autoResizeInput` on an input with untrusted value is exposed.

Note that `<script>` inserted via `innerHTML` does not run, but `onerror`/`onload` handlers on injected elements (img, svg, etc.) do, so this is a working execution primitive, not just markup injection.

## Fix

Use `textContent` instead of `innerHTML`. The ghost element exists only to measure the pixel width of the input's text, so it should hold the raw string, not parsed markup. `textContent` prevents the HTML parsing entirely and, combined with the existing `white-space:nowrap` on the ghost, measures the width more accurately for values containing HTML-special characters (`<`, `&`, etc.) which `innerHTML` would otherwise misrender.

```diff
- ghost.innerHTML = input!.value
+ ghost.textContent = input!.value
```

One-line change plus a changeset. No public API change, no behavior change for normal text input.
