### PR TITLE
fix(listbox): keep highlight when content scrolls under the cursor

### DIFF
--- a/.changeset/listbox-scroll-under-cursor.md
+++ b/.changeset/listbox-scroll-under-cursor.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/listbox": patch
+---
+
+Fix keyboard navigation moving the highlighted item when the mouse is resting over the list. Scrolling the item into view slid content under the cursor, and Safari treated the resulting pointermove as a real hover.

--- a/packages/machines/listbox/src/listbox.connect.ts
+++ b/packages/machines/listbox/src/listbox.connect.ts
@@ -1,4 +1,5 @@
 import { isGridCollection, type CollectionItem } from "@zag-js/collection"
+import { getInteractionModality } from "@zag-js/focus-visible"
 import type { Service } from "@zag-js/core"
 import {
   ariaAttr,
@@ -238,6 +239,7 @@ export function connect<T extends PropTypes, V extends CollectionItem = Collecti
         onPointerMove(event) {
           if (!props.highlightOnHover) return
           if (itemState.disabled || event.pointerType !== "mouse") return
+          if (getInteractionModality() !== "pointer") return
           if (itemState.highlighted) return
           send({ type: "ITEM.POINTER_MOVE", value: itemState.value })
         },


### PR DESCRIPTION
Closes #3273

## 📝 Description

Port the `getInteractionModality()` guard from `c15e7ec` to listbox so keyboard navigation keeps the highlighted item when scrollable content moves under a stationary cursor.

## ⛳️ Current behavior (updates)

With `highlightOnHover` enabled, keyboard navigation (e.g. End) scrolls the newly highlighted item into view. In Safari, that scroll fires a synthetic `pointermove` on whatever item is now under the resting mouse. Listbox treated it as a real hover and moved the highlight off the keyboard target.

## 🚀 New behavior

`onPointerMove` returns early unless the current interaction modality is `pointer`. Keyboard-driven synthetic `pointermove` is ignored; actually moving the mouse still updates the highlight.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Same guard already landed for menu, select, and combobox in `c15e7ec`. `@zag-js/focus-visible` was already a listbox dependency.

Verified manually in Safari on `/listbox/basic` with `highlightOnHover: true` (reverted before commit; the default example does not enable hover highlight). Chrome does not show this bug because it emits `pointerleave` rather than `pointermove`, and listbox has no leave handler.

No E2E added: the default listbox example does not pass `highlightOnHover`, so the existing select/menu scroll-under-cursor tests cannot be copied without changing the demo.