### PR TITLE
fix(color-picker): expose aria-disabled on area and channel slider thumbs

### DIFF
--- a/.changeset/color-picker-slider-aria-disabled.md
+++ b/.changeset/color-picker-slider-aria-disabled.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/color-picker": patch
+---
+
+Fix `aria-disabled` on the color area thumb and channel slider thumb so assistive technology reports both
+`role="slider"` elements as disabled when `disabled` is set. The channel slider thumb emitted `aria-disabled=""`, which
+browsers map to the `false` default, and the area thumb omitted the attribute entirely.

--- a/e2e/color-picker.e2e.ts
+++ b/e2e/color-picker.e2e.ts
@@ -153,3 +153,19 @@ test.describe("color-picker", () => {
     await I.seeColorPicker()
   })
 })
+
+test.describe("color-picker / disabled", () => {
+  test.beforeEach(async ({ page }) => {
+    I = new ColorPickerModel(page)
+    await I.gotoInline()
+    await I.controls.bool("disabled")
+  })
+
+  test("[disabled] area thumb should expose aria-disabled", async () => {
+    await I.seeAreaThumbIsDisabled()
+  })
+
+  test("[disabled] channel slider thumb should expose aria-disabled", async () => {
+    await I.seeChannelThumbIsDisabled("hue")
+  })
+})

--- a/e2e/models/color-picker.model.ts
+++ b/e2e/models/color-picker.model.ts
@@ -13,6 +13,10 @@ export class ColorPickerModel extends Model {
     return this.page.goto("/color-picker/basic")
   }
 
+  gotoInline() {
+    return this.page.goto("/color-picker/inline")
+  }
+
   private get trigger() {
     return this.page.locator(part("trigger"))
   }
@@ -103,6 +107,14 @@ export class ColorPickerModel extends Model {
 
   seeChannelThumbIsFocused(channel: Channel) {
     return expect(this.channelThumb(channel)).toBeFocused()
+  }
+
+  seeAreaThumbIsDisabled() {
+    return expect(this.areaThumb).toHaveAttribute("aria-disabled", "true")
+  }
+
+  seeChannelThumbIsDisabled(channel: Channel) {
+    return expect(this.channelThumb(channel)).toHaveAttribute("aria-disabled", "true")
   }
 
   clickFirstSwatch() {

--- a/packages/machines/color-picker/src/color-picker.connect.ts
+++ b/packages/machines/color-picker/src/color-picker.connect.ts
@@ -1,6 +1,6 @@
 import { getColorAreaGradient, normalizeColor } from "@zag-js/color-utils"
 import { getEventKey, getEventPoint, getEventStep, isComposingEvent, isLeftClick, isModifierKey } from "@zag-js/dom-query"
-import { dataAttr, query, visuallyHiddenStyle } from "@zag-js/dom-query"
+import { ariaAttr, dataAttr, query, visuallyHiddenStyle } from "@zag-js/dom-query"
 import { getPlacementSide, getPlacementStyles } from "@zag-js/popper"
 import type { NormalizeProps, PropTypes, EventKeyMap } from "@zag-js/types"
 import { parts } from "./color-picker.anatomy"
@@ -292,6 +292,7 @@ export function connect<T extends PropTypes>(
         "data-invalid": dataAttr(invalid),
         "data-readonly": dataAttr(readOnly),
         role: "slider",
+        "aria-disabled": ariaAttr(disabled),
         "aria-valuemin": 0,
         "aria-valuemax": 100,
         "aria-valuenow": xValue,
@@ -473,7 +474,7 @@ export function connect<T extends PropTypes>(
         "data-channel": channel,
         "data-disabled": dataAttr(disabled),
         "data-orientation": orientation,
-        "aria-disabled": dataAttr(disabled),
+        "aria-disabled": ariaAttr(disabled),
         "aria-orientation": orientation,
         "aria-valuemax": channelRange.maxValue,
         "aria-valuemin": channelRange.minValue,


### PR DESCRIPTION
## 📝 Description

Neither `role="slider"` element in `color-picker` exposes its disabled state.

`getChannelSliderThumbProps()` builds `aria-disabled` with `dataAttr()`, which returns `""`, and `getAreaThumbProps()` omits the attribute entirely. WAI-ARIA 1.2 types `aria-disabled` as `true/false` and defines only `true` and `false (default)`; §6.2.4 says "The default value for this value type is false unless otherwise specified" — so `aria-disabled=""` is read as *enabled*.

The sibling `slider` machine already uses `ariaAttr()` for the same thumb, so this is a copy of the adjacent `data-disabled` line rather than a deliberate difference.

## ⛳️ Current behavior (updates)

With `disabled: true` on `/color-picker/inline`, Chrome 151 computes both thumbs as `{role: slider, settable: true}` — no `disabled` property, identical to the attribute being absent.

## 🚀 New behavior

Both thumbs compute as `{role: slider, disabled: true}` and `settable` drops off.

Two e2e cases cover it. They fail on `main`, and also fail against the naive fix (adding `aria-disabled: dataAttr(disabled)` to the area thumb), which emits the attribute but keeps the empty value.

## 💣 Is this a breaking change (Yes/No):

No. Only adds/corrects an ARIA attribute; `data-disabled` and `tabIndex` are untouched.

## 📝 Additional Information

The existing axe check in `color-picker.e2e.ts` could not have caught this: axe-core 4.13's `aria-valid-attr-value` does not flag `aria-disabled=""`, and the check only runs in the enabled state. The new tests assert the attribute value directly.

Limits: disabled thumbs already drop `tabIndex`, so the gap shows up in browse/virtual-cursor navigation rather than tabbing. Verified via the Chrome accessibility tree (CDP `Accessibility.getPartialAXTree`), not with a screen reader.

