### PR TITLE
docs: update marko-zag adapter status to community maintained

### DIFF
--- a/website/data/guides/framework-adapters.mdx
+++ b/website/data/guides/framework-adapters.mdx
@@ -154,7 +154,7 @@ and framework versions before adopting it.
 | Framework | Adapter                                                | Status               |
 | --------- | ------------------------------------------------------ | -------------------- |
 | Angular   | [`zag-angular`](https://github.com/makuko/zag-angular) | Community maintained |
-| Marko     | [`marko-zag`](https://github.com/svallory/marko-zag)   | Work in progress     |
+| Marko     | [`marko-zag`](https://github.com/svallory/marko-zag)   | Community maintained |
 
 Built an adapter for another framework? Open a documentation pull request that
 links to its source, package, usage example, test suite, and supported version


### PR DESCRIPTION
## Description

Updates the Marko row in the community adapters table from **Work in progress** to **Community maintained**.

Per the guide's checklist for adapter listings:

- **Source**: https://github.com/svallory/marko-zag
- **Package**: [`marko-zag`](https://www.npmjs.com/package/marko-zag)
- **Docs & usage examples**: https://marko-zag.saulo.tech (three-tag pattern, SSR/hydration guide, full API reference)
- **Test suite**: [tests/](https://github.com/svallory/marko-zag/tree/main/tests) — 37 unit/integration tests (jsdom + node for the SSR path: normalizer, mergeProps, full machine lifecycle incl. controlled/uncontrolled bindables, sync flush, watch tracks, pre-start event buffering, @zag-js/checkbox integration) plus 14 real-Chromium tests (vitest browser mode: @zag-js/tooltip with real floating-ui positioning, @zag-js/combobox keyboard navigation/selection, and value/checked property semantics through compiled Marko templates)
- **Supported version ranges**: `@zag-js/* ^1.43.0`, `marko ^6.3.34` (peer)

The adapter follows this guide's contracts: ported from the Solid adapter's machine interpreter, `createNormalizer`-based prop normalization (focusin/focusout mapping, Marko attribute dialect), `mergeProps`, an SSR-safe portal, and a `useSyncExternalStore` analog for store-driven features.
