### PR TITLE
fix(cascade-select): keep highlight when content scrolls under the cu…

### DIFF
--- a/.changeset/cascade-select-scroll-under-cursor.md
+++ b/.changeset/cascade-select-scroll-under-cursor.md
@@ -1,0 +1,5 @@
+---
+"@zag-js/cascade-select": patch
+---
+
+Fix keyboard navigation moving the highlighted item when the mouse is resting over a cascade-select column. Scrolling the item into view slid content under the cursor, and the resulting pointer events were treated as a real hover.

--- a/packages/machines/cascade-select/src/cascade-select.connect.ts
+++ b/packages/machines/cascade-select/src/cascade-select.connect.ts
@@ -1,5 +1,6 @@
 import { ariaAttr, dataAttr, getEventKey, isEditableElement, isSelfTarget, isValidTabEvent } from "@zag-js/dom-query"
 import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
+import { getInteractionModality } from "@zag-js/focus-visible"
 import type { EventKeyMap, NormalizeProps, PropTypes } from "@zag-js/types"
 import type { Service } from "@zag-js/core"
 import { isEqual } from "@zag-js/utils"
@@ -383,6 +384,7 @@ export function connect<T extends PropTypes, V = TreeNode>(
         onPointerEnter(event) {
           if (!interactive) return
           if (itemState.disabled) return
+          if (getInteractionModality() !== "pointer") return
           send({
             type: "ITEM.POINTER_ENTER",
             value: itemState.value,
@@ -395,7 +397,7 @@ export function connect<T extends PropTypes, V = TreeNode>(
           if (!interactive) return
           if (itemState.disabled) return
           if (event.pointerType !== "mouse") return
-
+          if (getInteractionModality() !== "pointer") return
           const pointerMoved = service.event.previous()?.type.includes("POINTER")
           if (!pointerMoved) return
 


### PR DESCRIPTION
Closes #3274

## 📝 Description

Port the `getInteractionModality()` guard from `c15e7ec` to cascade-select so keyboard navigation keeps the highlighted item when a column scrolls under a stationary cursor.

## ⛳️ Current behavior (updates)

With `highlightTrigger` set to `hover`, keyboard navigation (e.g. End) scrolls the newly highlighted item into view. The item under the resting mouse changes, and the browser fires synthetic pointer events. Cascade-select treated those as a real hover (`ITEM.POINTER_ENTER` / `ITEM.POINTER_LEAVE`) and moved the highlight off the keyboard target. Reproduced in Chrome.

## 🚀 New behavior

`onPointerEnter` and `onPointerLeave` return early unless the current interaction modality is `pointer`. Keyboard-driven synthetic pointer events are ignored; actually moving the mouse still updates the highlight.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Same approach as menu, select, and combobox in `c15e7ec`. `@zag-js/focus-visible` was already a cascade-select dependency.

In this component the highlight move is driven by `onPointerEnter` (Chrome). The old `service.event.previous()?.type.includes("POINTER")` check is still present on `onPointerLeave` in addition to the modality guard. `getContentProps`'s `onPointerMove` (grace area) is unchanged.

Verified manually in Chrome on `/cascade-select/basic` with `highlightTrigger: hover`: hover a visible country, press End, highlight stays on the last item; moving the mouse afterwards still changes the highlight.