### PR TITLE
fix(menu): keep submenu open while pointer is over it or its trigger

### DIFF
--- a/.changeset/menu-submenu-stale-intent-polygon.md
+++ b/.changeset/menu-submenu-stale-intent-polygon.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/menu": patch
+---
+
+Keep a submenu open while the pointer is still over it or over its trigger item. The intent polygon is captured once
+from the submenu's rect, so a submenu that is still animating in or being repositioned was measured in the wrong place
+and closed under the pointer.

--- a/packages/machines/menu/src/menu.machine.ts
+++ b/packages/machines/menu/src/menu.machine.ts
@@ -660,6 +660,17 @@ export const machine = createMachine<MenuSchema>({
         const doc = scope.getDoc()
 
         return addDomEvent(doc, "pointermove", (e) => {
+          // `intentPolygon` is captured once, from the submenu's rect at the moment the
+          // pointer crossed the trigger item. While the submenu is still animating in or
+          // being repositioned, that snapshot no longer describes where the content is, so
+          // the polygon test misses and the submenu closes under the pointer. The pointer
+          // cannot have moved away from the submenu while it is still over the submenu
+          // itself, or over the trigger item that owns it.
+          const target = getEventTarget<Element>(e)
+          if (contains(dom.getContentEl(scope), target) || contains(dom.getTriggerEl(scope), target)) {
+            return
+          }
+
           const isMovingToSubmenu = isWithinPolygon(context.get("intentPolygon"), {
             x: e.clientX,
             y: e.clientY,


### PR DESCRIPTION
## 📝 Description

A nested menu can close itself the instant it opens: the submenu appears, then disappears again before the pointer can reach it.

The cause is that `intentPolygon` is a one-time snapshot of geometry that is still moving.

`setIntentPolygon` is wired only to `TRIGGER_POINTERMOVE` and `TRIGGER_POINTERLEAVE`, and captures the submenu's rect at that instant:

```ts
setIntentPolygon({ context, scope, event }) {
  const menu = dom.getContentEl(scope)
  const rect = menu.getBoundingClientRect()   // captured once
  const polygon = getElementPolygon(rect, placement)
  context.set("intentPolygon", [{ ...event.point, x: event.point.x + bleed }, ...polygon])
}
```

Nothing recomputes it when the submenu moves. So while the submenu is still running its enter animation, or is being repositioned by `autoUpdate`, the stored polygon describes where the content *was*, not where it *is*. `trackPointerMove` then tests the next `pointermove` against that stale polygon, the test misses, and `POINTER_MOVED_AWAY_FROM_SUBMENU` closes the submenu under the pointer.

This is easy to hit with any UI layer that animates menu content on open. Chakra UI v3, for example, applies `slide-fade-in` to `Menu.Content` — roughly 150 ms of `translate`, during which `getBoundingClientRect()` returns a moving rect. It is also reliably reproducible under browser automation, where a hover is a single synthetic `mousemove` rather than a stream of them.

## ⛳️ Current behavior (updates)

While the submenu is animating in or being repositioned, a `pointermove` that lands **on the submenu itself** — or on the trigger item that opened it — is treated as "moved away from submenu", and the submenu closes.

## 🚀 New behavior

`trackPointerMove` bails out before consulting the polygon when the pointer is still over the submenu content or over the trigger item that owns it. Neither can mean the pointer moved away from the submenu.

```ts
const target = getEventTarget<Element>(e)
if (contains(dom.getContentEl(scope), target) || contains(dom.getTriggerEl(scope), target)) {
  return
}
```

The polygon path itself is untouched, so crossing sibling items diagonally toward the submenu keeps working exactly as before. This only **adds** cases where closing is refused — it cannot cause a submenu to close where it previously stayed open.

`contains` and `getEventTarget` are already imported in `menu.machine.ts`, so no new imports or dependencies. Reading `e.target` avoids the forced layout that `elementFromPoint` would cost, and stays correct across shadow roots via `contains`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is the same class of bug as the earlier `@zag-js/focus-visible` fix ("Ignore same-position pointer moves only for trusted events" / content scrolling under a resting cursor) — a pointer event generated by the UI moving, rather than by the user moving — but that fix governs the highlighted item and interaction modality, and `trackPointerMove` never consults modality, so submenu dismissal was left uncovered.

Included a changeset for a `@zag-js/menu` patch bump.

I was not able to run the full workspace test suite locally, so I have leaned on keeping the change minimal and additive; happy to adjust if you would prefer the polygon be recomputed on reposition instead, which would be the more thorough fix but a larger change.

_Authored with the help of Claude Code._