### PR TITLE
feat(date-input): add max granularity

### DIFF
--- a/.changeset/date-input-max-granularity.md
+++ b/.changeset/date-input-max-granularity.md
@@ -2,5 +2,5 @@
 "@zag-js/date-input": minor
 ---
 
-Add `maxGranularity` to control the largest displayed date unit. Use `maxGranularity: "hour"` with a time granularity to
-create a locale-aware time-only input without a custom formatter.
+Add `maxGranularity` to control the largest displayed date unit. Use `maxGranularity: "hour"` with `granularity` set to
+`"hour"`, `"minute"`, or `"second"` to create a locale-aware time-only input without a custom formatter.

--- a/.changeset/date-input-max-granularity.md
+++ b/.changeset/date-input-max-granularity.md
@@ -1,0 +1,6 @@
+---
+"@zag-js/date-input": minor
+---
+
+Add `maxGranularity` to control the largest displayed date unit. Use `maxGranularity: "hour"` with a time granularity to
+create a locale-aware time-only input without a custom formatter.

--- a/examples/next-ts/pages/date-input/time-only-controlled.tsx
+++ b/examples/next-ts/pages/date-input/time-only-controlled.tsx
@@ -1,15 +1,9 @@
-import { DateFormatter, type DateValue } from "@internationalized/date"
+import type { DateValue } from "@internationalized/date"
 import * as dateInput from "@zag-js/date-input"
 import { normalizeProps, useMachine } from "@zag-js/react"
 import { useId, useState } from "react"
 import { StateVisualizer } from "../../components/state-visualizer"
 import { Toolbar } from "../../components/toolbar"
-
-const timeFormatter = new DateFormatter("en-US", {
-  hour: "2-digit",
-  minute: "2-digit",
-  hourCycle: "h23",
-})
 
 export default function Page() {
   const [value, setValue] = useState<DateValue[]>([])
@@ -18,8 +12,8 @@ export default function Page() {
     id: useId(),
     locale: "en-US",
     granularity: "minute",
+    maxGranularity: "hour",
     hourCycle: 24,
-    formatter: timeFormatter,
     value,
     onValueChange: ({ value }) => setValue(value),
   })

--- a/examples/next-ts/pages/date-input/time-only.tsx
+++ b/examples/next-ts/pages/date-input/time-only.tsx
@@ -1,23 +1,16 @@
-import { DateFormatter } from "@internationalized/date"
 import * as dateInput from "@zag-js/date-input"
 import { normalizeProps, useMachine } from "@zag-js/react"
 import { useId } from "react"
 import { StateVisualizer } from "../../components/state-visualizer"
 import { Toolbar } from "../../components/toolbar"
 
-const timeFormatter = new DateFormatter("en-US", {
-  hour: "2-digit",
-  minute: "2-digit",
-  hourCycle: "h23",
-})
-
 export default function Page() {
   const service = useMachine(dateInput.machine, {
     id: useId(),
     locale: "en-US",
     granularity: "minute",
+    maxGranularity: "hour",
     hourCycle: 24,
-    formatter: timeFormatter,
   })
 
   const api = dateInput.connect(service, normalizeProps)

--- a/examples/next-ts/pages/date-input/time-only.tsx
+++ b/examples/next-ts/pages/date-input/time-only.tsx
@@ -1,16 +1,26 @@
 import * as dateInput from "@zag-js/date-input"
 import { normalizeProps, useMachine } from "@zag-js/react"
+import { defineControls } from "@zag-js/shared"
 import { useId } from "react"
 import { StateVisualizer } from "../../components/state-visualizer"
 import { Toolbar } from "../../components/toolbar"
+import { useControls } from "../../hooks/use-controls"
+
+const localeControls = defineControls({
+  locale: {
+    type: "select",
+    options: ["en-US", "en-GB", "fr-FR", "de-DE", "cs-CZ", "ja-JP", "mk-MK", "zh-CN"] as const,
+    defaultValue: "en-US",
+  },
+})
 
 export default function Page() {
+  const controls = useControls(localeControls)
   const service = useMachine(dateInput.machine, {
     id: useId(),
-    locale: "en-US",
+    locale: controls.context.locale,
     granularity: "minute",
     maxGranularity: "hour",
-    hourCycle: 24,
   })
 
   const api = dateInput.connect(service, normalizeProps)
@@ -39,7 +49,7 @@ export default function Page() {
         </output>
       </main>
 
-      <Toolbar viz>
+      <Toolbar viz controls={controls.ui}>
         <StateVisualizer state={service} />
       </Toolbar>
     </>

--- a/examples/preact-ts/src/pages/date-input/time-only-controlled.tsx
+++ b/examples/preact-ts/src/pages/date-input/time-only-controlled.tsx
@@ -1,15 +1,9 @@
-import { DateFormatter, type DateValue } from "@internationalized/date"
+import type { DateValue } from "@internationalized/date"
 import * as dateInput from "@zag-js/date-input"
 import { normalizeProps, useMachine } from "@zag-js/preact"
 import { useId, useState } from "react"
 import { StateVisualizer } from "../../components/state-visualizer"
 import { Toolbar } from "../../components/toolbar"
-
-const timeFormatter = new DateFormatter("en-US", {
-  hour: "2-digit",
-  minute: "2-digit",
-  hourCycle: "h23",
-})
 
 export default function Page() {
   const [value, setValue] = useState<DateValue[]>([])
@@ -18,8 +12,8 @@ export default function Page() {
     id: useId(),
     locale: "en-US",
     granularity: "minute",
+    maxGranularity: "hour",
     hourCycle: 24,
-    formatter: timeFormatter,
     value,
     onValueChange: ({ value }) => setValue(value),
   })

--- a/examples/preact-ts/src/pages/date-input/time-only.tsx
+++ b/examples/preact-ts/src/pages/date-input/time-only.tsx
@@ -1,23 +1,16 @@
-import { DateFormatter } from "@internationalized/date"
 import * as dateInput from "@zag-js/date-input"
 import { normalizeProps, useMachine } from "@zag-js/preact"
 import { useId } from "react"
 import { StateVisualizer } from "../../components/state-visualizer"
 import { Toolbar } from "../../components/toolbar"
 
-const timeFormatter = new DateFormatter("en-US", {
-  hour: "2-digit",
-  minute: "2-digit",
-  hourCycle: "h23",
-})
-
 export default function Page() {
   const service = useMachine(dateInput.machine, {
     id: useId(),
     locale: "en-US",
     granularity: "minute",
+    maxGranularity: "hour",
     hourCycle: 24,
-    formatter: timeFormatter,
   })
 
   const api = dateInput.connect(service, normalizeProps)

--- a/packages/docs/data/api.json
+++ b/packages/docs/data/api.json
@@ -1546,7 +1546,7 @@
       },
       "maxGranularity": {
         "type": "MaxGranularity | undefined",
-        "description": "Determines the largest unit that is displayed in the date input.\nSet this to `\"hour\"` to create a time-only input.",
+        "description": "Determines the largest unit that is displayed in the date input.\nTo create a time-only input, set this to `\"hour\"` and set `granularity`\nto `\"hour\"`, `\"minute\"`, or `\"second\"`.",
         "defaultValue": "\"year\""
       },
       "shouldForceLeadingZeros": {

--- a/packages/docs/data/api.json
+++ b/packages/docs/data/api.json
@@ -1393,6 +1393,10 @@
         "type": "boolean",
         "description": "Whether the date input is invalid"
       },
+      "resolvedHourCycle": {
+        "type": "ResolvedHourCycle",
+        "description": "The resolved hour cycle used by the date input formatter."
+      },
       "value": {
         "type": "DateValue[]",
         "description": "The selected date(s)."
@@ -1539,6 +1543,11 @@
         "type": "DateGranularity | undefined",
         "description": "Determines the smallest unit that is displayed in the date input.",
         "defaultValue": "\"day\""
+      },
+      "maxGranularity": {
+        "type": "MaxGranularity | undefined",
+        "description": "Determines the largest unit that is displayed in the date input.\nSet this to `\"hour\"` to create a time-only input.",
+        "defaultValue": "\"year\""
       },
       "shouldForceLeadingZeros": {
         "type": "boolean | undefined",

--- a/packages/machines/date-input/src/date-input.connect.ts
+++ b/packages/machines/date-input/src/date-input.connect.ts
@@ -13,6 +13,7 @@ import * as dom from "./date-input.dom"
 import type { DateInputApi, DateInputService, SegmentProps, SegmentState } from "./date-input.types"
 import { getLocaleSeparator, isValidCharacter } from "@zag-js/date-utils"
 import { getSegmentLabel, PAGE_STEP } from "./utils/segments"
+import { resolvedHourCycle } from "./utils/incomplete-date"
 import { getGroupOffset } from "./utils/validity"
 
 export function connect<T extends PropTypes>(service: DateInputService, normalize: NormalizeProps<T>): DateInputApi<T> {
@@ -50,6 +51,7 @@ export function connect<T extends PropTypes>(service: DateInputService, normaliz
     focused,
     disabled,
     invalid,
+    resolvedHourCycle: resolvedHourCycle(prop("formatter")),
     value,
     valueAsDate,
     valueAsString: computed("valueAsString"),

--- a/packages/machines/date-input/src/date-input.machine.ts
+++ b/packages/machines/date-input/src/date-input.machine.ts
@@ -40,6 +40,7 @@ export const machine = createMachine<DateInputSchema>({
     const timeZone = props.timeZone || "UTC"
     const selectionMode = props.selectionMode || "single"
     const granularity = props.granularity || "day"
+    const maxGranularity = props.maxGranularity || "year"
 
     const calendar = resolveCalendar(locale, props.createCalendar)
 
@@ -64,6 +65,7 @@ export const machine = createMachine<DateInputSchema>({
         locale,
         getFormatterOptions({
           granularity,
+          maxGranularity,
           digitStyle,
           hourCycle,
           timeZone,
@@ -82,6 +84,7 @@ export const machine = createMachine<DateInputSchema>({
       value,
       defaultValue,
       granularity,
+      maxGranularity,
       shouldForceLeadingZeros,
       formatter,
       placeholderValue: typeof props.placeholderValue === "undefined" ? undefined : placeholderValue,

--- a/packages/machines/date-input/src/date-input.props.ts
+++ b/packages/machines/date-input/src/date-input.props.ts
@@ -37,6 +37,7 @@ export const props = createProps<DateInputProps>()([
   "hourCycle",
   "hideTimeZone",
   "granularity",
+  "maxGranularity",
   "shouldForceLeadingZeros",
   "allSegments",
   "formatter",

--- a/packages/machines/date-input/src/date-input.types.ts
+++ b/packages/machines/date-input/src/date-input.types.ts
@@ -180,7 +180,8 @@ export interface DateInputProps extends DirectionProperty, CommonProperties {
   granularity?: DateGranularity | undefined
   /**
    * Determines the largest unit that is displayed in the date input.
-   * Set this to `"hour"` to create a time-only input.
+   * To create a time-only input, set this to `"hour"` and set `granularity`
+   * to `"hour"`, `"minute"`, or `"second"`.
    * @default "year"
    */
   maxGranularity?: MaxGranularity | undefined

--- a/packages/machines/date-input/src/date-input.types.ts
+++ b/packages/machines/date-input/src/date-input.types.ts
@@ -44,6 +44,10 @@ export type SelectionMode = "single" | "range"
 
 export type HourCycle = 12 | 24
 
+export type MaxGranularity = "year" | "month" | DateGranularity
+
+export type ResolvedHourCycle = "h11" | "h12" | "h23" | "h24"
+
 export interface IntlTranslations {
   placeholder?: ((locale: string) => Record<EditableSegmentType, string>) | undefined
 }
@@ -175,6 +179,12 @@ export interface DateInputProps extends DirectionProperty, CommonProperties {
    */
   granularity?: DateGranularity | undefined
   /**
+   * Determines the largest unit that is displayed in the date input.
+   * Set this to `"hour"` to create a time-only input.
+   * @default "year"
+   */
+  maxGranularity?: MaxGranularity | undefined
+  /**
    * Whether to always show leading zeros in month, day, and hour fields.
    * When false, formatting follows the locale default (e.g. "1" instead of "01").
    * @default false
@@ -199,6 +209,7 @@ type PropsWithDefault =
   | "locale"
   | "timeZone"
   | "granularity"
+  | "maxGranularity"
   | "shouldForceLeadingZeros"
   | "formatter"
   | "allSegments"
@@ -364,6 +375,10 @@ export interface DateInputApi<T extends PropTypes = PropTypes> {
    * Whether the date input is invalid
    */
   invalid: boolean
+  /**
+   * The resolved hour cycle used by the date input formatter.
+   */
+  resolvedHourCycle: ResolvedHourCycle
   /**
    * The selected date(s).
    */

--- a/packages/machines/date-input/src/index.ts
+++ b/packages/machines/date-input/src/index.ts
@@ -21,6 +21,8 @@ export type {
   FormatDateDetails,
   HiddenInputProps,
   HourCycle,
+  MaxGranularity,
+  ResolvedHourCycle,
   IntlTranslations,
   LabelProps,
   PlaceholderChangeDetails,

--- a/packages/machines/date-input/src/utils/segments.ts
+++ b/packages/machines/date-input/src/utils/segments.ts
@@ -1,6 +1,6 @@
 import { DateFormatter } from "@internationalized/date"
 import type { DateGranularity } from "@zag-js/date-utils"
-import type { DateSegment, EditableSegmentType, IntlTranslations, Segments } from "../date-input.types"
+import type { DateSegment, EditableSegmentType, IntlTranslations, MaxGranularity, Segments } from "../date-input.types"
 import type { IncompleteDate } from "./incomplete-date"
 
 export function needsTimeGranularity(granularity: DateGranularity): boolean {
@@ -9,6 +9,7 @@ export function needsTimeGranularity(granularity: DateGranularity): boolean {
 
 export interface FormatterOptions {
   granularity: DateGranularity
+  maxGranularity: MaxGranularity
   digitStyle: "2-digit" | "numeric"
   hourCycle: "h12" | "h23" | undefined
   timeZone: string
@@ -18,18 +19,34 @@ export interface FormatterOptions {
   hideTimeZone?: boolean | undefined
 }
 
+const FIELD_ORDER = ["year", "month", "day", "hour", "minute", "second"] as const
+
 export function getFormatterOptions(opts: FormatterOptions): Intl.DateTimeFormatOptions {
-  const { granularity, digitStyle, hourCycle, timeZone, hasTimeZone, hideTimeZone } = opts
+  const { granularity, maxGranularity, digitStyle, hourCycle, timeZone, hasTimeZone, hideTimeZone } = opts
   const options: Intl.DateTimeFormatOptions = {
     timeZone,
-    day: digitStyle,
-    month: digitStyle,
-    year: "numeric",
     hourCycle,
   }
-  if (needsTimeGranularity(granularity)) options.hour = digitStyle
-  if (granularity === "minute" || granularity === "second") options.minute = "2-digit"
-  if (granularity === "second") options.second = "2-digit"
+
+  const fieldOptions = {
+    year: "numeric",
+    month: digitStyle,
+    day: digitStyle,
+    hour: digitStyle,
+    minute: "2-digit",
+    second: "2-digit",
+  } as const satisfies Record<(typeof FIELD_ORDER)[number], "numeric" | "2-digit">
+  const startIndex = FIELD_ORDER.indexOf(maxGranularity)
+  const endIndex = FIELD_ORDER.indexOf(granularity)
+
+  if (startIndex > endIndex) {
+    throw new Error("maxGranularity must be greater than granularity")
+  }
+
+  for (const field of FIELD_ORDER.slice(startIndex, endIndex + 1)) {
+    Object.assign(options, { [field]: fieldOptions[field] })
+  }
+
   if (hasTimeZone && !hideTimeZone) options.timeZoneName = "short"
   return options
 }

--- a/packages/machines/date-input/tests/formatting.test.ts
+++ b/packages/machines/date-input/tests/formatting.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest"
+import { getFormatterOptions } from "../src/utils/segments"
+
+const defaults = {
+  granularity: "minute",
+  maxGranularity: "year",
+  digitStyle: "numeric",
+  hourCycle: undefined,
+  timeZone: "UTC",
+} as const
+
+describe("@zag-js/date-input formatting", () => {
+  test("includes fields from maxGranularity through granularity", () => {
+    expect(getFormatterOptions(defaults)).toMatchObject({
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    })
+
+    expect(getFormatterOptions({ ...defaults, maxGranularity: "hour" })).toEqual({
+      timeZone: "UTC",
+      hourCycle: undefined,
+      hour: "numeric",
+      minute: "2-digit",
+    })
+  })
+
+  test("rejects a maxGranularity smaller than granularity", () => {
+    expect(() => getFormatterOptions({ ...defaults, granularity: "day", maxGranularity: "hour" })).toThrowError(
+      "maxGranularity must be greater than granularity",
+    )
+  })
+})

--- a/website/data/components/date-input.mdx
+++ b/website/data/components/date-input.mdx
@@ -369,6 +369,19 @@ const service = useMachine(dateInput.machine, {
 
 By default, this is determined by the locale.
 
+### Time-only input
+
+Set `maxGranularity` to `"hour"` to display only time segments. The hour cycle
+and day period are determined by the locale unless `hourCycle` is provided.
+
+```tsx
+const service = useMachine(dateInput.machine, {
+  locale: "en-US",
+  maxGranularity: "hour",
+  granularity: "minute",
+})
+```
+
 ### Custom formatter
 
 Provide a `formatter` to customize how dates are parsed and formatted.

--- a/website/data/components/date-input.mdx
+++ b/website/data/components/date-input.mdx
@@ -371,8 +371,9 @@ By default, this is determined by the locale.
 
 ### Time-only input
 
-Set `maxGranularity` to `"hour"` to display only time segments. The hour cycle
-and day period are determined by the locale unless `hourCycle` is provided.
+Set `maxGranularity` to `"hour"` and `granularity` to `"hour"`, `"minute"`, or
+`"second"` to display only time segments. The hour cycle and day period are
+determined by the locale unless `hourCycle` is provided.
 
 ```tsx
 const service = useMachine(dateInput.machine, {


### PR DESCRIPTION
## 📝 Description

Add `maxGranularity` support to date input.

## ⛳️ Current behavior (updates)

Date inputs cannot render only time segments without a custom formatter.

## 🚀 New behavior

`maxGranularity` controls the largest rendered segment, enabling time-only inputs such as hour and minute. The API also exposes the resolved hour cycle.


https://github.com/user-attachments/assets/78556e9d-2239-47d6-a58a-a2487f6450c8


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62762178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking documentation correction needed to prevent consumers from following an invalid standalone `maxGranularity` configuration.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fmachines%2Fdate-input%2Fsrc%2Fdate-input.types.ts%3A181-182%0AThe%20public%20JSDoc%20presents%20%60maxGranularity%3A%20%22hour%22%60%20as%20sufficient%20for%20a%20time-only%20input%2C%20but%20the%20default%20%60granularity%3A%20%22day%22%60%20causes%20%60getFormatterOptions%60%20to%20throw.%20Document%20that%20%60maxGranularity%3A%20%22hour%22%60%20must%20be%20paired%20with%20an%20hour-or-finer%20%60granularity%60%20so%20consumers%20do%20not%20follow%20the%20API%20guidance%20into%20an%20initialization%20failure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fzag&pr=3335&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Time\-only guidance omits granularity** <a href="https://github.com/chakra-ui/zag/pull/3335#discussion_r3982874141">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/machines/date-input/src/date-input.types.ts:181-182
The public JSDoc presents `maxGranularity: "hour"` as sufficient for a time-only input, but the default `granularity: "day"` causes `getFormatterOptions` to throw. Document that `maxGranularity: "hour"` must be paired with an hour-or-finer `granularity` so consumers do not follow the API guidance into an initialization failure.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Builds formatter fields from the configured maximum through minimum granularity.
- Exports the new prop and resolved-hour-cycle API types.
- Updates React and Preact examples, API data, website documentation, tests, and release metadata.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(date-input): add locale control to ..."](https://github.com/chakra-ui/zag/commit/3ab83fede06e760ee7c7553c783f202f7be5824d)</sub>

<!-- /greptile_comment -->