### PR TITLE
fix(aria-hidden): use inert to suppress content below modals

### DIFF
--- a/.changeset/aria-hidden-inert-modal.md
+++ b/.changeset/aria-hidden-inert-modal.md
@@ -9,3 +9,6 @@ Fix background content receiving clicks through a modal overlay when an
 underlying element sets `pointer-events: auto`. Content below a modal is now
 made `inert` (falling back to `aria-hidden` where `inert` is unsupported), so
 it can't be clicked or focused regardless of its `pointer-events` value.
+
+`persistentElements` are excluded from the `inert` walk, so they stay
+interactive under a modal as before.

--- a/.changeset/aria-hidden-inert-modal.md
+++ b/.changeset/aria-hidden-inert-modal.md
@@ -1,0 +1,11 @@
+---
+"@zag-js/aria-hidden": patch
+"@zag-js/dialog": patch
+"@zag-js/popover": patch
+"@zag-js/drawer": patch
+---
+
+Fix background content receiving clicks through a modal overlay when an
+underlying element sets `pointer-events: auto`. Content below a modal is now
+made `inert` (falling back to `aria-hidden` where `inert` is unsupported), so
+it can't be clicked or focused regardless of its `pointer-events` value.

--- a/packages/machines/dialog/src/dialog.machine.ts
+++ b/packages/machines/dialog/src/dialog.machine.ts
@@ -197,7 +197,10 @@ export const machine = createMachine<DialogSchema>({
 
       hideContentBelow({ scope, prop }) {
         if (!prop("modal")) return
-        const getElements = () => [dom.getContentEl(scope)]
+        const getElements = () => [
+          dom.getContentEl(scope),
+          ...(prop("persistentElements")?.map((fn) => fn() as HTMLElement | null) ?? []),
+        ]
         return ariaHidden(getElements, { defer: true })
       },
     },

--- a/packages/machines/popover/src/popover.machine.ts
+++ b/packages/machines/popover/src/popover.machine.ts
@@ -205,7 +205,11 @@ export const machine = createMachine<PopoverSchema>({
 
       hideContentBelow({ prop, scope, context }) {
         if (!prop("modal")) return
-        const getElements = () => [dom.getContentEl(scope), dom.getActiveTriggerEl(scope, context.get("triggerValue"))]
+        const getElements = () => [
+          dom.getContentEl(scope),
+          dom.getActiveTriggerEl(scope, context.get("triggerValue")),
+          ...(prop("persistentElements")?.map((fn) => fn() as HTMLElement | null) ?? []),
+        ]
         return ariaHidden(getElements, { defer: true })
       },
 

--- a/packages/utilities/aria-hidden/src/index.ts
+++ b/packages/utilities/aria-hidden/src/index.ts
@@ -1,4 +1,4 @@
-import { hideOthers } from "./aria-hidden"
+import { suppressOthers } from "./aria-hidden"
 
 const raf = (fn: VoidFunction) => {
   const frameId = requestAnimationFrame(() => fn())
@@ -22,7 +22,7 @@ export function ariaHidden(targetsOrFn: TargetsOrFn, options: Options = {}) {
       const targets = typeof targetsOrFn === "function" ? targetsOrFn() : targetsOrFn
       const elements = targets.filter(Boolean) as HTMLElement[]
       if (elements.length === 0) return
-      cleanups.push(hideOthers(elements))
+      cleanups.push(suppressOthers(elements))
     }),
   )
   return () => {

--- a/packages/utilities/aria-hidden/tests/index.test.ts
+++ b/packages/utilities/aria-hidden/tests/index.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeAll, describe, expect, test } from "vitest"
+import { ariaHidden } from "../src"
+
+beforeAll(() => {
+  // Force the inert branch of `suppressOthers`, which checks for this property.
+  if (!HTMLElement.prototype.hasOwnProperty("inert")) {
+    Object.defineProperty(HTMLElement.prototype, "inert", { value: false, writable: true, configurable: true })
+  }
+})
+
+afterEach(() => {
+  document.body.innerHTML = ""
+})
+
+describe("ariaHidden", () => {
+  test("makes sibling content inert and restores it on cleanup", () => {
+    document.body.innerHTML = `
+      <a id="outside" style="pointer-events: auto">link</a>
+      <div id="dialog"><button>close</button></div>
+    `
+    const outside = document.getElementById("outside")!
+    const dialog = document.getElementById("dialog")!
+
+    const restore = ariaHidden([dialog], { defer: false })!
+
+    // Inert blocks pointer events even when the element sets pointer-events: auto.
+    expect(outside.hasAttribute("inert")).toBe(true)
+    // The dialog itself stays interactive.
+    expect(dialog.hasAttribute("inert")).toBe(false)
+
+    restore()
+    expect(outside.hasAttribute("inert")).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #3203

## 📝 Description

modal content is suppressed with `inert` instead of `aria-hidden`, and `persistentElements` are kept out of the inert walk so they stay interactive.

## ⛳️ Current behavior (updates)

content below a modal is hidden with `aria-hidden` and a body-level `pointer-events: none`. that value only reaches children by inheritance, so an element with `pointer-events: auto` breaks out and stays clickable through the modal.

## 🚀 New behavior

`ariaHidden` now uses `suppressOthers`, which sets `inert`. inert blocks clicks and focus regardless of `pointer-events`, and falls back to `aria-hidden` on browsers without inert support. applies to modal dialog, popover, and drawer.

`persistentElements` are kept interactive by setting `pointer-events: auto`, which inert would otherwise override and kill. they're now passed into `hideContentBelow` so they're excluded from the inert walk, matching how the dismissable layer already excludes them. dialog and popover; drawer has no `persistentElements` prop.

## 💣 Is this a breaking change (Yes/No):

no. older browsers keep the `aria-hidden` path, and `persistentElements` keep working under a modal.

## 📝 Additional Information

changeset patches `@zag-js/aria-hidden`, `@zag-js/dialog`, `@zag-js/popover`, `@zag-js/drawer`.
