### PR TITLE
fix(vanilla): reconcile style prop per-property in spreadProps

### DIFF
--- a/.changeset/vanilla-style-prop-clobbers-inline-styles.md
+++ b/.changeset/vanilla-style-prop-clobbers-inline-styles.md
@@ -1,0 +1,7 @@
+---
+"@zag-js/vanilla": patch
+---
+
+Fix `spreadProps` replacing the entire `style` attribute whenever the serialized `style` prop string changed, which wiped out any inline style properties set on the same element outside of Zag's prop system (e.g. `@zag-js/dismissable`'s layer-stack, which writes `--layer-index`/`--nested-layer-count`/`--z-index` directly via `element.style.setProperty(...)`).
+
+`style` is now reconciled property by property - only the CSS properties Zag itself computed are added, updated, or removed, and any other inline style on the element is left untouched. This mirrors how the React adapter patches styles.

--- a/packages/frameworks/vanilla/src/spread-props.ts
+++ b/packages/frameworks/vanilla/src/spread-props.ts
@@ -4,6 +4,11 @@ export interface Attrs {
 
 const prevAttrsMap = new WeakMap<Element, Map<string, Attrs>>()
 
+// CSS property names previously applied to an element's inline style by `spreadProps` itself,
+// keyed like `prevAttrsMap`. Tracked separately so the `style` prop can be reconciled property by
+// property instead of replacing the whole `style` attribute.
+const prevStylePropsMap = new WeakMap<Element, Map<string, Set<string>>>()
+
 const assignableProps = new Set<string>(["value", "checked", "selected"])
 
 // SVG attributes that need to preserve case
@@ -30,6 +35,45 @@ const isSvgElement = (node: Element): boolean => {
 const getAttributeName = (node: Element, attrName: string): string => {
   const shouldPreserveCase = isSvgElement(node) && caseSensitiveSvgAttrs.has(attrName)
   return shouldPreserveCase ? attrName : attrName.toLowerCase()
+}
+
+// Parses a `prop:value;` style string back into a map
+const parseStyleString = (style: string): Map<string, string> => {
+  const result = new Map<string, string>()
+  for (const decl of style.split(";")) {
+    const separator = decl.indexOf(":")
+    if (separator === -1) continue
+    const prop = decl.slice(0, separator).trim()
+    const value = decl.slice(separator + 1).trim()
+    if (prop) result.set(prop, value)
+  }
+  return result
+}
+
+// Reconciles the element's inline style against only the CSS properties Zag previously applied
+// for this scope, adding/updating/removing exactly those - never touching any other property that
+// may be present on the element's `style`.
+const applyStyle = (node: Element, style: unknown, scopeKey: string): void => {
+  if (!("style" in node)) return
+  const declaration = (node as HTMLElement).style
+
+  let machineMap = prevStylePropsMap.get(node)
+  if (!machineMap) {
+    machineMap = new Map<string, Set<string>>()
+    prevStylePropsMap.set(node, machineMap)
+  }
+
+  const prevProps = machineMap.get(scopeKey) ?? new Set<string>()
+  const nextProps = parseStyleString(typeof style === "string" ? style : "")
+
+  for (const prop of prevProps) {
+    if (!nextProps.has(prop)) declaration.removeProperty(prop)
+  }
+  for (const [prop, value] of nextProps) {
+    declaration.setProperty(prop, value)
+  }
+
+  machineMap.set(scopeKey, new Set(nextProps.keys()))
 }
 
 export function spreadProps(node: Element, attrs: Attrs, machineId?: string): () => void {
@@ -71,6 +115,12 @@ export function spreadProps(node: Element, attrs: Attrs, machineId?: string): ()
       return
     }
 
+    // Reconcile style property-by-property instead of replacing the whole attribute
+    if (attrName === "style") {
+      applyStyle(node, value, scopeKey)
+      return
+    }
+
     // Handle DOM properties (value, checked, etc.) - must come before boolean check
     if (assignableProps.has(attrName)) {
       ;(node as any)[attrName] = value ?? ""
@@ -103,6 +153,8 @@ export function spreadProps(node: Element, attrs: Attrs, machineId?: string): ()
     if (attrs[key] == null) {
       if (key === "class") {
         ;(node as HTMLElement).className = ""
+      } else if (key === "style") {
+        applyStyle(node, undefined, scopeKey)
       } else if (assignableProps.has(key)) {
         ;(node as any)[key] = ""
       } else {
@@ -128,6 +180,13 @@ export function spreadProps(node: Element, attrs: Attrs, machineId?: string): ()
       currentMachineMap.delete(scopeKey)
       if (currentMachineMap.size === 0) {
         prevAttrsMap.delete(node)
+      }
+    }
+    const currentStyleMap = prevStylePropsMap.get(node)
+    if (currentStyleMap) {
+      currentStyleMap.delete(scopeKey)
+      if (currentStyleMap.size === 0) {
+        prevStylePropsMap.delete(node)
       }
     }
   }

--- a/packages/frameworks/vanilla/src/spread-props.ts
+++ b/packages/frameworks/vanilla/src/spread-props.ts
@@ -37,15 +37,19 @@ const getAttributeName = (node: Element, attrName: string): string => {
   return shouldPreserveCase ? attrName : attrName.toLowerCase()
 }
 
+// Scratch element reused to parse style strings via the browser's own CSS parser (see
+// `parseStyleString`) rather than a naive `;`-split, which would break on a semicolon that's part
+// of a value itself (e.g. `content: "a;b"`, or a `data:` URI's `;base64,`).
+const styleParserEl = typeof document !== "undefined" ? document.createElement("div") : null
+
 // Parses a `prop:value;` style string back into a map
 const parseStyleString = (style: string): Map<string, string> => {
   const result = new Map<string, string>()
-  for (const decl of style.split(";")) {
-    const separator = decl.indexOf(":")
-    if (separator === -1) continue
-    const prop = decl.slice(0, separator).trim()
-    const value = decl.slice(separator + 1).trim()
-    if (prop) result.set(prop, value)
+  if (!styleParserEl) return result
+  styleParserEl.style.cssText = style
+  for (let i = 0; i < styleParserEl.style.length; i++) {
+    const prop = styleParserEl.style.item(i)
+    result.set(prop, styleParserEl.style.getPropertyValue(prop))
   }
   return result
 }

--- a/packages/frameworks/vanilla/tests/spread-props.test.ts
+++ b/packages/frameworks/vanilla/tests/spread-props.test.ts
@@ -263,7 +263,55 @@ describe("spreadProps", () => {
       const div = document.createElement("div")
       spreadProps(div, { style: "color:red;font-size:16px;" })
 
-      expect(div.getAttribute("style")).toBe("color:red;font-size:16px;")
+      expect(div.style.color).toBe("red")
+      expect(div.style.fontSize).toBe("16px")
+    })
+
+    test("removes properties that are no longer present", () => {
+      const div = document.createElement("div")
+      spreadProps(div, { style: "color:red;font-size:16px;" })
+
+      spreadProps(div, { style: "color:red;" })
+      expect(div.style.color).toBe("red")
+      expect(div.style.fontSize).toBe("")
+    })
+
+    test("clears all managed properties when style is removed from attrs", () => {
+      const div = document.createElement("div")
+      spreadProps(div, { style: "color:red;" })
+      expect(div.style.color).toBe("red")
+
+      spreadProps(div, {})
+      expect(div.style.color).toBe("")
+    })
+
+    test("does not clobber inline styles set outside of spreadProps", () => {
+      const div = document.createElement("div")
+
+      // e.g. Zag's dismissable/layer-stack module tagging an element directly
+      div.style.setProperty("--layer-index", "1")
+
+      spreadProps(div, { style: "pointer-events:none;" })
+      expect(div.style.getPropertyValue("--layer-index")).toBe("1")
+
+      // a re-render whose computed style string changes (e.g. a dialog opening)
+      spreadProps(div, { style: "" })
+      expect(div.style.getPropertyValue("--layer-index")).toBe("1")
+      expect(div.style.pointerEvents).toBe("")
+    })
+
+    test("scopes managed style properties per machineId", () => {
+      const div = document.createElement("div")
+
+      spreadProps(div, { style: "color:red;" }, "machine-a")
+      spreadProps(div, { style: "font-size:16px;" }, "machine-b")
+
+      expect(div.style.color).toBe("red")
+      expect(div.style.fontSize).toBe("16px")
+
+      spreadProps(div, {}, "machine-a")
+      expect(div.style.color).toBe("")
+      expect(div.style.fontSize).toBe("16px")
     })
   })
 })

--- a/packages/frameworks/vanilla/tests/spread-props.test.ts
+++ b/packages/frameworks/vanilla/tests/spread-props.test.ts
@@ -300,6 +300,18 @@ describe("spreadProps", () => {
       expect(div.style.pointerEvents).toBe("")
     })
 
+    test("preserves values containing semicolons", () => {
+      const div = document.createElement("div")
+
+      spreadProps(div, {
+        style: `content:"a;b";background-image:url("data:image/svg+xml;base64,PHN2Zz0=");color:red;`,
+      })
+
+      expect(div.style.content).toBe('"a;b"')
+      expect(div.style.backgroundImage).toBe('url("data:image/svg+xml;base64,PHN2Zz0=")')
+      expect(div.style.color).toBe("red")
+    })
+
     test("scopes managed style properties per machineId", () => {
       const div = document.createElement("div")
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3327

## 📝 Description

`spreadProps` in `@zag-js/vanilla` applies the `style` prop by serializing it to a single CSS
string and setting it via `node.setAttribute('style', ...)` whenever that string changes between renders. This replaces the *entire* `style` attribute, so any inline style another piece of code sets directly on the same element (outside of Zag's prop system) gets wiped out the next time an unrelated `style` computation changes.

This is user-visible with Dialog + `@zag-js/dismissable`: the layer-stack module writes
`--layer-index`/`--nested-layer-count`/`--z-index` straight onto the positioner (and content) via `element.style.setProperty(...)` (`layerStyleTargets` in `dialog.machine.ts`). Dialog's positioner computes its own `style` prop from `pointerEvents: !open || !modal ? "none" : undefined`, which flips on every open/close — i.e. exactly when the layer-stack also re-tags the element. The subsequent re-render sees the new (now different) style string and calls
`setAttribute('style', ...)`, clobbering the layer-stack's custom properties right after they were set. This breaks stacking for nested dialogs (and anything else relying on inline styles set outside of `spreadProps`).

The React adapter doesn't have this problem because React reconciles the `style` *object*
property-by-property against the DOM's `CSSStyleDeclaration`, only touching the properties it's actually told about.

## ⛳️ Current behavior (updates)

`spreadProps` treats `style` like any other attribute: a changed string triggers `node.setAttribute('style', newString)`, and removing the prop triggers `node.removeAttribute('style')` — both wipe the whole attribute, including any properties set outside of `spreadProps`.

## 🚀 New behavior

`style` is now reconciled at the CSS-property level. `spreadProps` parses the incoming style string, diffs it against the set of property names *it* previously applied for that element/machine scope, and only calls `element.style.setProperty(...)` / `element.style.removeProperty(...)` for those specific properties. Any other inline style already present on the element (set by other code) is left completely untouched, whether the `style` prop is present, changed, or removed entirely.

## 💣 Is this a breaking change (Yes/No):

No. Output for every existing use of the `style` prop is unchanged (same properties end up on the element); the only observable difference is that unrelated externally-set inline styles are no longer lost, and `getAttribute('style')` reflects the browser's own serialization of `CSSStyleDeclaration` (e.g. `"color: red;"` instead of a byte-identical `"color:red;"`) rather than the raw string Zag produced.

## 📝 Additional Information

This fix and text was created with the help of ai.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes vanilla `spreadProps` to reconcile inline styles property-by-property so unrelated styles written directly to the DOM survive subsequent renders.
- Adds per-element and per-machine tracking of managed CSS property names.
- Parses serialized style text and applies individual properties through `CSSStyleDeclaration`.
- Adds coverage for property removal, preservation of externally written styles, and separate machine scopes.
- Adds a patch changeset for `@zag-js/vanilla`.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until property-level reconciliation preserves valid CSS values containing embedded semicolons.

The manual parser splits valid CSS values before handing them to the browser, causing previously accepted style strings such as data-URI declarations to be truncated or discarded.

**Files Needing Attention:** packages/frameworks/vanilla/src/spread-props.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frameworks/vanilla/src/spread-props.ts | Adds scoped per-property style reconciliation, but its delimiter-based parser corrupts valid CSS values containing semicolons. |
| packages/frameworks/vanilla/tests/spread-props.test.ts | Adds useful reconciliation and ownership tests but does not cover CSS values containing declaration-like delimiters. |
| .changeset/vanilla-style-prop-clobbers-inline-styles.md | Accurately describes the intended preservation of externally managed inline properties. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Serialized style prop] --> B[parseStyleString]
  B --> C[Diff managed property names]
  C --> D[removeProperty for removed names]
  C --> E[setProperty for current values]
  D --> F[Updated inline style]
  E --> F
  G[Externally managed properties] -->|left untouched| F
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20chakra-ui%2Fzag%20PR%20%233328%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=chakra-ui%2Fzag&pr=3328&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fframeworks%2Fvanilla%2Fsrc%2Fspread-props.ts%3A43%0A**Embedded%20semicolons%20corrupt%20style%20values**%0A%0AWhen%20a%20valid%20CSS%20value%20contains%20a%20semicolon%2C%20such%20as%20a%20data%20URI%20or%20quoted%20custom-property%20value%2C%20%60style.split%28%22%3B%22%29%60%20treats%20part%20of%20that%20value%20as%20a%20separate%20declaration%2C%20causing%20the%20browser%20to%20receive%20truncated%20or%20invalid%20styling%20that%20previously%20worked%20through%20%60setAttribute%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fzag&pr=3328&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/frameworks/vanilla/src/spread-props.ts:43
**Embedded semicolons corrupt style values**

When a valid CSS value contains a semicolon, such as a data URI or quoted custom-property value, `style.split(";")` treats part of that value as a separate declaration, causing the browser to receive truncated or invalid styling that previously worked through `setAttribute`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(vanilla): spread props style behavio..."](https://github.com/chakra-ui/zag/commit/676ca9b85485e5568c64231f649538b4416dc334) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61344929)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->