### PR TITLE
fix(scripts): derive package names with basename for Windows

### DIFF
--- a/scripts/check-type-exports.ts
+++ b/scripts/check-type-exports.ts
@@ -1,4 +1,4 @@
-import { join } from "path"
+import { basename, join } from "path"
 import {
   EnumDeclaration,
   InterfaceDeclaration,
@@ -190,7 +190,7 @@ async function main() {
   let totalIssues = 0
 
   for (const { dir } of machines) {
-    const machineName = dir.split("/").pop()!
+    const machineName = basename(dir)
     const result = checkMachine(project, dir, machineName)
 
     if (result.issues.length > 0) {

--- a/scripts/css-vars.ts
+++ b/scripts/css-vars.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path"
+import { basename, dirname, resolve } from "node:path"
 import { writeFileSync, readFileSync } from "node:fs"
 import { glob } from "fast-glob"
 import { Project, Node, SyntaxKind } from "ts-morph"
@@ -223,7 +223,7 @@ function extractCSSVariablesFromConnect(filePath: string, project: Project): CSS
   if (!sourceFile) return []
 
   const variables: CSSVariable[] = []
-  const component = filePath.split("/").slice(-3, -2)[0] // Extract component name from path
+  const component = basename(dirname(dirname(filePath)))
 
   sourceFile.forEachDescendant((node) => {
     if (Node.isPropertyAssignment(node) && node.getName() === "style") {
@@ -284,7 +284,7 @@ function extractCSSVariablesFromStyle(filePath: string, project: Project): CSSVa
   if (!sourceFile) return []
 
   const variables: CSSVariable[] = []
-  const component = filePath.split("/").slice(-3, -2)[0]
+  const component = basename(dirname(dirname(filePath)))
 
   sourceFile.forEachDescendant((node) => {
     if (Node.isObjectLiteralExpression(node)) {
@@ -326,8 +326,7 @@ function extractCSSVariablesFromUtility(filePath: string, project: Project): CSS
   if (!sourceFile) return []
 
   const variables: CSSVariable[] = []
-  const pathParts = filePath.split("/")
-  const utilityName = pathParts[pathParts.indexOf("utilities") + 1] // e.g., "popper", "dismissable"
+  const utilityName = basename(dirname(dirname(filePath))) // e.g., "popper", "dismissable"
 
   sourceFile.forEachDescendant((node) => {
     // Look for regular object literals with CSS variables

--- a/scripts/data-attr.ts
+++ b/scripts/data-attr.ts
@@ -1,6 +1,6 @@
 import { ModuleResolutionKind, Node, Project, StringLiteral, SyntaxKind, type ObjectLiteralElementLike } from "ts-morph"
 import * as fg from "fast-glob"
-import { join, sep } from "path"
+import { basename, dirname, join } from "path"
 import { writeFileSync, readFileSync } from "fs"
 
 const docsMap = {
@@ -207,7 +207,7 @@ async function main() {
   const json: Record<string, any> = {}
 
   files.forEach((file) => {
-    const widget = file.split(sep)[2]
+    const widget = basename(dirname(dirname(file)))
     project.addSourceFileAtPath(file)
 
     const hasDismissable = hasDismissableDependency(widget)

--- a/scripts/typedocs.ts
+++ b/scripts/typedocs.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from "fs"
-import { join } from "path"
+import { basename, join } from "path"
 import { ModuleResolutionKind, Node, Project, SourceFile, Symbol, TypeChecker } from "ts-morph"
 import { getMachinePackages } from "./get-packages"
 import { pascalCase } from "scule"
@@ -73,7 +73,7 @@ async function main() {
   const machines = await getMachinePackages()
 
   for (const { dir } of machines) {
-    const baseDir = dir.split("/").pop()!
+    const baseDir = basename(dir)
     const glob = `${dir}/src/**/*.ts`
 
     const typesFilePath = `${dir}/src/${baseDir}.types.ts`


### PR DESCRIPTION
## 📝 Description

`scripts/` feeds paths from three sources into string splitting: `find-packages` (platform-native absolute paths), `fast-glob` (always forward slashes) and `resolve()` (platform-native). Splitting by the wrong separator silently returns the whole path or `undefined` instead of the package name. This replaces the manual splitting with `basename`/`dirname` in the four affected scripts.

## ⛳️ Current behavior (updates)

On Windows, where `sep` is `\`:

- `pnpm check-type-exports` reports every index export of all 51 machines as missing — 699 false failures — and exits 1.
- `pnpm document-types` (run by `pnpm build` through `postbuild`) rewrites `packages/docs/data/api.json` with 51 keys that are absolute file paths and empty `api` / `context` objects. It exits 0, so the corruption is silent, and because `document-attr` runs next it also leaves the file on disk.
- `pnpm document-attr` throws `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` and exits 1, so `pnpm build` fails outright.
- `pnpm document-css-vars` collapses every connect/style variable under a single `undefined` key and loses the popper lookup, dropping 15 of 31 components and all of the positioner variables.

On macOS and Linux the paths are already `/`-separated, so none of this is visible.

## 🚀 New behavior

All four scripts resolve the package name on every platform. `check-type-exports` prints `All 51 machines have correct type exports! ✨` and exits 0, and `document-types`, `document-attr` and `document-css-vars` all exit 0 and regenerate the checked-in files.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Verified on Windows 10 with Node 24.14.1 and pnpm 11.22.0 against `a40f3f34a`:

| script | before | after |
| --- | --- | --- |
| `check-type-exports` | 699 failures, exit 1 | exit 0 |
| `document-types` | `api.json` rewritten with absolute-path keys | matches the committed file |
| `document-attr` | `TypeError`, exit 1 | exit 0, `data-attr.json` byte-identical to committed |
| `document-css-vars` | 16 of 31 components, no popper vars | 31 components, matches the committed file |

Every regenerated file was compared against the committed blob: `data-attr.json` is byte-identical; `api.json` differs only by `\n` → `\r\n` inside JSDoc strings, where all 157 differences are explained by this checkout's `core.autocrlf=true`; `css-vars.json` is JSON-equal with only filesystem-dependent key ordering. ESLint and Prettier are clean.

No changeset: only `scripts/` is touched and the content of the generated files is unchanged, so there is no user-facing change to describe. That follows `.claude/docs/changelog-guide.md` ("Skip internal refactors") and the precedent of `921419e59`, which changed `scripts/css-vars.ts` and `scripts/data-attr.ts` without one.
