### PR TITLE
test(dismissable): align sync-path tests with always-deferred registration

### DIFF
--- a/packages/utilities/dismissable/tests/dismissable-layer.test.ts
+++ b/packages/utilities/dismissable/tests/dismissable-layer.test.ts
@@ -32,25 +32,29 @@ describe("trackDismissableElement", () => {
     document.body.innerHTML = ""
   })
 
-  test("registers escape handler synchronously when the node is already available", () => {
+  test("registers escape handler on the microtask when the node is already available", async () => {
     const node = mountNode()
     const onDismiss = vi.fn()
 
     // `defer: true` is what every machine passes (dialog, popover, menu, ...)
     const cleanup = trackDismissableElement(node, { defer: true, onDismiss })
 
-    // no frame has passed — the dialog is painted and interactive at this point
+    // registration is always deferred to the microtask so a re-parented node is
+    // re-resolved after commit — still before any frame, so Escape works pre-paint
+    await Promise.resolve()
+
     pressEscape()
     expect(onDismiss).toHaveBeenCalledTimes(1)
 
     cleanup()
   })
 
-  test("adds the layer to the stack synchronously when the node is already available", () => {
+  test("adds the layer to the stack on the microtask when the node is already available", async () => {
     const node = mountNode()
 
     const cleanup = trackDismissableElement(node, { defer: true, onDismiss: noop })
 
+    await Promise.resolve()
     expect(layerStack.isTopMost(node)).toBe(true)
 
     cleanup()


### PR DESCRIPTION
## 📝 Description

Follow-up to de9aeaaf8 (#3323): the fix always defers `defer: true` registration to the microtask, but the two sync-path tests from 9a9381d still assert the old synchronous contract, so `dismissable-layer.test.ts` currently fails on `main` (2 failed / 17 passed).

This aligns them with the new contract: registration lands on the microtask after the call — still before any frame, so the Escape-timing guarantee from #3248 stays covered (`await Promise.resolve()` is the only wait, no `raf`).

Tests only, no source changes.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63089913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The test updates appear behaviorally sound, but the repository’s mandatory changeset requirement must be satisfied before merging.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Futilities%2Fdismissable%2Ftests%2Fdismissable-layer.test.ts%3A35%0AThis%20test-only%20change%20does%20not%20include%20a%20%60.changeset%60%20entry%2C%20violating%20the%20repository%20directive%20to%20always%20create%20a%20changeset%20when%20making%20code%20changes.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging%20by%20adding%20a%20patch%20changeset%20for%20the%20affected%20package.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fzag&pr=3337&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Required changeset is missing** <a href="https://github.com/chakra-ui/zag/pull/3337#discussion_r3989982591">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/utilities/dismissable/tests/dismissable-layer.test.ts:35
This test-only change does not include a `.changeset` entry, violating the repository directive to always create a changeset when making code changes. This repository requirement must be satisfied before merging by adding a patch changeset for the affected package.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Awaits one microtask before testing Escape-key dismissal.
- Awaits one microtask before checking the layer stack.
- Preserves the intended pre-frame timing coverage.
</details>

<sub>Reviews (1) · Last reviewed commit: ["test(dismissable): align sync-path tests..."](https://github.com/chakra-ui/zag/commit/cd6d40cd36cc6b8375579034f7f468712e2469df)</sub>

<!-- /greptile_comment -->